### PR TITLE
feat: introduce Layout::Header::SmartNavMenu – overflow-aware, user-customisable extension navigation

### DIFF
--- a/addon/components/layout/header.hbs
+++ b/addon/components/layout/header.hbs
@@ -7,27 +7,22 @@
             <Layout::Header::SidebarToggle class="mr-2" @onToggle={{@onSidebarToggle}} @disabled={{not @sidebarToggleEnabled}} />
         {{/if}}
         {{#unless (media "isMobile")}}
-            <div role="menu" class="next-catalog-menu-items flex mr-4">
-                {{#each this.menuItems as |menuItem|}}
-                    <LinkToExternal
-                        @route={{menuItem.route}}
-                        id={{concat (dasherize menuItem.route) "-header-button"}}
-                        class="next-view-header-item truncate {{menuItem.class}}"
-                        role="menuitem"
-                    >
-                        <div class="w-6">
-                            {{#if menuItem.iconComponent}}
-                                {{component (lazy-engine-component menuItem.iconComponent) options=menuItem.iconComponentOptions}}
-                            {{else}}
-                                <FaIcon @icon={{menuItem.icon}} @prefix={{menuItem.iconPrefix}} @size="sm" />
-                            {{/if}}
-                        </div>
-                        <div>
-                            <span>{{menuItem.title}}</span>
-                        </div>
-                    </LinkToExternal>
-                {{/each}}
-            </div>
+            {{!--
+                SmartNavMenu replaces the static `next-catalog-menu-items` div.
+                It implements the Priority+ overflow pattern: up to `@maxVisible`
+                (default 5) extensions are shown inline; the rest collapse into a
+                "More" dropdown.  A gear icon opens the customiser panel where
+                users can pin and reorder their favourite extensions.
+
+                Pass `@maxVisible={{n}}` to override the default cap of 5.
+                Pass `@mutateMenuItems={{fn}}` to mutate items before rendering
+                (same contract as the previous static implementation).
+            --}}
+            <Layout::Header::SmartNavMenu
+                class="next-catalog-menu-items mr-4"
+                @maxVisible={{or @maxVisibleNavItems 5}}
+                @mutateMenuItems={{@mutateMenuItems}}
+            />
         {{/unless}}
         <div id="view-header-left-content-a"></div>
         {{yield}}

--- a/addon/components/layout/header.js
+++ b/addon/components/layout/header.js
@@ -22,39 +22,16 @@ export default class LayoutHeaderComponent extends Component {
     @service abilities;
     @service fetch;
     @tracked company;
-    @tracked menuItems = [];
     @tracked organizationMenuItems = [];
     @tracked userMenuItems = [];
     @tracked extensions = [];
 
-    constructor(owner, { menuItems = [], organizationMenuItems = [], userMenuItems = [] }) {
+    constructor(owner, { organizationMenuItems = [], userMenuItems = [] }) {
         super(...arguments);
         this.extensions = getOwner(this).application.extensions ?? [];
         this.company = this.currentUser.getCompany();
-        this.menuItems = this.mergeMenuItems(menuItems);
         this.organizationMenuItems = this.mergeOrganizationMenuItems(organizationMenuItems);
         this.userMenuItems = this.mergeUserMenuItems(userMenuItems);
-    }
-
-    mergeMenuItems(menuItems = []) {
-        const headerMenuItems = this.universe.headerMenuItems;
-        const visibleMenuItems = [];
-        for (let i = 0; i < headerMenuItems.length; i++) {
-            const menuItem = headerMenuItems[i];
-            if (this.abilities.can(`${menuItem.id} see extension`)) {
-                visibleMenuItems.pushObject(menuItem);
-            }
-        }
-
-        // Merge additionals
-        visibleMenuItems.pushObjects(menuItems);
-
-        // Callback to allow mutation of menu items
-        if (typeof this.args.mutateMenuItems === 'function') {
-            this.args.mutateMenuItems(menuItems);
-        }
-
-        return visibleMenuItems;
     }
 
     mergeOrganizationMenuItems(organizationMenuItems = []) {

--- a/addon/components/layout/header/smart-nav-menu.hbs
+++ b/addon/components/layout/header/smart-nav-menu.hbs
@@ -1,0 +1,76 @@
+{{! Layout::Header::SmartNavMenu
+    ─────────────────────────────────────────────────────────────────────────
+    Smart, overflow-aware extension navigation bar.
+
+    Renders up to `@maxVisible` (default 5) extension items inline.  Any
+    additional items – or items that do not fit the available width – are
+    collected inside a "More" dropdown.  A gear icon opens the customiser
+    panel where users can choose which extensions are pinned to the bar.
+    ─────────────────────────────────────────────────────────────────────────
+}}
+<div
+    class="snm-container flex items-center"
+    role="menu"
+    aria-label="Extension navigation"
+    {{did-insert this.setupContainer}}
+    ...attributes
+>
+    {{! ── Visible (pinned) items ─────────────────────────────────────────── }}
+    {{#each this.visibleItems as |menuItem|}}
+        <Layout::Header::SmartNavMenu::Item @item={{menuItem}} />
+    {{/each}}
+
+    {{! ── "More" overflow button + dropdown ──────────────────────────────── }}
+    {{#if this.hasOverflow}}
+        <div class="snm-more-wrapper relative" {{did-insert this.registerMoreWrapper}}>
+            <button
+                type="button"
+                class="snm-more-btn next-view-header-item {{if this.isMoreOpen 'is-open'}}"
+                aria-haspopup="true"
+                aria-expanded={{if this.isMoreOpen "true" "false"}}
+                {{on "click" this.toggleMore}}
+            >
+                <FaIcon @icon="grip" @size="sm" class="mr-1.5" />
+                <span>More</span>
+                <FaIcon
+                    @icon={{if this.isMoreOpen "chevron-up" "chevron-down"}}
+                    @size="xs"
+                    class="ml-1 opacity-70"
+                />
+            </button>
+
+            {{#if this.isMoreOpen}}
+                <Layout::Header::SmartNavMenu::Dropdown
+                    @items={{this.overflowItems}}
+                    @onClose={{this.closeMore}}
+                    @onOpenCustomizer={{this.openCustomizer}}
+                />
+            {{/if}}
+        </div>
+    {{/if}}
+
+    {{! ── Customise button (always visible when there are items) ─────────── }}
+    {{#if this.allItems.length}}
+        <button
+            type="button"
+            class="snm-customise-btn next-view-header-item ml-0.5"
+            title="Customise navigation"
+            aria-label="Customise navigation"
+            {{on "click" this.openCustomizer}}
+        >
+            <FaIcon @icon="sliders" @size="sm" />
+        </button>
+    {{/if}}
+</div>
+
+{{! ── Customiser panel (rendered outside the flex row via BasicDropdown) ─ }}
+{{#if this.isCustomizerOpen}}
+    <Layout::Header::SmartNavMenu::Customizer
+        @allItems={{this.allItems}}
+        @pinnedIds={{this.pinnedIds}}
+        @maxVisible={{this.maxVisible}}
+        @onApply={{this.applyCustomization}}
+        @onClose={{this.closeCustomizer}}
+        @onReorder={{this.reorderPinned}}
+    />
+{{/if}}

--- a/addon/components/layout/header/smart-nav-menu.hbs
+++ b/addon/components/layout/header/smart-nav-menu.hbs
@@ -1,11 +1,14 @@
 {{! Layout::Header::SmartNavMenu
     ─────────────────────────────────────────────────────────────────────────
     Smart, overflow-aware extension navigation bar.
-
     Renders up to `@maxVisible` (default 5) extension items inline.  Any
     additional items – or items that do not fit the available width – are
     collected inside a "More" dropdown.  A gear icon opens the customiser
     panel where users can choose which extensions are pinned to the bar.
+
+    The overflow dropdown is rendered via EmberWormhole into
+    #application-root-wormhole so it escapes the 57px header height
+    constraint and uses position:fixed for correct screen placement.
     ─────────────────────────────────────────────────────────────────────────
 }}
 <div
@@ -20,29 +23,20 @@
         <Layout::Header::SmartNavMenu::Item @item={{menuItem}} />
     {{/each}}
 
-    {{! ── "More" overflow button + dropdown ──────────────────────────────── }}
+    {{! ── "More" overflow button ─────────────────────────────────────────── }}
     {{#if this.hasOverflow}}
-        <div class="snm-more-wrapper relative" {{did-insert this.registerMoreWrapper}}>
-            <button
-                type="button"
-                class="snm-more-btn next-view-header-item {{if this.isMoreOpen 'is-open'}}"
-                aria-haspopup="true"
-                aria-expanded={{if this.isMoreOpen "true" "false"}}
-                aria-label="More extensions"
-                title="More extensions"
-                {{on "click" this.toggleMore}}
-            >
-                <FaIcon @icon="ellipsis" @size="sm" />
-            </button>
-
-            {{#if this.isMoreOpen}}
-                <Layout::Header::SmartNavMenu::Dropdown
-                    @items={{this.overflowItems}}
-                    @onClose={{this.closeMore}}
-                    @onOpenCustomizer={{this.openCustomizer}}
-                />
-            {{/if}}
-        </div>
+        <button
+            type="button"
+            class="snm-more-btn next-view-header-item {{if this.isMoreOpen 'is-open'}}"
+            aria-haspopup="true"
+            aria-expanded={{if this.isMoreOpen "true" "false"}}
+            aria-label="More extensions"
+            title="More extensions"
+            {{did-insert this.registerMoreBtn}}
+            {{on "click" this.toggleMore}}
+        >
+            <FaIcon @icon="ellipsis" @size="sm" />
+        </button>
     {{/if}}
 
     {{! ── Customise button (always visible when there are items) ─────────── }}
@@ -58,6 +52,19 @@
         </button>
     {{/if}}
 </div>
+
+{{! ── Overflow dropdown – rendered via wormhole to escape the 57px header ── }}
+{{#if this.isMoreOpen}}
+    <EmberWormhole @to="application-root-wormhole">
+        <Layout::Header::SmartNavMenu::Dropdown
+            @items={{this.overflowItems}}
+            @top={{this.dropdownTop}}
+            @left={{this.dropdownLeft}}
+            @onClose={{this.closeMore}}
+            @onOpenCustomizer={{this.openCustomizer}}
+        />
+    </EmberWormhole>
+{{/if}}
 
 {{! ── Customiser panel ────────────────────────────────────────────────── }}
 {{#if this.isCustomizerOpen}}

--- a/addon/components/layout/header/smart-nav-menu.hbs
+++ b/addon/components/layout/header/smart-nav-menu.hbs
@@ -62,6 +62,8 @@
             @left={{this.dropdownLeft}}
             @onClose={{this.closeMore}}
             @onOpenCustomizer={{this.openCustomizer}}
+            @onQuickPin={{this.quickPin}}
+            @atPinnedLimit={{this.atPinnedLimit}}
         />
     </EmberWormhole>
 {{/if}}

--- a/addon/components/layout/header/smart-nav-menu.hbs
+++ b/addon/components/layout/header/smart-nav-menu.hbs
@@ -10,7 +10,7 @@
 }}
 <div
     class="snm-container flex items-center"
-    role="menu"
+    role="menubar"
     aria-label="Extension navigation"
     {{did-insert this.setupContainer}}
     ...attributes
@@ -28,15 +28,11 @@
                 class="snm-more-btn next-view-header-item {{if this.isMoreOpen 'is-open'}}"
                 aria-haspopup="true"
                 aria-expanded={{if this.isMoreOpen "true" "false"}}
+                aria-label="More extensions"
+                title="More extensions"
                 {{on "click" this.toggleMore}}
             >
-                <FaIcon @icon="grip" @size="sm" class="mr-1.5" />
-                <span>More</span>
-                <FaIcon
-                    @icon={{if this.isMoreOpen "chevron-up" "chevron-down"}}
-                    @size="xs"
-                    class="ml-1 opacity-70"
-                />
+                <FaIcon @icon="ellipsis" @size="sm" />
             </button>
 
             {{#if this.isMoreOpen}}
@@ -63,7 +59,7 @@
     {{/if}}
 </div>
 
-{{! ── Customiser panel (rendered outside the flex row via BasicDropdown) ─ }}
+{{! ── Customiser panel ────────────────────────────────────────────────── }}
 {{#if this.isCustomizerOpen}}
     <Layout::Header::SmartNavMenu::Customizer
         @allItems={{this.allItems}}

--- a/addon/components/layout/header/smart-nav-menu.hbs
+++ b/addon/components/layout/header/smart-nav-menu.hbs
@@ -57,7 +57,7 @@
 {{#if this.isMoreOpen}}
     <EmberWormhole @to="application-root-wormhole">
         <Layout::Header::SmartNavMenu::Dropdown
-            @items={{this.overflowItems}}
+            @items={{this.allItems}}
             @top={{this.dropdownTop}}
             @left={{this.dropdownLeft}}
             @onClose={{this.closeMore}}

--- a/addon/components/layout/header/smart-nav-menu.js
+++ b/addon/components/layout/header/smart-nav-menu.js
@@ -25,6 +25,9 @@ const NAV_PREFS_KEY = 'smart-nav-menu-prefs';
  * static `next-catalog-menu-items` div in `<Layout::Header />`.
  *
  * ## Features
+ * - **Reactive items** – reads directly from `universe.headerMenuItems` via a
+ *   getter so the component automatically re-renders whenever a new extension
+ *   registers its menu item (no manual event wiring needed).
  * - **Priority+ overflow** – items that do not fit the available header width
  *   are automatically moved into a "More" dropdown.  A `ResizeObserver` on the
  *   host container triggers re-evaluation whenever the viewport changes.
@@ -45,9 +48,6 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
     @service abilities;
 
     // ─── Tracked state ────────────────────────────────────────────────────────
-
-    /** All permission-filtered menu items sourced from the universe service. */
-    @tracked allItems = A([]);
 
     /**
      * Ordered list of item IDs the user has explicitly pinned to the bar.
@@ -85,17 +85,53 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
 
     constructor(owner, args) {
         super(owner, args);
-        this._loadItems();
         this._loadPreferences();
+        // Listen for new menu items being registered after boot so we
+        // re-distribute items without requiring a full re-render.
+        this.universe.menuService.on('menuItem.registered', this._onMenuItemRegistered);
     }
 
     willDestroy() {
         super.willDestroy(...arguments);
         this._teardownObserver();
-        this.unregisterMoreWrapper();
+        this._unregisterMoreWrapper();
+        // Clean up the universe event listener.
+        try {
+            this.universe.menuService.off('menuItem.registered', this._onMenuItemRegistered);
+        } catch (_) {
+            // Non-fatal – service may already be torn down.
+        }
     }
 
-    // ─── Computed helpers ─────────────────────────────────────────────────────
+    // ─── Reactive computed properties ─────────────────────────────────────────
+
+    /**
+     * All permission-filtered header menu items sourced from the universe
+     * service.  Defined as a **getter** (not a @tracked property) so that
+     * Glimmer's auto-tracking picks up changes to the underlying
+     * `TrackedMap`-backed registry whenever a new extension registers its
+     * menu item – no manual event wiring required for the initial render.
+     */
+    get allItems() {
+        const raw = this.universe.headerMenuItems ?? [];
+        const visible = [];
+        for (const item of raw) {
+            try {
+                if (this.abilities.can(`${item.id} see extension`)) {
+                    visible.push(item);
+                }
+            } catch (_) {
+                // Ability not defined – include the item by default so
+                // extensions that haven't registered an ability are still shown.
+                visible.push(item);
+            }
+        }
+        // Apply mutateMenuItems callback if provided.
+        if (typeof this.args.mutateMenuItems === 'function') {
+            this.args.mutateMenuItems(visible);
+        }
+        return A(visible);
+    }
 
     /**
      * Maximum number of items that may sit in the bar.  Consumers can override
@@ -113,18 +149,14 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
     // ─── Setup ────────────────────────────────────────────────────────────────
 
     /**
-     * Collect permission-filtered header menu items from the universe service.
+     * Called whenever a new menu item is registered with the universe service.
+     * Bound arrow function so `this` is preserved when used as an event handler.
      */
-    _loadItems() {
-        const raw = this.universe.headerMenuItems ?? [];
-        const visible = [];
-        for (const item of raw) {
-            if (this.abilities.can(`${item.id} see extension`)) {
-                visible.push(item);
-            }
+    _onMenuItemRegistered = (_menuItem, registryName) => {
+        if (registryName === 'header') {
+            scheduleOnce('afterRender', this, this._distributeFromAllItems);
         }
-        this.allItems = A(visible);
-    }
+    };
 
     /**
      * Load the user's saved navigation preferences from localStorage.
@@ -139,7 +171,6 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
         } catch (_) {
             // Preferences unavailable – use defaults.
         }
-        this._applyPreferences();
     }
 
     /**
@@ -158,28 +189,30 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
     /**
      * Re-order `allItems` so that pinned items appear first in the order the
      * user specified.  Unpinned items are appended at the end.
+     * Then split into visibleItems / overflowItems.
      */
-    _applyPreferences() {
+    _distributeFromAllItems() {
         const { pinnedIds, allItems } = this;
 
+        let ordered;
         if (!pinnedIds || pinnedIds.length === 0) {
             // No saved preference – use natural order from the universe service.
-            this._distributeItems(allItems);
-            return;
+            ordered = [...allItems];
+        } else {
+            // Build ordered list: pinned first (in user order), then the rest.
+            const pinned = [];
+            const rest = [];
+            for (const id of pinnedIds) {
+                const item = allItems.find((i) => i.id === id);
+                if (item) pinned.push(item);
+            }
+            for (const item of allItems) {
+                if (!pinnedIds.includes(item.id)) rest.push(item);
+            }
+            ordered = [...pinned, ...rest];
         }
 
-        // Build ordered list: pinned first (in user order), then the rest.
-        const pinned = [];
-        const rest = [];
-        for (const id of pinnedIds) {
-            const item = allItems.find((i) => i.id === id);
-            if (item) pinned.push(item);
-        }
-        for (const item of allItems) {
-            if (!pinnedIds.includes(item.id)) rest.push(item);
-        }
-
-        this._distributeItems([...pinned, ...rest]);
+        this._distributeItems(ordered);
     }
 
     /**
@@ -204,7 +237,7 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
         this._containerEl = element;
         this._setupObserver(element);
         // Run an initial distribution pass once the DOM has settled.
-        scheduleOnce('afterRender', this, this._recalculate);
+        scheduleOnce('afterRender', this, this._distributeFromAllItems);
     }
 
     _setupObserver(element) {
@@ -241,7 +274,7 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
 
         const { pinnedIds, allItems, maxVisible } = this;
 
-        // Determine ordered list (same logic as _applyPreferences).
+        // Determine ordered list (same logic as _distributeFromAllItems).
         let ordered;
         if (pinnedIds && pinnedIds.length > 0) {
             const pinned = [];
@@ -259,7 +292,7 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
         }
 
         // Available width for nav items (subtract "More" button reservation).
-        const MORE_BTN_WIDTH = 56; // px – approximate width of the "More ▾" button
+        const MORE_BTN_WIDTH = 44; // px – approximate width of the "⋯" button
         const availableWidth = container.offsetWidth - MORE_BTN_WIDTH;
 
         // Measure rendered item widths from the DOM.
@@ -292,13 +325,13 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
     @action registerMoreWrapper(element) {
         this._moreWrapperEl = element;
         this._outsideClickHandler = bind(this, this._handleOutsideClick);
-        document.addEventListener('click', this._outsideClickHandler, true);
+        document.addEventListener('mousedown', this._outsideClickHandler, true);
     }
 
     /** Clean up the outside-click listener when the wrapper is destroyed. */
-    @action unregisterMoreWrapper() {
+    _unregisterMoreWrapper() {
         if (this._outsideClickHandler) {
-            document.removeEventListener('click', this._outsideClickHandler, true);
+            document.removeEventListener('mousedown', this._outsideClickHandler, true);
             this._outsideClickHandler = null;
         }
         this._moreWrapperEl = null;
@@ -341,7 +374,7 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
     @action applyCustomization(orderedIds) {
         this.pinnedIds = orderedIds;
         this._savePreferences();
-        this._applyPreferences();
+        this._distributeFromAllItems();
         this.isCustomizerOpen = false;
         // Allow the DOM to update then re-measure.
         later(this, this._recalculate, 50);

--- a/addon/components/layout/header/smart-nav-menu.js
+++ b/addon/components/layout/header/smart-nav-menu.js
@@ -46,6 +46,8 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
     @service universe;
     @service currentUser;
     @service abilities;
+    @service router;
+    @service hostRouter;
 
     // ─── Tracked state ────────────────────────────────────────────────────────
 
@@ -90,6 +92,9 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
     /** Bound outside-click handler for cleanup. */
     _outsideClickHandler = null;
 
+    /** Bound routeDidChange handler for cleanup. */
+    _routeDidChangeHandler = null;
+
     // ─── Lifecycle ────────────────────────────────────────────────────────────
 
     constructor(owner, args) {
@@ -101,6 +106,17 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
             this.universe.menuService.on('menuItem.registered', this._onMenuItemRegistered);
         } catch (_) {
             // Non-fatal – service may not be available in all environments.
+        }
+        // Close the overflow dropdown automatically after any route transition so
+        // we never need to attach a click handler to <LinkToExternal /> elements
+        // (which would destroy the element mid-transition and cause a page reload).
+        this._routeDidChangeHandler = () => {
+            this.isMoreOpen = false;
+        };
+        try {
+            this._getRouter().on('routeDidChange', this._routeDidChangeHandler);
+        } catch (_) {
+            // Non-fatal – router may not be available in test environments.
         }
     }
 
@@ -114,6 +130,22 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
         } catch (_) {
             // Non-fatal – service may already be torn down.
         }
+        // Clean up the routeDidChange listener.
+        try {
+            if (this._routeDidChangeHandler) {
+                this._getRouter().off('routeDidChange', this._routeDidChangeHandler);
+                this._routeDidChangeHandler = null;
+            }
+        } catch (_) {
+            // Non-fatal.
+        }
+    }
+
+    // ─── Router helper ────────────────────────────────────────────────────────
+
+    /** Returns whichever router service is available, matching mobile-navbar pattern. */
+    _getRouter() {
+        return this.router ?? this.hostRouter;
     }
 
     // ─── Reactive computed properties ─────────────────────────────────────────

--- a/addon/components/layout/header/smart-nav-menu.js
+++ b/addon/components/layout/header/smart-nav-menu.js
@@ -531,6 +531,30 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
         const currentPinned = this.pinnedIds ? [...this.pinnedIds] : [];
         const id = menuItem.id ?? menuItem.route;
         if (!id || currentPinned.includes(id)) return; // already pinned
+
+        // If this is a shortcut item it does not exist in allItems (the universe
+        // registry only holds top-level MenuItem instances).  Register it as a
+        // proper header menu item first so _distributeFromAllItems can find it
+        // by id when rebuilding the bar.
+        //
+        // We pass a plain object so the id is preserved as-is (the string-branch
+        // of #normalizeMenuItem would dasherize the title and lose the shortcut id).
+        if (menuItem._isShortcut) {
+            const alreadyRegistered = this.allItems.find((i) => i.id === id);
+            if (!alreadyRegistered) {
+                this.universe.registerHeaderMenuItem({
+                    id,
+                    slug: id,
+                    title: menuItem.title,
+                    route: menuItem.route,
+                    icon: menuItem.icon,
+                    iconPrefix: menuItem.iconPrefix,
+                    description: menuItem.description,
+                    priority: 100,
+                });
+            }
+        }
+
         this.pinnedIds = [...currentPinned, id];
         this._savePreferences();
         this._distributeFromAllItems();

--- a/addon/components/layout/header/smart-nav-menu.js
+++ b/addon/components/layout/header/smart-nav-menu.js
@@ -457,6 +457,32 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
     }
 
     /**
+     * True when the bar is at or over the maxVisible cap.
+     * Passed to the dropdown so the pin button is disabled when the bar is full.
+     */
+    get atPinnedLimit() {
+        const pinned = this.pinnedIds ?? [];
+        return pinned.length >= this.maxVisible;
+    }
+    /**
+     * Quick-pin an overflow item directly from the dropdown.
+     * Only allowed when the bar has capacity (pinnedIds.length < maxVisible).
+     * Adds the item's ID to pinnedIds, saves preferences, and re-distributes
+     * so the item immediately moves from the overflow list to the bar.
+     *
+     * @param {Object} menuItem
+     */
+    @action quickPin(menuItem) {
+        if (this.atPinnedLimit) return; // bar is full
+        const currentPinned = this.pinnedIds ? [...this.pinnedIds] : [];
+        const id = menuItem.id ?? menuItem.route;
+        if (!id || currentPinned.includes(id)) return; // already pinned
+        this.pinnedIds = [...currentPinned, id];
+        this._savePreferences();
+        this._distributeFromAllItems();
+        later(this, this._recalculate, 50);
+    }
+    /**
      * Reorder handler for drag-sort within the customiser.
      * Kept here so the customiser sub-component stays stateless.
      */

--- a/addon/components/layout/header/smart-nav-menu.js
+++ b/addon/components/layout/header/smart-nav-menu.js
@@ -186,9 +186,13 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
         return this.args.maxVisible ?? DEFAULT_MAX_VISIBLE;
     }
 
-    /** True when there are items that did not fit in the bar. */
+    /**
+     * True when the More/Extensions dropdown button should be shown.
+     * Always shown when there are any registered items so the panel acts as
+     * a permanent app-launcher (not just a pure overflow mechanism).
+     */
     get hasOverflow() {
-        return this.overflowItems.length > 0;
+        return this.allItems.length > 0;
     }
 
     // ─── Setup ────────────────────────────────────────────────────────────────

--- a/addon/components/layout/header/smart-nav-menu.js
+++ b/addon/components/layout/header/smart-nav-menu.js
@@ -405,7 +405,8 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
         // Position the dropdown below the button, aligned to its left edge.
         this.dropdownTop = rect.bottom + 6;
         // Ensure the dropdown doesn't overflow the right edge of the viewport.
-        const dropdownWidth = 320;
+        // Wide multi-column dropdown (Phase 2: 2–3 card columns + search bar)
+        const dropdownWidth = 800;
         const rightEdge = rect.left + dropdownWidth;
         if (rightEdge > window.innerWidth - 8) {
             this.dropdownLeft = window.innerWidth - dropdownWidth - 8;

--- a/addon/components/layout/header/smart-nav-menu.js
+++ b/addon/components/layout/header/smart-nav-menu.js
@@ -289,6 +289,9 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
     _setupObserver(element) {
         if (typeof ResizeObserver === 'undefined') return;
         this._resizeObserver = new ResizeObserver(() => {
+            // Guard against re-entrancy: if we are already in the middle of a
+            // recalculate pass triggered by this same observer, skip.
+            if (this._isRecalculating) return;
             scheduleOnce('afterRender', this, this._recalculate);
         });
         this._resizeObserver.observe(element);
@@ -312,6 +315,8 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
     _recalculate() {
         const container = this._containerEl;
         if (!container) return;
+        // Prevent the ResizeObserver from re-firing while we are mutating the DOM.
+        this._isRecalculating = true;
 
         const { pinnedIds, allItems, maxVisible } = this;
 
@@ -371,8 +376,18 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
         const fitsInBar = barCandidates.slice(0, cutoff);
         const widthOverflow = barCandidates.slice(cutoff);
 
-        this.visibleItems = A(fitsInBar);
-        this.overflowItems = A([...widthOverflow, ...alwaysOverflow]);
+        // Only mutate tracked state when the distribution actually changes.
+        // This prevents the DOM mutation from triggering the ResizeObserver
+        // again, which would cause an infinite flicker loop.
+        const newVisibleIds = fitsInBar.map((i) => i.id).join(',');
+        const newOverflowIds = [...widthOverflow, ...alwaysOverflow].map((i) => i.id).join(',');
+        const curVisibleIds = this.visibleItems.map((i) => i.id).join(',');
+        const curOverflowIds = this.overflowItems.map((i) => i.id).join(',');
+        if (newVisibleIds !== curVisibleIds || newOverflowIds !== curOverflowIds) {
+            this.visibleItems = A(fitsInBar);
+            this.overflowItems = A([...widthOverflow, ...alwaysOverflow]);
+        }
+        this._isRecalculating = false;
     }
 
     // ─── "More" button registration ───────────────────────────────────────────

--- a/addon/components/layout/header/smart-nav-menu.js
+++ b/addon/components/layout/header/smart-nav-menu.js
@@ -334,24 +334,36 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
             alwaysOverflow = allItems.slice(maxVisible);
         }
 
-        // Available width for nav items (subtract "More" + customise button reservation).
-        const MORE_BTN_WIDTH = 60; // px – approximate width of ⋯ + sliders buttons
-        const availableWidth = container.offsetWidth - MORE_BTN_WIDTH;
-
         // Measure rendered item widths from the DOM.
         const itemEls = Array.from(container.querySelectorAll('.snm-item'));
+
+        // If no items have rendered yet, fall back to the simple distribution
+        // so we don't incorrectly overflow items based on zero-width measurements.
+        if (itemEls.length === 0) {
+            this._distributeFromAllItems();
+            return;
+        }
+
         const itemWidths = itemEls.map((el) => el.offsetWidth + 8); // 8px gap
+
+        // Available width: only subtract the customise-button (~44px).
+        // Do NOT pre-reserve space for the "More" button – it is not rendered
+        // when all items fit, so reserving its width causes a false overflow.
+        const CUSTOMISE_BTN_WIDTH = 44; // px – sliders button + gap
+        const availableWidth = container.offsetWidth - CUSTOMISE_BTN_WIDTH;
 
         let cumulative = 0;
         let cutoff = 0;
         for (let i = 0; i < barCandidates.length; i++) {
-            const w = itemWidths[i] ?? 120; // fallback estimate
-            if (cumulative + w > availableWidth) break;
+            const w = itemWidths[i] ?? 0;
+            // Skip items that haven't painted yet (zero width) to avoid
+            // incorrectly cutting them to overflow.
+            if (w > 0 && cumulative + w > availableWidth) break;
             cumulative += w;
             cutoff = i + 1;
         }
 
-        // If everything fits, show all bar candidates.
+        // If everything fits (or nothing was measured), show all bar candidates.
         if (cutoff === 0 && barCandidates.length > 0) {
             cutoff = barCandidates.length;
         }

--- a/addon/components/layout/header/smart-nav-menu.js
+++ b/addon/components/layout/header/smart-nav-menu.js
@@ -532,28 +532,9 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
         const id = menuItem.id ?? menuItem.route;
         if (!id || currentPinned.includes(id)) return; // already pinned
 
-        // If this is a shortcut item it does not exist in allItems (the universe
-        // registry only holds top-level MenuItem instances).  Register it as a
-        // proper header menu item first so _distributeFromAllItems can find it
-        // by id when rebuilding the bar.
-        //
-        // We pass a plain object so the id is preserved as-is (the string-branch
-        // of #normalizeMenuItem would dasherize the title and lose the shortcut id).
-        if (menuItem._isShortcut) {
-            const alreadyRegistered = this.allItems.find((i) => i.id === id);
-            if (!alreadyRegistered) {
-                this.universe.registerHeaderMenuItem({
-                    id,
-                    slug: id,
-                    title: menuItem.title,
-                    route: menuItem.route,
-                    icon: menuItem.icon,
-                    iconPrefix: menuItem.iconPrefix,
-                    description: menuItem.description,
-                    priority: 100,
-                });
-            }
-        }
+        // Shortcuts are now registered as first-class header menu items at boot
+        // time by registerHeaderMenuItem in ember-core, so they are already in
+        // allItems – no manual registration needed here.
 
         this.pinnedIds = [...currentPinned, id];
         this._savePreferences();

--- a/addon/components/layout/header/smart-nav-menu.js
+++ b/addon/components/layout/header/smart-nav-menu.js
@@ -1,0 +1,360 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import { later, scheduleOnce } from '@ember/runloop';
+import { A } from '@ember/array';
+import { bind } from '@ember/runloop';
+
+/**
+ * Default maximum number of extensions that may be pinned to the header bar
+ * before the overflow dropdown is activated.
+ */
+const DEFAULT_MAX_VISIBLE = 5;
+
+/**
+ * localStorage key suffix used when persisting per-user navigation preferences.
+ * The full key is prefixed with the user ID by the `currentUser` service.
+ */
+const NAV_PREFS_KEY = 'smart-nav-menu-prefs';
+
+/**
+ * `Layout::Header::SmartNavMenu`
+ *
+ * A smart, self-managing extension navigation component that replaces the
+ * static `next-catalog-menu-items` div in `<Layout::Header />`.
+ *
+ * ## Features
+ * - **Priority+ overflow** – items that do not fit the available header width
+ *   are automatically moved into a "More" dropdown.  A `ResizeObserver` on the
+ *   host container triggers re-evaluation whenever the viewport changes.
+ * - **Hard cap** – by default no more than `DEFAULT_MAX_VISIBLE` extensions
+ *   are ever shown in the bar; the rest always live in the dropdown.
+ * - **User customisation** – a gear-icon customiser panel lets users choose
+ *   which extensions are pinned to the bar and drag-reorder them.
+ * - **Persistence** – preferences are written to `localStorage` via the
+ *   `currentUser` service's `setOption` / `getOption` helpers so they survive
+ *   page refreshes and are scoped per user.
+ *
+ * @class LayoutHeaderSmartNavMenuComponent
+ * @extends Component
+ */
+export default class LayoutHeaderSmartNavMenuComponent extends Component {
+    @service universe;
+    @service currentUser;
+    @service abilities;
+
+    // ─── Tracked state ────────────────────────────────────────────────────────
+
+    /** All permission-filtered menu items sourced from the universe service. */
+    @tracked allItems = A([]);
+
+    /**
+     * Ordered list of item IDs the user has explicitly pinned to the bar.
+     * `null` means "no preference saved yet" – fall back to default ordering.
+     */
+    @tracked pinnedIds = null;
+
+    /** Items currently rendered in the visible bar (respects cap + width). */
+    @tracked visibleItems = A([]);
+
+    /** Items that have been pushed into the overflow "More" dropdown. */
+    @tracked overflowItems = A([]);
+
+    /** Controls visibility of the "More" dropdown. */
+    @tracked isMoreOpen = false;
+
+    /** Controls visibility of the customiser panel. */
+    @tracked isCustomizerOpen = false;
+
+    // ─── Private internals ────────────────────────────────────────────────────
+
+    /** Reference to the flex container element observed by ResizeObserver. */
+    _containerEl = null;
+
+    /** Active ResizeObserver instance. */
+    _resizeObserver = null;
+
+    /** Reference to the "More" wrapper element for outside-click detection. */
+    _moreWrapperEl = null;
+
+    /** Bound outside-click handler for cleanup. */
+    _outsideClickHandler = null;
+
+    // ─── Lifecycle ────────────────────────────────────────────────────────────
+
+    constructor(owner, args) {
+        super(owner, args);
+        this._loadItems();
+        this._loadPreferences();
+    }
+
+    willDestroy() {
+        super.willDestroy(...arguments);
+        this._teardownObserver();
+        this.unregisterMoreWrapper();
+    }
+
+    // ─── Computed helpers ─────────────────────────────────────────────────────
+
+    /**
+     * Maximum number of items that may sit in the bar.  Consumers can override
+     * via `@maxVisible={{n}}`.
+     */
+    get maxVisible() {
+        return this.args.maxVisible ?? DEFAULT_MAX_VISIBLE;
+    }
+
+    /** True when there are items that did not fit in the bar. */
+    get hasOverflow() {
+        return this.overflowItems.length > 0;
+    }
+
+    // ─── Setup ────────────────────────────────────────────────────────────────
+
+    /**
+     * Collect permission-filtered header menu items from the universe service.
+     */
+    _loadItems() {
+        const raw = this.universe.headerMenuItems ?? [];
+        const visible = [];
+        for (const item of raw) {
+            if (this.abilities.can(`${item.id} see extension`)) {
+                visible.push(item);
+            }
+        }
+        this.allItems = A(visible);
+    }
+
+    /**
+     * Load the user's saved navigation preferences from localStorage.
+     * Falls back gracefully when no preferences have been stored yet.
+     */
+    _loadPreferences() {
+        try {
+            const raw = this.currentUser.getOption(NAV_PREFS_KEY);
+            if (raw && typeof raw === 'object' && Array.isArray(raw.pinnedIds)) {
+                this.pinnedIds = raw.pinnedIds;
+            }
+        } catch (_) {
+            // Preferences unavailable – use defaults.
+        }
+        this._applyPreferences();
+    }
+
+    /**
+     * Persist the current preferences to localStorage via the currentUser service.
+     */
+    _savePreferences() {
+        try {
+            this.currentUser.setOption(NAV_PREFS_KEY, {
+                pinnedIds: this.pinnedIds ?? this.allItems.map((i) => i.id),
+            });
+        } catch (_) {
+            // Non-fatal – silently ignore storage errors.
+        }
+    }
+
+    /**
+     * Re-order `allItems` so that pinned items appear first in the order the
+     * user specified.  Unpinned items are appended at the end.
+     */
+    _applyPreferences() {
+        const { pinnedIds, allItems } = this;
+
+        if (!pinnedIds || pinnedIds.length === 0) {
+            // No saved preference – use natural order from the universe service.
+            this._distributeItems(allItems);
+            return;
+        }
+
+        // Build ordered list: pinned first (in user order), then the rest.
+        const pinned = [];
+        const rest = [];
+        for (const id of pinnedIds) {
+            const item = allItems.find((i) => i.id === id);
+            if (item) pinned.push(item);
+        }
+        for (const item of allItems) {
+            if (!pinnedIds.includes(item.id)) rest.push(item);
+        }
+
+        this._distributeItems([...pinned, ...rest]);
+    }
+
+    /**
+     * Split `ordered` into `visibleItems` (bar) and `overflowItems` (dropdown)
+     * respecting the hard `maxVisible` cap.  Width-based overflow is handled
+     * separately by the ResizeObserver path.
+     */
+    _distributeItems(ordered) {
+        const cap = this.maxVisible;
+        this.visibleItems = A(ordered.slice(0, cap));
+        this.overflowItems = A(ordered.slice(cap));
+    }
+
+    // ─── ResizeObserver ───────────────────────────────────────────────────────
+
+    /**
+     * Called by the `{{did-insert}}` modifier when the container element mounts.
+     * Sets up a ResizeObserver so the component can react to width changes and
+     * move items in/out of the overflow dropdown dynamically.
+     */
+    @action setupContainer(element) {
+        this._containerEl = element;
+        this._setupObserver(element);
+        // Run an initial distribution pass once the DOM has settled.
+        scheduleOnce('afterRender', this, this._recalculate);
+    }
+
+    _setupObserver(element) {
+        if (typeof ResizeObserver === 'undefined') return;
+        this._resizeObserver = new ResizeObserver(() => {
+            scheduleOnce('afterRender', this, this._recalculate);
+        });
+        this._resizeObserver.observe(element);
+    }
+
+    _teardownObserver() {
+        if (this._resizeObserver) {
+            this._resizeObserver.disconnect();
+            this._resizeObserver = null;
+        }
+    }
+
+    /**
+     * Measure the available container width and determine how many items fit
+     * without overflowing.  Items beyond the hard cap are always in overflow
+     * regardless of available space.
+     *
+     * The algorithm:
+     *   1. Start with the full ordered list (pinned first).
+     *   2. Measure the width of each rendered item element.
+     *   3. Reserve ~44 px for the "More" button.
+     *   4. Walk items left-to-right; once cumulative width exceeds available
+     *      space, push remaining items to overflow.
+     *   5. Never exceed `maxVisible` in the bar.
+     */
+    _recalculate() {
+        const container = this._containerEl;
+        if (!container) return;
+
+        const { pinnedIds, allItems, maxVisible } = this;
+
+        // Determine ordered list (same logic as _applyPreferences).
+        let ordered;
+        if (pinnedIds && pinnedIds.length > 0) {
+            const pinned = [];
+            const rest = [];
+            for (const id of pinnedIds) {
+                const item = allItems.find((i) => i.id === id);
+                if (item) pinned.push(item);
+            }
+            for (const item of allItems) {
+                if (!pinnedIds.includes(item.id)) rest.push(item);
+            }
+            ordered = [...pinned, ...rest];
+        } else {
+            ordered = [...allItems];
+        }
+
+        // Available width for nav items (subtract "More" button reservation).
+        const MORE_BTN_WIDTH = 56; // px – approximate width of the "More ▾" button
+        const availableWidth = container.offsetWidth - MORE_BTN_WIDTH;
+
+        // Measure rendered item widths from the DOM.
+        const itemEls = Array.from(container.querySelectorAll('.snm-item'));
+        const itemWidths = itemEls.map((el) => el.offsetWidth + 8); // 8px gap
+
+        let cumulative = 0;
+        let cutoff = 0;
+
+        for (let i = 0; i < ordered.length; i++) {
+            if (i >= maxVisible) break;
+            const w = itemWidths[i] ?? 120; // fallback estimate
+            if (cumulative + w > availableWidth) break;
+            cumulative += w;
+            cutoff = i + 1;
+        }
+
+        // If everything fits and we are under the cap, hide the "More" button.
+        if (cutoff === 0 && ordered.length <= maxVisible) {
+            cutoff = Math.min(ordered.length, maxVisible);
+        }
+
+        this.visibleItems = A(ordered.slice(0, cutoff));
+        this.overflowItems = A(ordered.slice(cutoff));
+    }
+
+    // ─── Actions ──────────────────────────────────────────────────────────────
+
+    /** Register the "More" wrapper element and attach an outside-click listener. */
+    @action registerMoreWrapper(element) {
+        this._moreWrapperEl = element;
+        this._outsideClickHandler = bind(this, this._handleOutsideClick);
+        document.addEventListener('click', this._outsideClickHandler, true);
+    }
+
+    /** Clean up the outside-click listener when the wrapper is destroyed. */
+    @action unregisterMoreWrapper() {
+        if (this._outsideClickHandler) {
+            document.removeEventListener('click', this._outsideClickHandler, true);
+            this._outsideClickHandler = null;
+        }
+        this._moreWrapperEl = null;
+    }
+
+    /** Close the dropdown when a click occurs outside the wrapper element. */
+    _handleOutsideClick(event) {
+        if (this._moreWrapperEl && !this._moreWrapperEl.contains(event.target)) {
+            this.isMoreOpen = false;
+        }
+    }
+
+    /** Toggle the "More" overflow dropdown open/closed. */
+    @action toggleMore() {
+        this.isMoreOpen = !this.isMoreOpen;
+        if (this.isCustomizerOpen) this.isCustomizerOpen = false;
+    }
+
+    /** Close the "More" dropdown (called on outside-click or item selection). */
+    @action closeMore() {
+        this.isMoreOpen = false;
+    }
+
+    /** Open the customiser panel. */
+    @action openCustomizer() {
+        this.isMoreOpen = false;
+        this.isCustomizerOpen = true;
+    }
+
+    /** Close the customiser panel without saving. */
+    @action closeCustomizer() {
+        this.isCustomizerOpen = false;
+    }
+
+    /**
+     * Called by `NavMenuCustomizer` when the user confirms their selection.
+     *
+     * @param {string[]} orderedIds - Ordered array of pinned item IDs.
+     */
+    @action applyCustomization(orderedIds) {
+        this.pinnedIds = orderedIds;
+        this._savePreferences();
+        this._applyPreferences();
+        this.isCustomizerOpen = false;
+        // Allow the DOM to update then re-measure.
+        later(this, this._recalculate, 50);
+    }
+
+    /**
+     * Reorder handler for drag-sort within the customiser.
+     * Kept here so the customiser sub-component stays stateless.
+     */
+    @action reorderPinned({ sourceList, sourceIndex, targetList, targetIndex }) {
+        if (sourceList === targetList && sourceIndex === targetIndex) return;
+        const item = sourceList.objectAt(sourceIndex);
+        sourceList.removeAt(sourceIndex);
+        targetList.insertAt(targetIndex, item);
+    }
+}

--- a/addon/components/layout/header/smart-nav-menu.js
+++ b/addon/components/layout/header/smart-nav-menu.js
@@ -351,11 +351,33 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
 
         const itemWidths = itemEls.map((el) => el.offsetWidth + 8); // 8px gap
 
-        // Available width: only subtract the customise-button (~44px).
-        // Do NOT pre-reserve space for the "More" button – it is not rendered
-        // when all items fit, so reserving its width causes a false overflow.
-        const CUSTOMISE_BTN_WIDTH = 44; // px – sliders button + gap
-        const availableWidth = container.offsetWidth - CUSTOMISE_BTN_WIDTH;
+        // Measure available width from the PARENT element (.next-view-header-left),
+        // not from the container itself.  The container is flex:1 so its offsetWidth
+        // shrinks as items are moved to overflow – measuring it creates a
+        // chicken-and-egg collapse loop.  The parent is stable (flex:1 of the full
+        // header) so its width is independent of how many items are visible.
+        const parent = container.closest('.next-view-header-left') || container.parentElement;
+        const parentWidth = parent ? parent.offsetWidth : container.offsetWidth;
+
+        // Subtract fixed siblings that are always present in .next-view-header-left:
+        //   • Logo + margin: ~60px
+        //   • Sidebar toggle (when visible): ~36px
+        // We measure them directly from the DOM so the number stays accurate
+        // across different configurations.
+        let fixedSiblingsWidth = 0;
+        if (parent) {
+            for (const child of parent.children) {
+                // Skip the snm-container itself – we want sibling widths only.
+                if (child === container) continue;
+                // Also skip zero-width wormhole targets and hidden elements.
+                const w = child.offsetWidth;
+                if (w > 0) fixedSiblingsWidth += w + 4; // 4px gap allowance
+            }
+        }
+
+        // Reserve space for the customise button (always rendered inside the container).
+        const CUSTOMISE_BTN_WIDTH = 44;
+        const availableWidth = parentWidth - fixedSiblingsWidth - CUSTOMISE_BTN_WIDTH;
 
         let cumulative = 0;
         let cutoff = 0;

--- a/addon/components/layout/header/smart-nav-menu.js
+++ b/addon/components/layout/header/smart-nav-menu.js
@@ -405,8 +405,8 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
         // Position the dropdown below the button, aligned to its left edge.
         this.dropdownTop = rect.bottom + 6;
         // Ensure the dropdown doesn't overflow the right edge of the viewport.
-        // Wide multi-column dropdown (Phase 2: 2–3 card columns + search bar)
-        const dropdownWidth = 800;
+        // Wide multi-column dropdown (Phase 2: 2 card columns + search bar)
+        const dropdownWidth = 680;
         const rightEdge = rect.left + dropdownWidth;
         if (rightEdge > window.innerWidth - 8) {
             this.dropdownLeft = window.innerWidth - dropdownWidth - 8;

--- a/addon/components/layout/header/smart-nav-menu.js
+++ b/addon/components/layout/header/smart-nav-menu.js
@@ -67,6 +67,15 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
     /** Controls visibility of the customiser panel. */
     @tracked isCustomizerOpen = false;
 
+    /**
+     * Fixed-position coordinates for the overflow dropdown panel.
+     * Calculated from the "More" button's getBoundingClientRect() when opened.
+     * The dropdown is rendered via EmberWormhole into #application-root-wormhole
+     * so it escapes the 57px header height constraint entirely.
+     */
+    @tracked dropdownTop = 0;
+    @tracked dropdownLeft = 0;
+
     // ─── Private internals ────────────────────────────────────────────────────
 
     /** Reference to the flex container element observed by ResizeObserver. */
@@ -75,8 +84,8 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
     /** Active ResizeObserver instance. */
     _resizeObserver = null;
 
-    /** Reference to the "More" wrapper element for outside-click detection. */
-    _moreWrapperEl = null;
+    /** Reference to the "More" button element for position calculation. */
+    _moreBtnEl = null;
 
     /** Bound outside-click handler for cleanup. */
     _outsideClickHandler = null;
@@ -88,13 +97,17 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
         this._loadPreferences();
         // Listen for new menu items being registered after boot so we
         // re-distribute items without requiring a full re-render.
-        this.universe.menuService.on('menuItem.registered', this._onMenuItemRegistered);
+        try {
+            this.universe.menuService.on('menuItem.registered', this._onMenuItemRegistered);
+        } catch (_) {
+            // Non-fatal – service may not be available in all environments.
+        }
     }
 
     willDestroy() {
         super.willDestroy(...arguments);
         this._teardownObserver();
-        this._unregisterMoreWrapper();
+        this._unregisterMoreBtn();
         // Clean up the universe event listener.
         try {
             this.universe.menuService.off('menuItem.registered', this._onMenuItemRegistered);
@@ -179,7 +192,7 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
     _savePreferences() {
         try {
             this.currentUser.setOption(NAV_PREFS_KEY, {
-                pinnedIds: this.pinnedIds ?? this.allItems.map((i) => i.id),
+                pinnedIds: this.pinnedIds ?? [],
             });
         } catch (_) {
             // Non-fatal – silently ignore storage errors.
@@ -187,43 +200,44 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
     }
 
     /**
-     * Re-order `allItems` so that pinned items appear first in the order the
-     * user specified.  Unpinned items are appended at the end.
-     * Then split into visibleItems / overflowItems.
+     * Distribute `allItems` into `visibleItems` (bar) and `overflowItems` (dropdown).
+     *
+     * Key behaviour:
+     *   - When the user has explicitly saved a pinned list, ONLY those pinned
+     *     items appear in the bar (in saved order).  Everything else goes to
+     *     overflow regardless of `maxVisible`.  The cap still applies as an
+     *     upper bound in case the user somehow saved more than `maxVisible` IDs.
+     *   - When no preference has been saved yet (`pinnedIds` is null/empty),
+     *     the first `maxVisible` items from the universe registry are shown in
+     *     the bar by default, and the rest go to overflow.
      */
     _distributeFromAllItems() {
-        const { pinnedIds, allItems } = this;
+        const { pinnedIds, allItems, maxVisible } = this;
 
-        let ordered;
         if (!pinnedIds || pinnedIds.length === 0) {
-            // No saved preference – use natural order from the universe service.
-            ordered = [...allItems];
-        } else {
-            // Build ordered list: pinned first (in user order), then the rest.
-            const pinned = [];
-            const rest = [];
-            for (const id of pinnedIds) {
-                const item = allItems.find((i) => i.id === id);
-                if (item) pinned.push(item);
-            }
-            for (const item of allItems) {
-                if (!pinnedIds.includes(item.id)) rest.push(item);
-            }
-            ordered = [...pinned, ...rest];
+            // No saved preference – show first `maxVisible` items by default.
+            this.visibleItems = A(allItems.slice(0, maxVisible));
+            this.overflowItems = A(allItems.slice(maxVisible));
+            return;
         }
 
-        this._distributeItems(ordered);
-    }
+        // User has an explicit pinned list.
+        // Build the pinned array in the user's saved order (skip stale IDs).
+        const pinned = [];
+        for (const id of pinnedIds) {
+            const item = allItems.find((i) => i.id === id);
+            if (item) pinned.push(item);
+        }
 
-    /**
-     * Split `ordered` into `visibleItems` (bar) and `overflowItems` (dropdown)
-     * respecting the hard `maxVisible` cap.  Width-based overflow is handled
-     * separately by the ResizeObserver path.
-     */
-    _distributeItems(ordered) {
-        const cap = this.maxVisible;
-        this.visibleItems = A(ordered.slice(0, cap));
-        this.overflowItems = A(ordered.slice(cap));
+        // Respect the hard cap (in case maxVisible was reduced after saving).
+        const barItems = pinned.slice(0, maxVisible);
+
+        // Everything not in the bar goes to overflow.
+        const barIds = new Set(barItems.map((i) => i.id));
+        const overflow = allItems.filter((i) => !barIds.has(i.id));
+
+        this.visibleItems = A(barItems);
+        this.overflowItems = A(overflow);
     }
 
     // ─── ResizeObserver ───────────────────────────────────────────────────────
@@ -260,13 +274,8 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
      * without overflowing.  Items beyond the hard cap are always in overflow
      * regardless of available space.
      *
-     * The algorithm:
-     *   1. Start with the full ordered list (pinned first).
-     *   2. Measure the width of each rendered item element.
-     *   3. Reserve ~44 px for the "More" button.
-     *   4. Walk items left-to-right; once cumulative width exceeds available
-     *      space, push remaining items to overflow.
-     *   5. Never exceed `maxVisible` in the bar.
+     * When the user has an explicit pinned list, only pinned items are
+     * candidates for the bar – unpinned items always stay in overflow.
      */
     _recalculate() {
         const container = this._containerEl;
@@ -274,25 +283,27 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
 
         const { pinnedIds, allItems, maxVisible } = this;
 
-        // Determine ordered list (same logic as _distributeFromAllItems).
-        let ordered;
+        // Determine which items are candidates for the bar.
+        let barCandidates;
+        let alwaysOverflow;
+
         if (pinnedIds && pinnedIds.length > 0) {
+            // Only pinned items can appear in the bar.
             const pinned = [];
-            const rest = [];
             for (const id of pinnedIds) {
                 const item = allItems.find((i) => i.id === id);
                 if (item) pinned.push(item);
             }
-            for (const item of allItems) {
-                if (!pinnedIds.includes(item.id)) rest.push(item);
-            }
-            ordered = [...pinned, ...rest];
+            barCandidates = pinned.slice(0, maxVisible);
+            const barIds = new Set(barCandidates.map((i) => i.id));
+            alwaysOverflow = allItems.filter((i) => !barIds.has(i.id));
         } else {
-            ordered = [...allItems];
+            barCandidates = allItems.slice(0, maxVisible);
+            alwaysOverflow = allItems.slice(maxVisible);
         }
 
-        // Available width for nav items (subtract "More" button reservation).
-        const MORE_BTN_WIDTH = 44; // px – approximate width of the "⋯" button
+        // Available width for nav items (subtract "More" + customise button reservation).
+        const MORE_BTN_WIDTH = 60; // px – approximate width of ⋯ + sliders buttons
         const availableWidth = container.offsetWidth - MORE_BTN_WIDTH;
 
         // Measure rendered item widths from the DOM.
@@ -301,51 +312,84 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
 
         let cumulative = 0;
         let cutoff = 0;
-
-        for (let i = 0; i < ordered.length; i++) {
-            if (i >= maxVisible) break;
+        for (let i = 0; i < barCandidates.length; i++) {
             const w = itemWidths[i] ?? 120; // fallback estimate
             if (cumulative + w > availableWidth) break;
             cumulative += w;
             cutoff = i + 1;
         }
 
-        // If everything fits and we are under the cap, hide the "More" button.
-        if (cutoff === 0 && ordered.length <= maxVisible) {
-            cutoff = Math.min(ordered.length, maxVisible);
+        // If everything fits, show all bar candidates.
+        if (cutoff === 0 && barCandidates.length > 0) {
+            cutoff = barCandidates.length;
         }
 
-        this.visibleItems = A(ordered.slice(0, cutoff));
-        this.overflowItems = A(ordered.slice(cutoff));
+        const fitsInBar = barCandidates.slice(0, cutoff);
+        const widthOverflow = barCandidates.slice(cutoff);
+
+        this.visibleItems = A(fitsInBar);
+        this.overflowItems = A([...widthOverflow, ...alwaysOverflow]);
     }
 
-    // ─── Actions ──────────────────────────────────────────────────────────────
+    // ─── "More" button registration ───────────────────────────────────────────
 
-    /** Register the "More" wrapper element and attach an outside-click listener. */
-    @action registerMoreWrapper(element) {
-        this._moreWrapperEl = element;
+    /**
+     * Register the "More" button element so we can:
+     *   1. Calculate its screen position for the fixed-position dropdown.
+     *   2. Detect outside-clicks to close the dropdown.
+     */
+    @action registerMoreBtn(element) {
+        this._moreBtnEl = element;
         this._outsideClickHandler = bind(this, this._handleOutsideClick);
         document.addEventListener('mousedown', this._outsideClickHandler, true);
     }
 
-    /** Clean up the outside-click listener when the wrapper is destroyed. */
-    _unregisterMoreWrapper() {
+    /** Clean up the outside-click listener when the button is destroyed. */
+    _unregisterMoreBtn() {
         if (this._outsideClickHandler) {
             document.removeEventListener('mousedown', this._outsideClickHandler, true);
             this._outsideClickHandler = null;
         }
-        this._moreWrapperEl = null;
+        this._moreBtnEl = null;
     }
 
-    /** Close the dropdown when a click occurs outside the wrapper element. */
+    /** Close the dropdown when a click occurs outside the button and dropdown portal. */
     _handleOutsideClick(event) {
-        if (this._moreWrapperEl && !this._moreWrapperEl.contains(event.target)) {
+        // Allow clicks inside the wormhole portal (the dropdown itself) to pass through.
+        const portal = document.getElementById('application-root-wormhole');
+        if (portal && portal.contains(event.target)) return;
+        if (this._moreBtnEl && !this._moreBtnEl.contains(event.target)) {
             this.isMoreOpen = false;
         }
     }
 
+    /**
+     * Calculate the fixed-position coordinates for the dropdown panel
+     * based on the "More" button's current screen position.
+     */
+    _calculateDropdownPosition() {
+        if (!this._moreBtnEl) return;
+        const rect = this._moreBtnEl.getBoundingClientRect();
+        // Position the dropdown below the button, aligned to its left edge.
+        this.dropdownTop = rect.bottom + 6;
+        // Ensure the dropdown doesn't overflow the right edge of the viewport.
+        const dropdownWidth = 320;
+        const rightEdge = rect.left + dropdownWidth;
+        if (rightEdge > window.innerWidth - 8) {
+            this.dropdownLeft = window.innerWidth - dropdownWidth - 8;
+        } else {
+            this.dropdownLeft = rect.left;
+        }
+    }
+
+    // ─── Actions ──────────────────────────────────────────────────────────────
+
     /** Toggle the "More" overflow dropdown open/closed. */
     @action toggleMore() {
+        if (!this.isMoreOpen) {
+            // Calculate position before opening so the panel renders in the right place.
+            this._calculateDropdownPosition();
+        }
         this.isMoreOpen = !this.isMoreOpen;
         if (this.isCustomizerOpen) this.isCustomizerOpen = false;
     }

--- a/addon/components/layout/header/smart-nav-menu/customizer.hbs
+++ b/addon/components/layout/header/smart-nav-menu/customizer.hbs
@@ -1,0 +1,151 @@
+{{! Layout::Header::SmartNavMenu::Customizer
+    ─────────────────────────────────────────────────────────────────────────
+    Modal-style panel for customising which extensions are pinned to the
+    header bar.  Uses a backdrop overlay so it feels like a focused dialog.
+    ─────────────────────────────────────────────────────────────────────────
+}}
+<div class="snm-customizer-backdrop" role="presentation" {{on "click" this.cancel}}></div>
+
+<div
+    class="snm-customizer-panel"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Customise navigation"
+>
+    {{! ── Header ──────────────────────────────────────────────────────────── }}
+    <div class="snm-customizer-header">
+        <div class="snm-customizer-header-left">
+            <FaIcon @icon="sliders" @size="sm" class="mr-2 text-blue-400" />
+            <h2 class="snm-customizer-title">Customise Navigation</h2>
+        </div>
+        <button
+            type="button"
+            class="snm-customizer-close"
+            aria-label="Close"
+            {{on "click" this.cancel}}
+        >
+            <FaIcon @icon="xmark" @size="sm" />
+        </button>
+    </div>
+
+    {{! ── Body ───────────────────────────────────────────────────────────── }}
+    <div class="snm-customizer-body">
+        {{! Left column – pinned items (drag-sortable) }}
+        <div class="snm-customizer-col snm-customizer-col-pinned">
+            <div class="snm-customizer-col-header">
+                <span class="snm-customizer-col-title">
+                    <FaIcon @icon="thumbtack" @size="xs" class="mr-1.5 text-blue-400" />
+                    Pinned to bar
+                </span>
+                <span class="snm-customizer-col-badge {{if this.atPinnedLimit 'at-limit'}}">
+                    {{this.workingPinned.length}} / {{@maxVisible}}
+                </span>
+            </div>
+
+            {{#if this.workingPinned.length}}
+                <DragSortList
+                    @items={{this.workingPinned}}
+                    @dragEndAction={{this.reorderPinned}}
+                    @group="snm-pinned"
+                    @dragHandle=".snm-drag-handle"
+                    class="snm-customizer-drag-list"
+                    as |item|
+                >
+                    <div class="snm-customizer-pinned-item">
+                        <span class="snm-drag-handle" title="Drag to reorder">
+                            <FaIcon @icon="grip-vertical" @size="sm" />
+                        </span>
+                        <div class="snm-customizer-item-icon">
+                            {{#if item.iconComponent}}
+                                {{component (lazy-engine-component item.iconComponent) options=item.iconComponentOptions}}
+                            {{else}}
+                                <FaIcon @icon={{or item.icon "circle-dot"}} @prefix={{item.iconPrefix}} @size="sm" />
+                            {{/if}}
+                        </div>
+                        <span class="snm-customizer-item-title truncate">{{item.title}}</span>
+                        <button
+                            type="button"
+                            class="snm-customizer-unpin-btn"
+                            title="Remove from bar"
+                            {{on "click" (fn this.togglePin item)}}
+                        >
+                            <FaIcon @icon="xmark" @size="xs" />
+                        </button>
+                    </div>
+                </DragSortList>
+            {{else}}
+                <div class="snm-customizer-empty-state">
+                    <FaIcon @icon="inbox" @size="lg" class="mb-2 text-gray-500" />
+                    <p>No extensions pinned yet.</p>
+                    <p class="text-xs">Add extensions from the list on the right.</p>
+                </div>
+            {{/if}}
+        </div>
+
+        {{! Divider }}
+        <div class="snm-customizer-divider"></div>
+
+        {{! Right column – all available extensions }}
+        <div class="snm-customizer-col snm-customizer-col-all">
+            <div class="snm-customizer-col-header">
+                <span class="snm-customizer-col-title">
+                    <FaIcon @icon="grid-2" @size="xs" class="mr-1.5 text-gray-400" />
+                    All extensions
+                </span>
+            </div>
+
+            <div class="snm-customizer-all-list">
+                {{#each @allItems as |item|}}
+                    <button
+                        type="button"
+                        class="snm-customizer-all-item {{if (this.isPinned item) 'is-pinned'}} {{if (and this.atPinnedLimit (not (this.isPinned item))) 'is-disabled'}}"
+                        title={{if (this.isPinned item) "Click to unpin" "Click to pin to bar"}}
+                        disabled={{and this.atPinnedLimit (not (this.isPinned item))}}
+                        {{on "click" (fn this.togglePin item)}}
+                    >
+                        <div class="snm-customizer-item-icon">
+                            {{#if item.iconComponent}}
+                                {{component (lazy-engine-component item.iconComponent) options=item.iconComponentOptions}}
+                            {{else}}
+                                <FaIcon @icon={{or item.icon "circle-dot"}} @prefix={{item.iconPrefix}} @size="sm" />
+                            {{/if}}
+                        </div>
+                        <span class="snm-customizer-item-title truncate">{{item.title}}</span>
+                        {{#if (this.isPinned item)}}
+                            <FaIcon @icon="check" @size="xs" class="snm-customizer-pinned-check ml-auto flex-shrink-0" />
+                        {{/if}}
+                    </button>
+                {{/each}}
+            </div>
+        </div>
+    </div>
+
+    {{! ── Footer ─────────────────────────────────────────────────────────── }}
+    <div class="snm-customizer-footer">
+        <button
+            type="button"
+            class="snm-customizer-reset-btn"
+            {{on "click" this.resetToDefault}}
+        >
+            <FaIcon @icon="rotate-left" @size="xs" class="mr-1.5" />
+            Reset to default
+        </button>
+        <div class="snm-customizer-footer-actions">
+            <button
+                type="button"
+                class="snm-btn snm-btn-secondary"
+                {{on "click" this.cancel}}
+            >
+                Cancel
+            </button>
+            <button
+                type="button"
+                class="snm-btn snm-btn-primary"
+                {{on "click" this.apply}}
+            >
+                <FaIcon @icon="check" @size="xs" class="mr-1.5" />
+                Apply
+            </button>
+        </div>
+    </div>
+</div>

--- a/addon/components/layout/header/smart-nav-menu/customizer.hbs
+++ b/addon/components/layout/header/smart-nav-menu/customizer.hbs
@@ -63,6 +63,9 @@
                             {{/if}}
                         </div>
                         <span class="snm-customizer-item-title truncate">{{item.title}}</span>
+                        {{#if item._parentTitle}}
+                            <span class="snm-customizer-item-parent-label">· {{item._parentTitle}}</span>
+                        {{/if}}
                         <button
                             type="button"
                             class="snm-customizer-unpin-btn"
@@ -111,6 +114,9 @@
                             {{/if}}
                         </div>
                         <span class="snm-customizer-item-title truncate">{{item.title}}</span>
+                        {{#if item._parentTitle}}
+                            <span class="snm-customizer-item-parent-label">· {{item._parentTitle}}</span>
+                        {{/if}}
                         {{#if (this.isPinned item)}}
                             <FaIcon @icon="check" @size="xs" class="snm-customizer-pinned-check ml-auto flex-shrink-0" />
                         {{/if}}

--- a/addon/components/layout/header/smart-nav-menu/customizer.js
+++ b/addon/components/layout/header/smart-nav-menu/customizer.js
@@ -1,0 +1,132 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { A } from '@ember/array';
+
+/**
+ * `Layout::Header::SmartNavMenu::Customizer`
+ *
+ * A modal-style panel that allows users to:
+ *   - Select which extensions are pinned to the header bar (up to `@maxVisible`).
+ *   - Drag-and-drop to reorder pinned extensions.
+ *   - Preview which items will appear in the bar vs. the overflow dropdown.
+ *
+ * The component is intentionally stateless with respect to persistence –
+ * it delegates saving to the parent `SmartNavMenu` via `@onApply`.
+ *
+ * @class LayoutHeaderSmartNavMenuCustomizerComponent
+ * @extends Component
+ */
+export default class LayoutHeaderSmartNavMenuCustomizerComponent extends Component {
+    /**
+     * Working copy of the pinned items list, mutated locally until the user
+     * clicks "Apply".  Initialised from `@pinnedIds` (or all items if none
+     * have been saved yet).
+     *
+     * @type {Array<Object>}
+     */
+    @tracked workingPinned = A([]);
+
+    constructor(owner, args) {
+        super(owner, args);
+        this._initWorkingState();
+    }
+
+    // ─── Computed ─────────────────────────────────────────────────────────────
+
+    /** Items that are NOT in the working pinned list. */
+    get unpinnedItems() {
+        const pinnedIds = this.workingPinned.map((i) => i.id);
+        return (this.args.allItems ?? []).filter((i) => !pinnedIds.includes(i.id));
+    }
+
+    /** True when the user has reached the maximum allowed pinned items. */
+    get atPinnedLimit() {
+        return this.workingPinned.length >= (this.args.maxVisible ?? 5);
+    }
+
+    // ─── Setup ────────────────────────────────────────────────────────────────
+
+    _initWorkingState() {
+        const { allItems = [], pinnedIds } = this.args;
+
+        if (pinnedIds && pinnedIds.length > 0) {
+            // Restore saved order.
+            const ordered = [];
+            for (const id of pinnedIds) {
+                const item = allItems.find((i) => i.id === id);
+                if (item) ordered.push(item);
+            }
+            this.workingPinned = A(ordered);
+        } else {
+            // Default: first `maxVisible` items are pinned.
+            const cap = this.args.maxVisible ?? 5;
+            this.workingPinned = A(allItems.slice(0, cap));
+        }
+    }
+
+    // ─── Actions ──────────────────────────────────────────────────────────────
+
+    /**
+     * Toggle an item's pinned state.
+     *
+     * @param {Object} item
+     */
+    @action togglePin(item) {
+        const idx = this.workingPinned.findIndex((i) => i.id === item.id);
+        if (idx >= 0) {
+            // Unpin.
+            this.workingPinned.removeAt(idx);
+            // Trigger reactivity.
+            this.workingPinned = A([...this.workingPinned]);
+        } else if (!this.atPinnedLimit) {
+            // Pin.
+            this.workingPinned = A([...this.workingPinned, item]);
+        }
+    }
+
+    /**
+     * Whether a given item is currently in the working pinned list.
+     * Decorated with @action so it can be called from the template.
+     *
+     * @param {Object} item
+     * @returns {boolean}
+     */
+    @action isPinned(item) {
+        return this.workingPinned.some((i) => i.id === item.id);
+    }
+
+    /**
+     * Drag-sort reorder handler for the pinned items list.
+     */
+    @action reorderPinned({ sourceList, sourceIndex, targetList, targetIndex }) {
+        if (sourceList === targetList && sourceIndex === targetIndex) return;
+        const item = sourceList.objectAt(sourceIndex);
+        sourceList.removeAt(sourceIndex);
+        targetList.insertAt(targetIndex, item);
+        this.workingPinned = A([...this.workingPinned]);
+    }
+
+    /**
+     * Confirm and apply the customisation.
+     */
+    @action apply() {
+        const orderedIds = this.workingPinned.map((i) => i.id);
+        if (typeof this.args.onApply === 'function') {
+            this.args.onApply(orderedIds);
+        }
+    }
+
+    /** Discard changes and close the panel. */
+    @action cancel() {
+        if (typeof this.args.onClose === 'function') {
+            this.args.onClose();
+        }
+    }
+
+    /** Reset to default (first `maxVisible` items in universe order). */
+    @action resetToDefault() {
+        const cap = this.args.maxVisible ?? 5;
+        this.workingPinned = A((this.args.allItems ?? []).slice(0, cap));
+    }
+}

--- a/addon/components/layout/header/smart-nav-menu/dropdown.hbs
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.hbs
@@ -86,9 +86,6 @@
                                         <FaIcon @icon={{item.icon}} @prefix={{item.iconPrefix}} @size="sm" />
                                     </span>
                                     <span class="snm-dropdown-card-title">{{item.title}}</span>
-                                    {{#if item._parentTitle}}
-                                        <span class="snm-dropdown-card-from" aria-hidden="true">&middot; {{item._parentTitle}}</span>
-                                    {{/if}}
                                 </LinkToExternal>
                             </div>
                             {{#unless @atPinnedLimit}}
@@ -103,6 +100,11 @@
                                 </button>
                             {{/unless}}
                         </div>
+                        {{#if item.description}}
+                            <p class="snm-dropdown-card-description">{{item.description}}</p>
+                        {{else if item._parentTitle}}
+                            <p class="snm-dropdown-card-description snm-dropdown-card-description--from"><em>from {{item._parentTitle}}</em></p>
+                        {{/if}}
                     </div>
                 {{else}}
                     {{! ── Primary extension card ──────────────────────────── }}

--- a/addon/components/layout/header/smart-nav-menu/dropdown.hbs
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.hbs
@@ -1,0 +1,60 @@
+{{! Layout::Header::SmartNavMenu::Dropdown
+    The overflow "More" panel.  Positioned absolutely below the "More" button.
+    Styled to match the existing `next-dd-menu` family of dropdowns.
+}}
+<div class="snm-dropdown next-dd-menu" role="menu" aria-label="More extensions">
+    <div class="snm-dropdown-header">
+        <span class="snm-dropdown-title">All Extensions</span>
+    </div>
+
+    <div class="snm-dropdown-items">
+        {{#each @items as |menuItem|}}
+            {{#if menuItem.onClick}}
+                <a
+                    href="javascript:;"
+                    role="menuitem"
+                    class="snm-dropdown-item next-dd-item"
+                    title={{menuItem.title}}
+                    {{on "click" (fn this.handleItemClick menuItem.onClick)}}
+                >
+                    <div class="snm-dropdown-item-icon">
+                        {{#if menuItem.iconComponent}}
+                            {{component (lazy-engine-component menuItem.iconComponent) options=menuItem.iconComponentOptions}}
+                        {{else}}
+                            <FaIcon @icon={{or menuItem.icon "circle-dot"}} @prefix={{menuItem.iconPrefix}} @size="sm" />
+                        {{/if}}
+                    </div>
+                    <span class="truncate">{{menuItem.title}}</span>
+                </a>
+            {{else}}
+                <LinkToExternal
+                    @route={{menuItem.route}}
+                    class="snm-dropdown-item next-dd-item"
+                    role="menuitem"
+                    title={{menuItem.title}}
+                    {{on "click" @onClose}}
+                >
+                    <div class="snm-dropdown-item-icon">
+                        {{#if menuItem.iconComponent}}
+                            {{component (lazy-engine-component menuItem.iconComponent) options=menuItem.iconComponentOptions}}
+                        {{else}}
+                            <FaIcon @icon={{or menuItem.icon "circle-dot"}} @prefix={{menuItem.iconPrefix}} @size="sm" />
+                        {{/if}}
+                    </div>
+                    <span class="truncate">{{menuItem.title}}</span>
+                </LinkToExternal>
+            {{/if}}
+        {{/each}}
+    </div>
+
+    <div class="snm-dropdown-footer">
+        <button
+            type="button"
+            class="snm-dropdown-customise-link"
+            {{on "click" this.openCustomizer}}
+        >
+            <FaIcon @icon="sliders" @size="sm" class="mr-1.5" />
+            Customise navigation
+        </button>
+    </div>
+</div>

--- a/addon/components/layout/header/smart-nav-menu/dropdown.hbs
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.hbs
@@ -20,7 +20,7 @@
 }}
 <div
     class="snm-dropdown"
-    style="top: {{@top}}px; left: {{@left}}px;"
+    style={{this.positionStyle}}
     role="dialog"
     aria-label="More extensions"
 >

--- a/addon/components/layout/header/smart-nav-menu/dropdown.hbs
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.hbs
@@ -108,6 +108,8 @@
                         </div>
                         {{#if item.description}}
                             <p class="snm-dropdown-card-description">{{item.description}}</p>
+                        {{else if item._parentTitle}}
+                            <p class="snm-dropdown-card-description snm-dropdown-card-description--from"><em>from {{item._parentTitle}}</em></p>
                         {{/if}}
                     </div>
                 {{else}}

--- a/addon/components/layout/header/smart-nav-menu/dropdown.hbs
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.hbs
@@ -2,6 +2,10 @@
     Layout::Header::SmartNavMenu::Dropdown
     Phase 2: multi-column card grid with search filter.
 
+    Shortcuts are expanded as independent sibling items in the grid (AWS-style).
+    The JS getter `expandedItems` interleaves parent MenuItems and their
+    shortcut objects so each appears as its own flat card.
+
     Args:
       @items            - Array of MenuItem objects to display
       @top              - Fixed-position top offset (px, from JS)
@@ -17,9 +21,32 @@
     role="dialog"
     aria-label="More extensions"
 >
-    {{! ── Header ──────────────────────────────────────────────────────────── }}
+    {{! ── Header: title + inline search + close ──────────────────────────── }}
     <div class="snm-dropdown-header">
         <span class="snm-dropdown-title">Extensions</span>
+        <div class="snm-dropdown-search-bar">
+            <span class="snm-dropdown-search-icon" aria-hidden="true">
+                <FaIcon @icon="magnifying-glass" @size="xs" />
+            </span>
+            <input
+                type="text"
+                class="snm-dropdown-search-input"
+                placeholder="Search extensions..."
+                value={{this.searchQuery}}
+                aria-label="Search extensions"
+                {{on "input" this.updateSearch}}
+            />
+            {{#if this.searchQuery}}
+                <button
+                    type="button"
+                    class="snm-dropdown-search-clear"
+                    aria-label="Clear search"
+                    {{on "click" this.clearSearch}}
+                >
+                    <FaIcon @icon="xmark" @size="xs" />
+                </button>
+            {{/if}}
+        </div>
         <button
             type="button"
             class="snm-dropdown-close"
@@ -30,34 +57,8 @@
         </button>
     </div>
 
-    {{! ── Search bar ──────────────────────────────────────────────────────── }}
-    <div class="snm-dropdown-search-bar">
-        <span class="snm-dropdown-search-icon" aria-hidden="true">
-            <FaIcon @icon="magnifying-glass" @size="sm" />
-        </span>
-        <input
-            type="text"
-            class="snm-dropdown-search-input"
-            placeholder="Search extensions..."
-            value={{this.searchQuery}}
-            aria-label="Search extensions"
-            {{on "input" this.updateSearch}}
-        />
-        {{#if this.searchQuery}}
-            <button
-                type="button"
-                class="snm-dropdown-search-clear"
-                aria-label="Clear search"
-                {{on "click" this.clearSearch}}
-            >
-                <FaIcon @icon="xmark" @size="xs" />
-            </button>
-        {{/if}}
-    </div>
-
     {{! ── Card grid ───────────────────────────────────────────────────────── }}
     <div class="snm-dropdown-grid" aria-label="Extension list">
-
         {{#if this.hasNoResults}}
             <div class="snm-dropdown-empty">
                 <FaIcon @icon="magnifying-glass" @size="lg" class="snm-dropdown-empty-icon" />
@@ -67,89 +68,87 @@
                 </p>
             </div>
         {{else}}
-            {{#each this.filteredItems as |menuItem|}}
-                <div class="snm-dropdown-card" role="presentation">
-
-                    {{! Card header: icon + title + pin button }}
-                    <div class="snm-dropdown-card-header">
-                        {{#if menuItem.onClick}}
-                            <a
-                                href="javascript:;"
-                                class="snm-dropdown-card-link"
-                                title={{menuItem.title}}
-                                {{on "click" (fn this.handleItemClick menuItem)}}
-                            >
-                                <span class="snm-dropdown-card-icon">
-                                    {{#if menuItem.iconComponent}}
-                                        {{component (lazy-engine-component menuItem.iconComponent) options=menuItem.iconComponentOptions}}
-                                    {{else}}
-                                        <FaIcon @icon={{or menuItem.icon "circle-dot"}} @prefix={{menuItem.iconPrefix}} @size="sm" />
-                                    {{/if}}
-                                </span>
-                                <span class="snm-dropdown-card-title">{{menuItem.title}}</span>
-                            </a>
-                        {{else}}
+            {{#each this.filteredItems as |item|}}
+                {{#if item._isShortcut}}
+                    {{! ── Shortcut sibling card (AWS-style flat item) ─────── }}
+                    <div class="snm-dropdown-card snm-dropdown-card--shortcut" role="presentation">
+                        <div class="snm-dropdown-card-header">
                             <div class="snm-dropdown-card-link-wrapper" role="none" {{on "click" @onClose}}>
                                 <LinkToExternal
-                                    @route={{menuItem.route}}
-                                    id={{concat (dasherize (or menuItem.route menuItem.id "nav")) "-dropdown-card"}}
+                                    @route={{item.route}}
+                                    id={{concat (dasherize (or item.route item.id "sc")) "-dropdown-card"}}
                                     class="snm-dropdown-card-link"
-                                    title={{menuItem.title}}
+                                    title={{item.title}}
                                 >
                                     <span class="snm-dropdown-card-icon">
-                                        {{#if menuItem.iconComponent}}
-                                            {{component (lazy-engine-component menuItem.iconComponent) options=menuItem.iconComponentOptions}}
-                                        {{else}}
-                                            <FaIcon @icon={{or menuItem.icon "circle-dot"}} @prefix={{menuItem.iconPrefix}} @size="sm" />
-                                        {{/if}}
+                                        <FaIcon @icon={{item.icon}} @prefix={{item.iconPrefix}} @size="xs" />
                                     </span>
-                                    <span class="snm-dropdown-card-title">{{menuItem.title}}</span>
+                                    <span class="snm-dropdown-card-title">{{item.title}}</span>
                                 </LinkToExternal>
                             </div>
+                        </div>
+                        {{#if item._parentTitle}}
+                            <p class="snm-dropdown-card-parent-label">{{item._parentTitle}}</p>
                         {{/if}}
-
-                        {{#unless @atPinnedLimit}}
-                            <button
-                                type="button"
-                                class="snm-dropdown-pin-btn"
-                                title="Pin to navigation bar"
-                                aria-label="Pin {{menuItem.title}} to navigation bar"
-                                {{on "click" (fn @onQuickPin menuItem)}}
-                            >
-                                <FaIcon @icon="thumbtack" @size="xs" />
-                            </button>
-                        {{/unless}}
                     </div>
-
-                    {{#if menuItem.description}}
-                        <p class="snm-dropdown-card-description">{{menuItem.description}}</p>
-                    {{/if}}
-
-                    {{#if menuItem.shortcuts}}
-                        <ul class="snm-dropdown-shortcuts" role="group" aria-label="Shortcuts">
-                            {{#each menuItem.shortcuts as |shortcut|}}
-                                <li class="snm-dropdown-shortcut-item">
-                                    <div role="none" {{on "click" this.handleShortcutClick}}>
-                                        <LinkToExternal
-                                            @route={{shortcut.route}}
-                                            class="snm-dropdown-shortcut-link"
-                                            title={{shortcut.title}}
-                                        >
-                                            <span class="snm-dropdown-shortcut-icon" aria-hidden="true">
-                                                <FaIcon @icon={{or shortcut.icon "arrow-right"}} @prefix={{shortcut.iconPrefix}} @size="xs" />
-                                            </span>
-                                            <span class="snm-dropdown-shortcut-title">{{shortcut.title}}</span>
-                                        </LinkToExternal>
-                                    </div>
-                                </li>
-                            {{/each}}
-                        </ul>
-                    {{/if}}
-
-                </div>
+                {{else}}
+                    {{! ── Primary extension card ──────────────────────────── }}
+                    <div class="snm-dropdown-card" role="presentation">
+                        <div class="snm-dropdown-card-header">
+                            {{#if item.onClick}}
+                                <a
+                                    href="javascript:;"
+                                    class="snm-dropdown-card-link"
+                                    title={{item.title}}
+                                    {{on "click" (fn this.handleItemClick item)}}
+                                >
+                                    <span class="snm-dropdown-card-icon">
+                                        {{#if item.iconComponent}}
+                                            {{component (lazy-engine-component item.iconComponent) options=item.iconComponentOptions}}
+                                        {{else}}
+                                            <FaIcon @icon={{or item.icon "circle-dot"}} @prefix={{item.iconPrefix}} @size="sm" />
+                                        {{/if}}
+                                    </span>
+                                    <span class="snm-dropdown-card-title">{{item.title}}</span>
+                                </a>
+                            {{else}}
+                                <div class="snm-dropdown-card-link-wrapper" role="none" {{on "click" @onClose}}>
+                                    <LinkToExternal
+                                        @route={{item.route}}
+                                        id={{concat (dasherize (or item.route item.id "nav")) "-dropdown-card"}}
+                                        class="snm-dropdown-card-link"
+                                        title={{item.title}}
+                                    >
+                                        <span class="snm-dropdown-card-icon">
+                                            {{#if item.iconComponent}}
+                                                {{component (lazy-engine-component item.iconComponent) options=item.iconComponentOptions}}
+                                            {{else}}
+                                                <FaIcon @icon={{or item.icon "circle-dot"}} @prefix={{item.iconPrefix}} @size="sm" />
+                                            {{/if}}
+                                        </span>
+                                        <span class="snm-dropdown-card-title">{{item.title}}</span>
+                                    </LinkToExternal>
+                                </div>
+                            {{/if}}
+                            {{#unless @atPinnedLimit}}
+                                <button
+                                    type="button"
+                                    class="snm-dropdown-pin-btn"
+                                    title="Pin to navigation bar"
+                                    aria-label="Pin {{item.title}} to navigation bar"
+                                    {{on "click" (fn @onQuickPin item)}}
+                                >
+                                    <FaIcon @icon="thumbtack" @size="xs" />
+                                </button>
+                            {{/unless}}
+                        </div>
+                        {{#if item.description}}
+                            <p class="snm-dropdown-card-description">{{item.description}}</p>
+                        {{/if}}
+                    </div>
+                {{/if}}
             {{/each}}
         {{/if}}
-
     </div>
 
     {{! ── Footer ──────────────────────────────────────────────────────────── }}

--- a/addon/components/layout/header/smart-nav-menu/dropdown.hbs
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.hbs
@@ -14,6 +14,11 @@
       @onOpenCustomizer - Action to open the customiser panel
       @onQuickPin       - Action to pin an item directly from the dropdown
       @atPinnedLimit    - Boolean: true when the bar is full (pin button hidden)
+
+    NOTE: @onClose is attached directly to <LinkToExternal> elements (not to a
+    wrapper div) so the Ember router handles the transition first and the
+    dropdown closes afterwards.  A wrapper-div click handler fires before the
+    router can intercept the anchor click, causing a full page refresh.
 }}
 <div
     class="snm-dropdown snm-dropdown--wide"
@@ -75,25 +80,30 @@
                     {{! ── Shortcut sibling card (AWS-style flat item) ─────── }}
                     <div class="snm-dropdown-card" role="presentation">
                         <div class="snm-dropdown-card-header">
-                            <div class="snm-dropdown-card-link-wrapper" role="none" {{on "click" @onClose}}>
-                                <LinkToExternal
-                                    @route={{item.route}}
-                                    id={{concat (dasherize (or item.route item.id "sc")) "-dropdown-card"}}
-                                    class="snm-dropdown-card-link"
-                                    title={{item.title}}
-                                >
-                                    <span class="snm-dropdown-card-icon">
-                                        <FaIcon @icon={{item.icon}} @prefix={{item.iconPrefix}} @size="sm" />
-                                    </span>
-                                    {{! Title row: shortcut name + always-visible muted parent attribution }}
-                                    <span class="snm-dropdown-card-title-group">
-                                        <span class="snm-dropdown-card-title">{{item.title}}</span>
-                                        {{#if item._parentTitle}}
-                                            <span class="snm-dropdown-card-parent-label" aria-label="from {{item._parentTitle}}">· {{item._parentTitle}}</span>
-                                        {{/if}}
-                                    </span>
-                                </LinkToExternal>
-                            </div>
+                            {{! onClose is on the LinkToExternal itself so the Ember router
+                                handles the transition before the dropdown closes. }}
+                            <LinkToExternal
+                                @route={{item.route}}
+                                id={{concat (dasherize (or item.route item.id "sc")) "-dropdown-card"}}
+                                class="snm-dropdown-card-link"
+                                title={{item.title}}
+                                {{on "click" @onClose}}
+                            >
+                                <span class="snm-dropdown-card-icon">
+                                    {{#if item.iconComponent}}
+                                        {{component (lazy-engine-component item.iconComponent) options=item.iconComponentOptions}}
+                                    {{else}}
+                                        <FaIcon @icon={{or item.icon "circle-dot"}} @prefix={{item.iconPrefix}} @size="sm" />
+                                    {{/if}}
+                                </span>
+                                {{! Title row: shortcut name + always-visible muted parent attribution }}
+                                <span class="snm-dropdown-card-title-group">
+                                    <span class="snm-dropdown-card-title">{{item.title}}</span>
+                                    {{#if item._parentTitle}}
+                                        <span class="snm-dropdown-card-parent-label" aria-label="from {{item._parentTitle}}">· {{item._parentTitle}}</span>
+                                    {{/if}}
+                                </span>
+                            </LinkToExternal>
                             {{#unless @atPinnedLimit}}
                                 <button
                                     type="button"
@@ -130,7 +140,6 @@
                                             <FaIcon @icon={{or item.icon "circle-dot"}} @prefix={{item.iconPrefix}} @size="sm" />
                                         {{/if}}
                                     </span>
-                                    {{! Title row: always show muted parent label when this is a pinned shortcut }}
                                     <span class="snm-dropdown-card-title-group">
                                         <span class="snm-dropdown-card-title">{{item.title}}</span>
                                         {{#if item._parentTitle}}
@@ -139,29 +148,29 @@
                                     </span>
                                 </a>
                             {{else}}
-                                <div class="snm-dropdown-card-link-wrapper" role="none" {{on "click" @onClose}}>
-                                    <LinkToExternal
-                                        @route={{item.route}}
-                                        id={{concat (dasherize (or item.route item.id "nav")) "-dropdown-card"}}
-                                        class="snm-dropdown-card-link"
-                                        title={{item.title}}
-                                    >
-                                        <span class="snm-dropdown-card-icon">
-                                            {{#if item.iconComponent}}
-                                                {{component (lazy-engine-component item.iconComponent) options=item.iconComponentOptions}}
-                                            {{else}}
-                                                <FaIcon @icon={{or item.icon "circle-dot"}} @prefix={{item.iconPrefix}} @size="sm" />
-                                            {{/if}}
-                                        </span>
-                                        {{! Title row: always show muted parent label when this is a pinned shortcut }}
-                                        <span class="snm-dropdown-card-title-group">
-                                            <span class="snm-dropdown-card-title">{{item.title}}</span>
-                                            {{#if item._parentTitle}}
-                                                <span class="snm-dropdown-card-parent-label" aria-label="from {{item._parentTitle}}">· {{item._parentTitle}}</span>
-                                            {{/if}}
-                                        </span>
-                                    </LinkToExternal>
-                                </div>
+                                {{! onClose is on the LinkToExternal itself – not on a wrapper div –
+                                    so the Ember router handles the transition before the dropdown closes. }}
+                                <LinkToExternal
+                                    @route={{item.route}}
+                                    id={{concat (dasherize (or item.route item.id "nav")) "-dropdown-card"}}
+                                    class="snm-dropdown-card-link"
+                                    title={{item.title}}
+                                    {{on "click" @onClose}}
+                                >
+                                    <span class="snm-dropdown-card-icon">
+                                        {{#if item.iconComponent}}
+                                            {{component (lazy-engine-component item.iconComponent) options=item.iconComponentOptions}}
+                                        {{else}}
+                                            <FaIcon @icon={{or item.icon "circle-dot"}} @prefix={{item.iconPrefix}} @size="sm" />
+                                        {{/if}}
+                                    </span>
+                                    <span class="snm-dropdown-card-title-group">
+                                        <span class="snm-dropdown-card-title">{{item.title}}</span>
+                                        {{#if item._parentTitle}}
+                                            <span class="snm-dropdown-card-parent-label" aria-label="from {{item._parentTitle}}">· {{item._parentTitle}}</span>
+                                        {{/if}}
+                                    </span>
+                                </LinkToExternal>
                             {{/if}}
                             {{#unless @atPinnedLimit}}
                                 <button

--- a/addon/components/layout/header/smart-nav-menu/dropdown.hbs
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.hbs
@@ -5,6 +5,11 @@
     Position is supplied as @top / @left (fixed-position px values calculated
     from the "More" button's getBoundingClientRect in the parent component).
 
+    Each item mirrors the same dual-branch pattern used by
+    SmartNavMenu::Item: if the item defines an `onClick` handler it is
+    invoked directly; otherwise a `<LinkToExternal />` route link is
+    rendered — identical behaviour to the original next-catalog-menu-items.
+
     Args:
       @items            - Array of MenuItem objects to display
       @top              - CSS top value in px (fixed position)
@@ -21,10 +26,7 @@
 >
     {{! ── Header ──────────────────────────────────────────────────────────── }}
     <div class="snm-dropdown-header">
-        <span class="snm-dropdown-title">
-            <FaIcon @icon="grid-2" @size="xs" class="mr-1.5 opacity-60" />
-            Extensions
-        </span>
+        <span class="snm-dropdown-title">Extensions</span>
         <button
             type="button"
             class="snm-dropdown-close"
@@ -35,11 +37,11 @@
         </button>
     </div>
 
-    {{! ── Items grid ──────────────────────────────────────────────────────── }}
+    {{! ── Items list ──────────────────────────────────────────────────────── }}
     <div class="snm-dropdown-items" role="menu" aria-label="More extensions">
         {{#each @items as |menuItem|}}
             {{#if menuItem.onClick}}
-                {{! onClick-style item (no route) }}
+                {{! onClick-style item: invoke the handler then close the dropdown }}
                 <a
                     href="javascript:;"
                     class="snm-dropdown-item"
@@ -57,13 +59,13 @@
                     <span class="snm-dropdown-item-title truncate">{{menuItem.title}}</span>
                 </a>
             {{else}}
-                {{! Route-based item }}
+                {{! Standard route link via LinkToExternal — same as the original header }}
                 <LinkToExternal
                     @route={{menuItem.route}}
+                    id={{concat (dasherize (or menuItem.route menuItem.id "nav")) "-dropdown-button"}}
                     class="snm-dropdown-item"
                     role="menuitem"
                     title={{menuItem.title}}
-                    {{on "click" @onClose}}
                 >
                     <span class="snm-dropdown-item-icon">
                         {{#if menuItem.iconComponent}}

--- a/addon/components/layout/header/smart-nav-menu/dropdown.hbs
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.hbs
@@ -15,10 +15,10 @@
       @onQuickPin       - Action to pin an item directly from the dropdown
       @atPinnedLimit    - Boolean: true when the bar is full (pin button hidden)
 
-    NOTE: @onClose is attached directly to <LinkToExternal> elements (not to a
-    wrapper div) so the Ember router handles the transition first and the
-    dropdown closes afterwards.  A wrapper-div click handler fires before the
-    router can intercept the anchor click, causing a full page refresh.
+    NOTE: Route-based cards use a plain <a> with {{on "click" (fn this.navigateTo item)}}
+    rather than <LinkToExternal>.  The navigateTo action calls preventDefault,
+    closes the dropdown, then calls router.transitionTo so the Ember router
+    handles navigation without a full page reload.
 }}
 <div
     class="snm-dropdown snm-dropdown--wide"
@@ -80,14 +80,12 @@
                     {{! ── Shortcut sibling card (AWS-style flat item) ─────── }}
                     <div class="snm-dropdown-card" role="presentation">
                         <div class="snm-dropdown-card-header">
-                            {{! onClose is on the LinkToExternal itself so the Ember router
-                                handles the transition before the dropdown closes. }}
-                            <LinkToExternal
-                                @route={{item.route}}
+                            <a
+                                href="javascript:;"
                                 id={{concat (dasherize (or item.route item.id "sc")) "-dropdown-card"}}
                                 class="snm-dropdown-card-link"
                                 title={{item.title}}
-                                {{on "click" @onClose}}
+                                {{on "click" (fn this.navigateTo item)}}
                             >
                                 <span class="snm-dropdown-card-icon">
                                     {{#if item.iconComponent}}
@@ -103,7 +101,7 @@
                                         <span class="snm-dropdown-card-parent-label" aria-label="from {{item._parentTitle}}">· {{item._parentTitle}}</span>
                                     {{/if}}
                                 </span>
-                            </LinkToExternal>
+                            </a>
                             {{#unless @atPinnedLimit}}
                                 <button
                                     type="button"
@@ -148,14 +146,12 @@
                                     </span>
                                 </a>
                             {{else}}
-                                {{! onClose is on the LinkToExternal itself – not on a wrapper div –
-                                    so the Ember router handles the transition before the dropdown closes. }}
-                                <LinkToExternal
-                                    @route={{item.route}}
+                                <a
+                                    href="javascript:;"
                                     id={{concat (dasherize (or item.route item.id "nav")) "-dropdown-card"}}
                                     class="snm-dropdown-card-link"
                                     title={{item.title}}
-                                    {{on "click" @onClose}}
+                                    {{on "click" (fn this.navigateTo item)}}
                                 >
                                     <span class="snm-dropdown-card-icon">
                                         {{#if item.iconComponent}}
@@ -170,7 +166,7 @@
                                             <span class="snm-dropdown-card-parent-label" aria-label="from {{item._parentTitle}}">· {{item._parentTitle}}</span>
                                         {{/if}}
                                     </span>
-                                </LinkToExternal>
+                                </a>
                             {{/if}}
                             {{#unless @atPinnedLimit}}
                                 <button

--- a/addon/components/layout/header/smart-nav-menu/dropdown.hbs
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.hbs
@@ -21,32 +21,9 @@
     role="dialog"
     aria-label="More extensions"
 >
-    {{! ── Header: title + inline search + close ──────────────────────────── }}
+    {{! ── Header: title + close ────────────────────────────────────────────── }}
     <div class="snm-dropdown-header">
         <span class="snm-dropdown-title">Extensions</span>
-        <div class="snm-dropdown-search-bar">
-            <span class="snm-dropdown-search-icon" aria-hidden="true">
-                <FaIcon @icon="magnifying-glass" @size="xs" />
-            </span>
-            <input
-                type="text"
-                class="snm-dropdown-search-input"
-                placeholder="Search extensions..."
-                value={{this.searchQuery}}
-                aria-label="Search extensions"
-                {{on "input" this.updateSearch}}
-            />
-            {{#if this.searchQuery}}
-                <button
-                    type="button"
-                    class="snm-dropdown-search-clear"
-                    aria-label="Clear search"
-                    {{on "click" this.clearSearch}}
-                >
-                    <FaIcon @icon="xmark" @size="xs" />
-                </button>
-            {{/if}}
-        </div>
         <button
             type="button"
             class="snm-dropdown-close"
@@ -55,6 +32,31 @@
         >
             <FaIcon @icon="xmark" @size="sm" />
         </button>
+    </div>
+
+    {{! ── Search bar (own row) ────────────────────────────────────────────── }}
+    <div class="snm-dropdown-search-bar">
+        <span class="snm-dropdown-search-icon" aria-hidden="true">
+            <FaIcon @icon="magnifying-glass" @size="xs" />
+        </span>
+        <input
+            type="text"
+            class="snm-dropdown-search-input"
+            placeholder="Search extensions..."
+            value={{this.searchQuery}}
+            aria-label="Search extensions"
+            {{on "input" this.updateSearch}}
+        />
+        {{#if this.searchQuery}}
+            <button
+                type="button"
+                class="snm-dropdown-search-clear"
+                aria-label="Clear search"
+                {{on "click" this.clearSearch}}
+            >
+                <FaIcon @icon="xmark" @size="xs" />
+            </button>
+        {{/if}}
     </div>
 
     {{! ── Card grid ───────────────────────────────────────────────────────── }}

--- a/addon/components/layout/header/smart-nav-menu/dropdown.hbs
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.hbs
@@ -85,7 +85,13 @@
                                     <span class="snm-dropdown-card-icon">
                                         <FaIcon @icon={{item.icon}} @prefix={{item.iconPrefix}} @size="sm" />
                                     </span>
-                                    <span class="snm-dropdown-card-title">{{item.title}}</span>
+                                    {{! Title row: shortcut name + always-visible muted parent attribution }}
+                                    <span class="snm-dropdown-card-title-group">
+                                        <span class="snm-dropdown-card-title">{{item.title}}</span>
+                                        {{#if item._parentTitle}}
+                                            <span class="snm-dropdown-card-parent-label" aria-label="from {{item._parentTitle}}">· {{item._parentTitle}}</span>
+                                        {{/if}}
+                                    </span>
                                 </LinkToExternal>
                             </div>
                             {{#unless @atPinnedLimit}}
@@ -102,8 +108,6 @@
                         </div>
                         {{#if item.description}}
                             <p class="snm-dropdown-card-description">{{item.description}}</p>
-                        {{else if item._parentTitle}}
-                            <p class="snm-dropdown-card-description snm-dropdown-card-description--from"><em>from {{item._parentTitle}}</em></p>
                         {{/if}}
                     </div>
                 {{else}}
@@ -124,7 +128,13 @@
                                             <FaIcon @icon={{or item.icon "circle-dot"}} @prefix={{item.iconPrefix}} @size="sm" />
                                         {{/if}}
                                     </span>
-                                    <span class="snm-dropdown-card-title">{{item.title}}</span>
+                                    {{! Title row: always show muted parent label when this is a pinned shortcut }}
+                                    <span class="snm-dropdown-card-title-group">
+                                        <span class="snm-dropdown-card-title">{{item.title}}</span>
+                                        {{#if item._parentTitle}}
+                                            <span class="snm-dropdown-card-parent-label" aria-label="from {{item._parentTitle}}">· {{item._parentTitle}}</span>
+                                        {{/if}}
+                                    </span>
                                 </a>
                             {{else}}
                                 <div class="snm-dropdown-card-link-wrapper" role="none" {{on "click" @onClose}}>
@@ -141,7 +151,13 @@
                                                 <FaIcon @icon={{or item.icon "circle-dot"}} @prefix={{item.iconPrefix}} @size="sm" />
                                             {{/if}}
                                         </span>
-                                        <span class="snm-dropdown-card-title">{{item.title}}</span>
+                                        {{! Title row: always show muted parent label when this is a pinned shortcut }}
+                                        <span class="snm-dropdown-card-title-group">
+                                            <span class="snm-dropdown-card-title">{{item.title}}</span>
+                                            {{#if item._parentTitle}}
+                                                <span class="snm-dropdown-card-parent-label" aria-label="from {{item._parentTitle}}">· {{item._parentTitle}}</span>
+                                            {{/if}}
+                                        </span>
                                     </LinkToExternal>
                                 </div>
                             {{/if}}

--- a/addon/components/layout/header/smart-nav-menu/dropdown.hbs
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.hbs
@@ -1,33 +1,18 @@
-{{! Layout::Header::SmartNavMenu::Dropdown
-    ─────────────────────────────────────────────────────────────────────────
-    Overflow dropdown panel.  Rendered via EmberWormhole into
-    #application-root-wormhole so it escapes the header's 57px height.
-    Position is supplied as @top / @left (fixed-position px values calculated
-    from the "More" button's getBoundingClientRect in the parent component).
-
-    Each item row has:
-      - An icon + title link (onClick branch or LinkToExternal)
-      - A pin button on the right — only shown when the bar has capacity
-        (@atPinnedLimit is false).  Clicking it calls @onQuickPin and
-        immediately moves the item from the dropdown to the bar.
-
-    The LinkToExternal items are wrapped in a <div> that calls @onClose
-    on click (without preventDefault) so the dropdown closes after the
-    user navigates.  The router transition is not interrupted because
-    the event continues to bubble to the LinkToExternal anchor.
+{{!
+    Layout::Header::SmartNavMenu::Dropdown
+    Phase 2: multi-column card grid with search filter.
 
     Args:
-      @items          - Array of MenuItem objects to display
-      @top            - CSS top value in px (fixed position)
-      @left           - CSS left value in px (fixed position)
-      @onClose        - Action to close this dropdown
+      @items            - Array of MenuItem objects to display
+      @top              - Fixed-position top offset (px, from JS)
+      @left             - Fixed-position left offset (px, from JS)
+      @onClose          - Action to close this dropdown
       @onOpenCustomizer - Action to open the customiser panel
-      @onQuickPin     - Action to pin an item directly from the dropdown
-      @atPinnedLimit  - Boolean: true when the bar is full (pin button disabled)
-    ─────────────────────────────────────────────────────────────────────────
+      @onQuickPin       - Action to pin an item directly from the dropdown
+      @atPinnedLimit    - Boolean: true when the bar is full (pin button hidden)
 }}
 <div
-    class="snm-dropdown"
+    class="snm-dropdown snm-dropdown--wide"
     style={{this.positionStyle}}
     role="dialog"
     aria-label="More extensions"
@@ -45,71 +30,126 @@
         </button>
     </div>
 
-    {{! ── Items list ──────────────────────────────────────────────────────── }}
-    <div class="snm-dropdown-items" role="menu" aria-label="More extensions">
-        {{#each @items as |menuItem|}}
-            <div class="snm-dropdown-item-row">
-                {{#if menuItem.onClick}}
-                    {{! onClick-style item: invoke the handler then close }}
-                    <a
-                        href="javascript:;"
-                        class="snm-dropdown-item"
-                        role="menuitem"
-                        title={{menuItem.title}}
-                        {{on "click" (fn this.handleItemClick menuItem)}}
-                    >
-                        <span class="snm-dropdown-item-icon">
-                            {{#if menuItem.iconComponent}}
-                                {{component (lazy-engine-component menuItem.iconComponent) options=menuItem.iconComponentOptions}}
-                            {{else}}
-                                <FaIcon @icon={{or menuItem.icon "circle-dot"}} @prefix={{menuItem.iconPrefix}} @size="sm" />
-                            {{/if}}
-                        </span>
-                        <span class="snm-dropdown-item-title truncate">{{menuItem.title}}</span>
-                    </a>
-                {{else}}
-                    {{! Standard route link via LinkToExternal.
-                        Wrapped in a div with an on-click that calls @onClose
-                        WITHOUT preventDefault — the event continues to bubble
-                        so the router handles the transition normally, and the
-                        dropdown closes cleanly after navigation. }}
-                    <div class="snm-dropdown-item-link-wrapper" role="none" {{on "click" @onClose}}>
-                        <LinkToExternal
-                            @route={{menuItem.route}}
-                            id={{concat (dasherize (or menuItem.route menuItem.id "nav")) "-dropdown-button"}}
-                            class="snm-dropdown-item"
-                            role="menuitem"
-                            title={{menuItem.title}}
-                        >
-                            <span class="snm-dropdown-item-icon">
-                                {{#if menuItem.iconComponent}}
-                                    {{component (lazy-engine-component menuItem.iconComponent) options=menuItem.iconComponentOptions}}
-                                {{else}}
-                                    <FaIcon @icon={{or menuItem.icon "circle-dot"}} @prefix={{menuItem.iconPrefix}} @size="sm" />
-                                {{/if}}
-                            </span>
-                            <span class="snm-dropdown-item-title truncate">{{menuItem.title}}</span>
-                        </LinkToExternal>
-                    </div>
-                {{/if}}
+    {{! ── Search bar ──────────────────────────────────────────────────────── }}
+    <div class="snm-dropdown-search-bar">
+        <span class="snm-dropdown-search-icon" aria-hidden="true">
+            <FaIcon @icon="magnifying-glass" @size="sm" />
+        </span>
+        <input
+            type="text"
+            class="snm-dropdown-search-input"
+            placeholder="Search extensions..."
+            value={{this.searchQuery}}
+            aria-label="Search extensions"
+            {{on "input" this.updateSearch}}
+        />
+        {{#if this.searchQuery}}
+            <button
+                type="button"
+                class="snm-dropdown-search-clear"
+                aria-label="Clear search"
+                {{on "click" this.clearSearch}}
+            >
+                <FaIcon @icon="xmark" @size="xs" />
+            </button>
+        {{/if}}
+    </div>
 
-                {{! ── Inline pin button ──────────────────────────────────── }}
-                {{! Only shown when the bar still has capacity.
-                    Clicking pins the item directly to the bar without
-                    opening the full customiser panel. }}
-                {{#unless @atPinnedLimit}}
-                    <button
-                        type="button"
-                        class="snm-dropdown-pin-btn"
-                        title="Pin to navigation bar"
-                        aria-label="Pin {{menuItem.title}} to navigation bar"
-                        {{on "click" (fn @onQuickPin menuItem)}}
-                    >
-                        <FaIcon @icon="thumbtack" @size="xs" />
-                    </button>
-                {{/unless}}
+    {{! ── Card grid ───────────────────────────────────────────────────────── }}
+    <div class="snm-dropdown-grid" aria-label="Extension list">
+
+        {{#if this.hasNoResults}}
+            <div class="snm-dropdown-empty">
+                <FaIcon @icon="magnifying-glass" @size="lg" class="snm-dropdown-empty-icon" />
+                <p class="snm-dropdown-empty-text">
+                    No extensions match
+                    <strong>{{this.searchQuery}}</strong>
+                </p>
             </div>
-        {{/each}}
+        {{else}}
+            {{#each this.filteredItems as |menuItem|}}
+                <div class="snm-dropdown-card" role="presentation">
+
+                    {{! Card header: icon + title + pin button }}
+                    <div class="snm-dropdown-card-header">
+                        {{#if menuItem.onClick}}
+                            <a
+                                href="javascript:;"
+                                class="snm-dropdown-card-link"
+                                title={{menuItem.title}}
+                                {{on "click" (fn this.handleItemClick menuItem)}}
+                            >
+                                <span class="snm-dropdown-card-icon">
+                                    {{#if menuItem.iconComponent}}
+                                        {{component (lazy-engine-component menuItem.iconComponent) options=menuItem.iconComponentOptions}}
+                                    {{else}}
+                                        <FaIcon @icon={{or menuItem.icon "circle-dot"}} @prefix={{menuItem.iconPrefix}} @size="sm" />
+                                    {{/if}}
+                                </span>
+                                <span class="snm-dropdown-card-title">{{menuItem.title}}</span>
+                            </a>
+                        {{else}}
+                            <div class="snm-dropdown-card-link-wrapper" role="none" {{on "click" @onClose}}>
+                                <LinkToExternal
+                                    @route={{menuItem.route}}
+                                    id={{concat (dasherize (or menuItem.route menuItem.id "nav")) "-dropdown-card"}}
+                                    class="snm-dropdown-card-link"
+                                    title={{menuItem.title}}
+                                >
+                                    <span class="snm-dropdown-card-icon">
+                                        {{#if menuItem.iconComponent}}
+                                            {{component (lazy-engine-component menuItem.iconComponent) options=menuItem.iconComponentOptions}}
+                                        {{else}}
+                                            <FaIcon @icon={{or menuItem.icon "circle-dot"}} @prefix={{menuItem.iconPrefix}} @size="sm" />
+                                        {{/if}}
+                                    </span>
+                                    <span class="snm-dropdown-card-title">{{menuItem.title}}</span>
+                                </LinkToExternal>
+                            </div>
+                        {{/if}}
+
+                        {{#unless @atPinnedLimit}}
+                            <button
+                                type="button"
+                                class="snm-dropdown-pin-btn"
+                                title="Pin to navigation bar"
+                                aria-label="Pin {{menuItem.title}} to navigation bar"
+                                {{on "click" (fn @onQuickPin menuItem)}}
+                            >
+                                <FaIcon @icon="thumbtack" @size="xs" />
+                            </button>
+                        {{/unless}}
+                    </div>
+
+                    {{#if menuItem.description}}
+                        <p class="snm-dropdown-card-description">{{menuItem.description}}</p>
+                    {{/if}}
+
+                    {{#if menuItem.shortcuts}}
+                        <ul class="snm-dropdown-shortcuts" role="group" aria-label="Shortcuts">
+                            {{#each menuItem.shortcuts as |shortcut|}}
+                                <li class="snm-dropdown-shortcut-item">
+                                    <div role="none" {{on "click" this.handleShortcutClick}}>
+                                        <LinkToExternal
+                                            @route={{shortcut.route}}
+                                            class="snm-dropdown-shortcut-link"
+                                            title={{shortcut.title}}
+                                        >
+                                            <span class="snm-dropdown-shortcut-icon" aria-hidden="true">
+                                                <FaIcon @icon={{or shortcut.icon "arrow-right"}} @prefix={{shortcut.iconPrefix}} @size="xs" />
+                                            </span>
+                                            <span class="snm-dropdown-shortcut-title">{{shortcut.title}}</span>
+                                        </LinkToExternal>
+                                    </div>
+                                </li>
+                            {{/each}}
+                        </ul>
+                    {{/if}}
+
+                </div>
+            {{/each}}
+        {{/if}}
+
     </div>
 
     {{! ── Footer ──────────────────────────────────────────────────────────── }}

--- a/addon/components/layout/header/smart-nav-menu/dropdown.hbs
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.hbs
@@ -1,21 +1,29 @@
 {{! Layout::Header::SmartNavMenu::Dropdown
-    The overflow "More" panel.  Positioned absolutely below the "More" button.
-    Styled to match the existing `next-dd-menu` family of dropdowns.
+    ─────────────────────────────────────────────────────────────────────────
+    Overflow dropdown panel.  Rendered when the "More" (⋯) button is active.
+    Items are the extension menu items that did not fit in the header bar.
+
+    Args:
+      @items            - Array of MenuItem objects to display
+      @onClose          - Action to close this dropdown
+      @onOpenCustomizer - Action to open the customiser panel
+    ─────────────────────────────────────────────────────────────────────────
 }}
-<div class="snm-dropdown next-dd-menu" aria-label="More extensions">
+<div class="snm-dropdown next-dd-menu">
     <div class="snm-dropdown-header">
-        <span class="snm-dropdown-title">All Extensions</span>
+        <span class="snm-dropdown-title">Extensions</span>
     </div>
 
     <div class="snm-dropdown-items" role="menu" aria-label="More extensions">
         {{#each @items as |menuItem|}}
             {{#if menuItem.onClick}}
+                {{! onClick-style item (no route) }}
                 <a
                     href="javascript:;"
-                    role="menuitem"
                     class="snm-dropdown-item next-dd-item"
+                    role="menuitem"
                     title={{menuItem.title}}
-                    {{on "click" (fn this.handleItemClick menuItem.onClick)}}
+                    {{on "click" (fn this.handleItemClick menuItem)}}
                 >
                     <div class="snm-dropdown-item-icon">
                         {{#if menuItem.iconComponent}}
@@ -27,6 +35,7 @@
                     <span class="truncate">{{menuItem.title}}</span>
                 </a>
             {{else}}
+                {{! Route-based item }}
                 <LinkToExternal
                     @route={{menuItem.route}}
                     class="snm-dropdown-item next-dd-item"
@@ -51,7 +60,7 @@
         <button
             type="button"
             class="snm-dropdown-customise-link"
-            {{on "click" this.openCustomizer}}
+            {{on "click" @onOpenCustomizer}}
         >
             <FaIcon @icon="sliders" @size="sm" class="mr-1.5" />
             Customise navigation

--- a/addon/components/layout/header/smart-nav-menu/dropdown.hbs
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.hbs
@@ -1,68 +1,91 @@
 {{! Layout::Header::SmartNavMenu::Dropdown
     ─────────────────────────────────────────────────────────────────────────
-    Overflow dropdown panel.  Rendered when the "More" (⋯) button is active.
-    Items are the extension menu items that did not fit in the header bar.
+    Overflow dropdown panel.  Rendered via EmberWormhole into
+    #application-root-wormhole so it escapes the header's 57px height.
+    Position is supplied as @top / @left (fixed-position px values calculated
+    from the "More" button's getBoundingClientRect in the parent component).
 
     Args:
       @items            - Array of MenuItem objects to display
+      @top              - CSS top value in px (fixed position)
+      @left             - CSS left value in px (fixed position)
       @onClose          - Action to close this dropdown
       @onOpenCustomizer - Action to open the customiser panel
     ─────────────────────────────────────────────────────────────────────────
 }}
-<div class="snm-dropdown next-dd-menu">
+<div
+    class="snm-dropdown"
+    style="top: {{@top}}px; left: {{@left}}px;"
+    role="dialog"
+    aria-label="More extensions"
+>
+    {{! ── Header ──────────────────────────────────────────────────────────── }}
     <div class="snm-dropdown-header">
-        <span class="snm-dropdown-title">Extensions</span>
+        <span class="snm-dropdown-title">
+            <FaIcon @icon="grid-2" @size="xs" class="mr-1.5 opacity-60" />
+            Extensions
+        </span>
+        <button
+            type="button"
+            class="snm-dropdown-close"
+            aria-label="Close"
+            {{on "click" @onClose}}
+        >
+            <FaIcon @icon="xmark" @size="sm" />
+        </button>
     </div>
 
+    {{! ── Items grid ──────────────────────────────────────────────────────── }}
     <div class="snm-dropdown-items" role="menu" aria-label="More extensions">
         {{#each @items as |menuItem|}}
             {{#if menuItem.onClick}}
                 {{! onClick-style item (no route) }}
                 <a
                     href="javascript:;"
-                    class="snm-dropdown-item next-dd-item"
+                    class="snm-dropdown-item"
                     role="menuitem"
                     title={{menuItem.title}}
                     {{on "click" (fn this.handleItemClick menuItem)}}
                 >
-                    <div class="snm-dropdown-item-icon">
+                    <span class="snm-dropdown-item-icon">
                         {{#if menuItem.iconComponent}}
                             {{component (lazy-engine-component menuItem.iconComponent) options=menuItem.iconComponentOptions}}
                         {{else}}
                             <FaIcon @icon={{or menuItem.icon "circle-dot"}} @prefix={{menuItem.iconPrefix}} @size="sm" />
                         {{/if}}
-                    </div>
-                    <span class="truncate">{{menuItem.title}}</span>
+                    </span>
+                    <span class="snm-dropdown-item-title truncate">{{menuItem.title}}</span>
                 </a>
             {{else}}
                 {{! Route-based item }}
                 <LinkToExternal
                     @route={{menuItem.route}}
-                    class="snm-dropdown-item next-dd-item"
+                    class="snm-dropdown-item"
                     role="menuitem"
                     title={{menuItem.title}}
                     {{on "click" @onClose}}
                 >
-                    <div class="snm-dropdown-item-icon">
+                    <span class="snm-dropdown-item-icon">
                         {{#if menuItem.iconComponent}}
                             {{component (lazy-engine-component menuItem.iconComponent) options=menuItem.iconComponentOptions}}
                         {{else}}
                             <FaIcon @icon={{or menuItem.icon "circle-dot"}} @prefix={{menuItem.iconPrefix}} @size="sm" />
                         {{/if}}
-                    </div>
-                    <span class="truncate">{{menuItem.title}}</span>
+                    </span>
+                    <span class="snm-dropdown-item-title truncate">{{menuItem.title}}</span>
                 </LinkToExternal>
             {{/if}}
         {{/each}}
     </div>
 
+    {{! ── Footer ──────────────────────────────────────────────────────────── }}
     <div class="snm-dropdown-footer">
         <button
             type="button"
             class="snm-dropdown-customise-link"
             {{on "click" @onOpenCustomizer}}
         >
-            <FaIcon @icon="sliders" @size="sm" class="mr-1.5" />
+            <FaIcon @icon="sliders" @size="xs" class="mr-1.5" />
             Customise navigation
         </button>
     </div>

--- a/addon/components/layout/header/smart-nav-menu/dropdown.hbs
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.hbs
@@ -5,17 +5,25 @@
     Position is supplied as @top / @left (fixed-position px values calculated
     from the "More" button's getBoundingClientRect in the parent component).
 
-    Each item mirrors the same dual-branch pattern used by
-    SmartNavMenu::Item: if the item defines an `onClick` handler it is
-    invoked directly; otherwise a `<LinkToExternal />` route link is
-    rendered — identical behaviour to the original next-catalog-menu-items.
+    Each item row has:
+      - An icon + title link (onClick branch or LinkToExternal)
+      - A pin button on the right — only shown when the bar has capacity
+        (@atPinnedLimit is false).  Clicking it calls @onQuickPin and
+        immediately moves the item from the dropdown to the bar.
+
+    The LinkToExternal items are wrapped in a <div> that calls @onClose
+    on click (without preventDefault) so the dropdown closes after the
+    user navigates.  The router transition is not interrupted because
+    the event continues to bubble to the LinkToExternal anchor.
 
     Args:
-      @items            - Array of MenuItem objects to display
-      @top              - CSS top value in px (fixed position)
-      @left             - CSS left value in px (fixed position)
-      @onClose          - Action to close this dropdown
+      @items          - Array of MenuItem objects to display
+      @top            - CSS top value in px (fixed position)
+      @left           - CSS left value in px (fixed position)
+      @onClose        - Action to close this dropdown
       @onOpenCustomizer - Action to open the customiser panel
+      @onQuickPin     - Action to pin an item directly from the dropdown
+      @atPinnedLimit  - Boolean: true when the bar is full (pin button disabled)
     ─────────────────────────────────────────────────────────────────────────
 }}
 <div
@@ -40,43 +48,67 @@
     {{! ── Items list ──────────────────────────────────────────────────────── }}
     <div class="snm-dropdown-items" role="menu" aria-label="More extensions">
         {{#each @items as |menuItem|}}
-            {{#if menuItem.onClick}}
-                {{! onClick-style item: invoke the handler then close the dropdown }}
-                <a
-                    href="javascript:;"
-                    class="snm-dropdown-item"
-                    role="menuitem"
-                    title={{menuItem.title}}
-                    {{on "click" (fn this.handleItemClick menuItem)}}
-                >
-                    <span class="snm-dropdown-item-icon">
-                        {{#if menuItem.iconComponent}}
-                            {{component (lazy-engine-component menuItem.iconComponent) options=menuItem.iconComponentOptions}}
-                        {{else}}
-                            <FaIcon @icon={{or menuItem.icon "circle-dot"}} @prefix={{menuItem.iconPrefix}} @size="sm" />
-                        {{/if}}
-                    </span>
-                    <span class="snm-dropdown-item-title truncate">{{menuItem.title}}</span>
-                </a>
-            {{else}}
-                {{! Standard route link via LinkToExternal — same as the original header }}
-                <LinkToExternal
-                    @route={{menuItem.route}}
-                    id={{concat (dasherize (or menuItem.route menuItem.id "nav")) "-dropdown-button"}}
-                    class="snm-dropdown-item"
-                    role="menuitem"
-                    title={{menuItem.title}}
-                >
-                    <span class="snm-dropdown-item-icon">
-                        {{#if menuItem.iconComponent}}
-                            {{component (lazy-engine-component menuItem.iconComponent) options=menuItem.iconComponentOptions}}
-                        {{else}}
-                            <FaIcon @icon={{or menuItem.icon "circle-dot"}} @prefix={{menuItem.iconPrefix}} @size="sm" />
-                        {{/if}}
-                    </span>
-                    <span class="snm-dropdown-item-title truncate">{{menuItem.title}}</span>
-                </LinkToExternal>
-            {{/if}}
+            <div class="snm-dropdown-item-row">
+                {{#if menuItem.onClick}}
+                    {{! onClick-style item: invoke the handler then close }}
+                    <a
+                        href="javascript:;"
+                        class="snm-dropdown-item"
+                        role="menuitem"
+                        title={{menuItem.title}}
+                        {{on "click" (fn this.handleItemClick menuItem)}}
+                    >
+                        <span class="snm-dropdown-item-icon">
+                            {{#if menuItem.iconComponent}}
+                                {{component (lazy-engine-component menuItem.iconComponent) options=menuItem.iconComponentOptions}}
+                            {{else}}
+                                <FaIcon @icon={{or menuItem.icon "circle-dot"}} @prefix={{menuItem.iconPrefix}} @size="sm" />
+                            {{/if}}
+                        </span>
+                        <span class="snm-dropdown-item-title truncate">{{menuItem.title}}</span>
+                    </a>
+                {{else}}
+                    {{! Standard route link via LinkToExternal.
+                        Wrapped in a div with an on-click that calls @onClose
+                        WITHOUT preventDefault — the event continues to bubble
+                        so the router handles the transition normally, and the
+                        dropdown closes cleanly after navigation. }}
+                    <div class="snm-dropdown-item-link-wrapper" role="none" {{on "click" @onClose}}>
+                        <LinkToExternal
+                            @route={{menuItem.route}}
+                            id={{concat (dasherize (or menuItem.route menuItem.id "nav")) "-dropdown-button"}}
+                            class="snm-dropdown-item"
+                            role="menuitem"
+                            title={{menuItem.title}}
+                        >
+                            <span class="snm-dropdown-item-icon">
+                                {{#if menuItem.iconComponent}}
+                                    {{component (lazy-engine-component menuItem.iconComponent) options=menuItem.iconComponentOptions}}
+                                {{else}}
+                                    <FaIcon @icon={{or menuItem.icon "circle-dot"}} @prefix={{menuItem.iconPrefix}} @size="sm" />
+                                {{/if}}
+                            </span>
+                            <span class="snm-dropdown-item-title truncate">{{menuItem.title}}</span>
+                        </LinkToExternal>
+                    </div>
+                {{/if}}
+
+                {{! ── Inline pin button ──────────────────────────────────── }}
+                {{! Only shown when the bar still has capacity.
+                    Clicking pins the item directly to the bar without
+                    opening the full customiser panel. }}
+                {{#unless @atPinnedLimit}}
+                    <button
+                        type="button"
+                        class="snm-dropdown-pin-btn"
+                        title="Pin to navigation bar"
+                        aria-label="Pin {{menuItem.title}} to navigation bar"
+                        {{on "click" (fn @onQuickPin menuItem)}}
+                    >
+                        <FaIcon @icon="thumbtack" @size="xs" />
+                    </button>
+                {{/unless}}
+            </div>
         {{/each}}
     </div>
 

--- a/addon/components/layout/header/smart-nav-menu/dropdown.hbs
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.hbs
@@ -2,12 +2,12 @@
     The overflow "More" panel.  Positioned absolutely below the "More" button.
     Styled to match the existing `next-dd-menu` family of dropdowns.
 }}
-<div class="snm-dropdown next-dd-menu" role="menu" aria-label="More extensions">
+<div class="snm-dropdown next-dd-menu" aria-label="More extensions">
     <div class="snm-dropdown-header">
         <span class="snm-dropdown-title">All Extensions</span>
     </div>
 
-    <div class="snm-dropdown-items">
+    <div class="snm-dropdown-items" role="menu" aria-label="More extensions">
         {{#each @items as |menuItem|}}
             {{#if menuItem.onClick}}
                 <a

--- a/addon/components/layout/header/smart-nav-menu/dropdown.hbs
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.hbs
@@ -73,7 +73,7 @@
             {{#each this.filteredItems as |item|}}
                 {{#if item._isShortcut}}
                     {{! ── Shortcut sibling card (AWS-style flat item) ─────── }}
-                    <div class="snm-dropdown-card snm-dropdown-card--shortcut" role="presentation">
+                    <div class="snm-dropdown-card" role="presentation">
                         <div class="snm-dropdown-card-header">
                             <div class="snm-dropdown-card-link-wrapper" role="none" {{on "click" @onClose}}>
                                 <LinkToExternal
@@ -83,15 +83,26 @@
                                     title={{item.title}}
                                 >
                                     <span class="snm-dropdown-card-icon">
-                                        <FaIcon @icon={{item.icon}} @prefix={{item.iconPrefix}} @size="xs" />
+                                        <FaIcon @icon={{item.icon}} @prefix={{item.iconPrefix}} @size="sm" />
                                     </span>
                                     <span class="snm-dropdown-card-title">{{item.title}}</span>
+                                    {{#if item._parentTitle}}
+                                        <span class="snm-dropdown-card-from" aria-hidden="true">&middot; {{item._parentTitle}}</span>
+                                    {{/if}}
                                 </LinkToExternal>
                             </div>
+                            {{#unless @atPinnedLimit}}
+                                <button
+                                    type="button"
+                                    class="snm-dropdown-pin-btn"
+                                    title="Pin to navigation bar"
+                                    aria-label="Pin {{item.title}} to navigation bar"
+                                    {{on "click" (fn @onQuickPin item)}}
+                                >
+                                    <FaIcon @icon="thumbtack" @size="xs" />
+                                </button>
+                            {{/unless}}
                         </div>
-                        {{#if item._parentTitle}}
-                            <p class="snm-dropdown-card-parent-label">{{item._parentTitle}}</p>
-                        {{/if}}
                     </div>
                 {{else}}
                     {{! ── Primary extension card ──────────────────────────── }}

--- a/addon/components/layout/header/smart-nav-menu/dropdown.hbs
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.hbs
@@ -15,10 +15,9 @@
       @onQuickPin       - Action to pin an item directly from the dropdown
       @atPinnedLimit    - Boolean: true when the bar is full (pin button hidden)
 
-    NOTE: Route-based cards use a plain <a> with {{on "click" (fn this.navigateTo item)}}
-    rather than <LinkToExternal>.  The navigateTo action calls preventDefault,
-    closes the dropdown, then calls router.transitionTo so the Ember router
-    handles navigation without a full page reload.
+    NOTE: Route-based cards use <LinkToExternal> with no click handler.
+    The dropdown is closed via the routeDidChange listener in smart-nav-menu.js
+    which sets isMoreOpen = false on every route transition.
 }}
 <div
     class="snm-dropdown snm-dropdown--wide"
@@ -80,12 +79,11 @@
                     {{! ── Shortcut sibling card (AWS-style flat item) ─────── }}
                     <div class="snm-dropdown-card" role="presentation">
                         <div class="snm-dropdown-card-header">
-                            <a
-                                href="javascript:;"
+                            <LinkToExternal
+                                @route={{item.route}}
                                 id={{concat (dasherize (or item.route item.id "sc")) "-dropdown-card"}}
                                 class="snm-dropdown-card-link"
                                 title={{item.title}}
-                                {{on "click" (fn this.navigateTo item)}}
                             >
                                 <span class="snm-dropdown-card-icon">
                                     {{#if item.iconComponent}}
@@ -101,7 +99,7 @@
                                         <span class="snm-dropdown-card-parent-label" aria-label="from {{item._parentTitle}}">· {{item._parentTitle}}</span>
                                     {{/if}}
                                 </span>
-                            </a>
+                            </LinkToExternal>
                             {{#unless @atPinnedLimit}}
                                 <button
                                     type="button"
@@ -146,12 +144,11 @@
                                     </span>
                                 </a>
                             {{else}}
-                                <a
-                                    href="javascript:;"
+                                <LinkToExternal
+                                    @route={{item.route}}
                                     id={{concat (dasherize (or item.route item.id "nav")) "-dropdown-card"}}
                                     class="snm-dropdown-card-link"
                                     title={{item.title}}
-                                    {{on "click" (fn this.navigateTo item)}}
                                 >
                                     <span class="snm-dropdown-card-icon">
                                         {{#if item.iconComponent}}
@@ -166,7 +163,7 @@
                                             <span class="snm-dropdown-card-parent-label" aria-label="from {{item._parentTitle}}">· {{item._parentTitle}}</span>
                                         {{/if}}
                                     </span>
-                                </a>
+                                </LinkToExternal>
                             {{/if}}
                             {{#unless @atPinnedLimit}}
                                 <button

--- a/addon/components/layout/header/smart-nav-menu/dropdown.js
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.js
@@ -43,6 +43,7 @@ export default class LayoutHeaderSmartNavMenuDropdownComponent extends Component
                         route: sc.route,
                         icon: sc.icon ?? 'arrow-right',
                         iconPrefix: sc.iconPrefix,
+                        description: sc.description ?? null,
                         _isShortcut: true,
                         _parentTitle: item.title,
                     });

--- a/addon/components/layout/header/smart-nav-menu/dropdown.js
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.js
@@ -16,6 +16,8 @@ import { htmlSafe } from '@ember/template';
  *   @left             {Number}     Fixed-position left coordinate in px.
  *   @onClose          {Function}  Called when the dropdown should close.
  *   @onOpenCustomizer {Function}  Called when the customiser should open.
+ *   @onQuickPin       {Function}  Called with a menuItem to pin it directly to the bar.
+ *   @atPinnedLimit    {Boolean}   True when the bar is full; hides the pin button.
  *
  * @class LayoutHeaderSmartNavMenuDropdownComponent
  * @extends Component

--- a/addon/components/layout/header/smart-nav-menu/dropdown.js
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.js
@@ -7,6 +7,11 @@ import { htmlSafe } from '@ember/template';
  * Layout::Header::SmartNavMenu::Dropdown
  *
  * Phase 2: multi-column card grid + search filter.
+ *
+ * Shortcuts are expanded as independent sibling items in the grid (AWS-style).
+ * Each shortcut is normalised into a flat display item with `_isShortcut: true`
+ * so the template can render it with a slightly different visual treatment
+ * (muted style, no pin button).
  */
 export default class LayoutHeaderSmartNavMenuDropdownComponent extends Component {
     @tracked searchQuery = '';
@@ -17,18 +22,45 @@ export default class LayoutHeaderSmartNavMenuDropdownComponent extends Component
         return htmlSafe('top: ' + top + 'px; left: ' + left + 'px;');
     }
 
+    /**
+     * Expand every MenuItem's shortcuts array into sibling flat items.
+     * The resulting array interleaves parent items and their shortcuts in
+     * registration order, matching the AWS Console pattern.
+     *
+     * Each shortcut is normalised to:
+     *   { title, route, icon, iconPrefix, id, _isShortcut: true, _parentTitle }
+     */
+    get expandedItems() {
+        const items = this.args.items ?? [];
+        const result = [];
+        for (const item of items) {
+            result.push(item);
+            if (Array.isArray(item.shortcuts)) {
+                for (const sc of item.shortcuts) {
+                    result.push({
+                        id: sc.id ?? item.id + '-sc-' + sc.title,
+                        title: sc.title,
+                        route: sc.route,
+                        icon: sc.icon ?? 'arrow-right',
+                        iconPrefix: sc.iconPrefix,
+                        _isShortcut: true,
+                        _parentTitle: item.title,
+                    });
+                }
+            }
+        }
+        return result;
+    }
+
     get filteredItems() {
         const query = (this.searchQuery || '').trim().toLowerCase();
-        const items = this.args.items ?? [];
         if (!query) {
-            return items;
+            return this.expandedItems;
         }
-        return items.filter((item) => {
+        return this.expandedItems.filter((item) => {
             if ((item.title || '').toLowerCase().includes(query)) return true;
             if (item.description && item.description.toLowerCase().includes(query)) return true;
-            if (Array.isArray(item.shortcuts)) {
-                return item.shortcuts.some((sc) => (sc.title || '').toLowerCase().includes(query));
-            }
+            if (item._parentTitle && item._parentTitle.toLowerCase().includes(query)) return true;
             return false;
         });
     }
@@ -50,12 +82,6 @@ export default class LayoutHeaderSmartNavMenuDropdownComponent extends Component
         if (menuItem && typeof menuItem.onClick === 'function') {
             menuItem.onClick(menuItem);
         }
-        if (typeof this.args.onClose === 'function') {
-            this.args.onClose();
-        }
-    }
-
-    @action handleShortcutClick() {
         if (typeof this.args.onClose === 'function') {
             this.args.onClose();
         }

--- a/addon/components/layout/header/smart-nav-menu/dropdown.js
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.js
@@ -63,7 +63,7 @@ export default class LayoutHeaderSmartNavMenuDropdownComponent extends Component
 
                         // ── Metadata ─────────────────────────────────────────
                         description: sc.description ?? null,
-                        tags: isArray(sc.tags) ? sc.tags : (isArray(item.tags) ? item.tags : null),
+                        tags: isArray(sc.tags) ? sc.tags : isArray(item.tags) ? item.tags : null,
 
                         // ── Behaviour ────────────────────────────────────────
                         onClick: sc.onClick ?? null,

--- a/addon/components/layout/header/smart-nav-menu/dropdown.js
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.js
@@ -1,0 +1,52 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+
+/**
+ * `Layout::Header::SmartNavMenu::Dropdown`
+ *
+ * The "More" overflow dropdown panel.  Displays all extension items that
+ * could not fit in the visible bar, plus a footer link to open the
+ * customiser panel.
+ *
+ * @class LayoutHeaderSmartNavMenuDropdownComponent
+ * @extends Component
+ */
+export default class LayoutHeaderSmartNavMenuDropdownComponent extends Component {
+    @service router;
+    @service hostRouter;
+
+    /**
+     * Navigate to a route and close the dropdown.
+     *
+     * @param {string} route
+     */
+    @action navigateTo(route) {
+        const r = this.router ?? this.hostRouter;
+        r.transitionTo(route);
+        if (typeof this.args.onClose === 'function') {
+            this.args.onClose();
+        }
+    }
+
+    /**
+     * Handle a custom onClick item and close the dropdown.
+     *
+     * @param {Function} handler
+     */
+    @action handleItemClick(handler) {
+        if (typeof handler === 'function') {
+            handler();
+        }
+        if (typeof this.args.onClose === 'function') {
+            this.args.onClose();
+        }
+    }
+
+    /** Open the customiser panel. */
+    @action openCustomizer() {
+        if (typeof this.args.onOpenCustomizer === 'function') {
+            this.args.onOpenCustomizer();
+        }
+    }
+}

--- a/addon/components/layout/header/smart-nav-menu/dropdown.js
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.js
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
 import { dasherize } from '@ember/string';
 import { isArray } from '@ember/array';
 import { htmlSafe } from '@ember/template';
@@ -17,15 +16,7 @@ import { htmlSafe } from '@ember/template';
  * (muted style, no pin button).
  */
 export default class LayoutHeaderSmartNavMenuDropdownComponent extends Component {
-    @service router;
-    @service hostRouter;
-
     @tracked searchQuery = '';
-
-    /** Returns whichever router service is available. */
-    get _router() {
-        return this.router ?? this.hostRouter;
-    }
 
     get positionStyle() {
         const top = this.args.top ?? 0;
@@ -126,22 +117,6 @@ export default class LayoutHeaderSmartNavMenuDropdownComponent extends Component
         }
         if (typeof this.args.onClose === 'function') {
             this.args.onClose();
-        }
-    }
-
-    /**
-     * Navigate to a route-based menu item programmatically.
-     * Closes the dropdown first, then transitions via the router service so
-     * the Ember router handles the navigation (no full page reload).
-     */
-    @action navigateTo(menuItem, event) {
-        event?.preventDefault();
-        if (typeof this.args.onClose === 'function') {
-            this.args.onClose();
-        }
-        const route = menuItem?.route;
-        if (route && this._router) {
-            this._router.transitionTo(route);
         }
     }
 }

--- a/addon/components/layout/header/smart-nav-menu/dropdown.js
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.js
@@ -9,6 +9,11 @@ import { action } from '@ember/object';
  * could not fit in the visible bar, plus a footer link to open the
  * customiser panel.
  *
+ * Args:
+ *   @items            {MenuItem[]} Items to render in the dropdown.
+ *   @onClose          {Function}  Called when the dropdown should close.
+ *   @onOpenCustomizer {Function}  Called when the customiser should open.
+ *
  * @class LayoutHeaderSmartNavMenuDropdownComponent
  * @extends Component
  */
@@ -17,36 +22,17 @@ export default class LayoutHeaderSmartNavMenuDropdownComponent extends Component
     @service hostRouter;
 
     /**
-     * Navigate to a route and close the dropdown.
-     *
-     * @param {string} route
-     */
-    @action navigateTo(route) {
-        const r = this.router ?? this.hostRouter;
-        r.transitionTo(route);
-        if (typeof this.args.onClose === 'function') {
-            this.args.onClose();
-        }
-    }
-
-    /**
      * Handle a custom onClick item and close the dropdown.
+     * Receives the full `menuItem` object so we can call `menuItem.onClick`.
      *
-     * @param {Function} handler
+     * @param {Object} menuItem
      */
-    @action handleItemClick(handler) {
-        if (typeof handler === 'function') {
-            handler();
+    @action handleItemClick(menuItem) {
+        if (menuItem && typeof menuItem.onClick === 'function') {
+            menuItem.onClick(menuItem);
         }
         if (typeof this.args.onClose === 'function') {
             this.args.onClose();
-        }
-    }
-
-    /** Open the customiser panel. */
-    @action openCustomizer() {
-        if (typeof this.args.onOpenCustomizer === 'function') {
-            this.args.onOpenCustomizer();
         }
     }
 }

--- a/addon/components/layout/header/smart-nav-menu/dropdown.js
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { dasherize } from '@ember/string';
 import { htmlSafe } from '@ember/template';
 
 /**
@@ -38,7 +39,7 @@ export default class LayoutHeaderSmartNavMenuDropdownComponent extends Component
             if (Array.isArray(item.shortcuts)) {
                 for (const sc of item.shortcuts) {
                     result.push({
-                        id: sc.id ?? item.id + '-sc-' + sc.title,
+                        id: sc.id ?? dasherize(item.id + '-sc-' + sc.title),
                         title: sc.title,
                         route: sc.route,
                         icon: sc.icon ?? 'arrow-right',

--- a/addon/components/layout/header/smart-nav-menu/dropdown.js
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.js
@@ -1,56 +1,61 @@
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { htmlSafe } from '@ember/template';
 
 /**
- * `Layout::Header::SmartNavMenu::Dropdown`
+ * Layout::Header::SmartNavMenu::Dropdown
  *
- * The "More" overflow dropdown panel.  Each item mirrors the same dual-branch
- * pattern used by SmartNavMenu::Item: if the item defines an `onClick` handler
- * it is invoked directly; otherwise a `<LinkToExternal />` route link is
- * rendered — identical behaviour to the original next-catalog-menu-items.
- *
- * Args:
- *   @items            {MenuItem[]} Items to render in the dropdown.
- *   @top              {Number}     Fixed-position top coordinate in px.
- *   @left             {Number}     Fixed-position left coordinate in px.
- *   @onClose          {Function}  Called when the dropdown should close.
- *   @onOpenCustomizer {Function}  Called when the customiser should open.
- *   @onQuickPin       {Function}  Called with a menuItem to pin it directly to the bar.
- *   @atPinnedLimit    {Boolean}   True when the bar is full; hides the pin button.
- *
- * @class LayoutHeaderSmartNavMenuDropdownComponent
- * @extends Component
+ * Phase 2: multi-column card grid + search filter.
  */
 export default class LayoutHeaderSmartNavMenuDropdownComponent extends Component {
-    /**
-     * Computes the fixed-position style string for the dropdown panel.
-     * Uses `htmlSafe()` to satisfy the `no-inline-styles` and
-     * `style-concatenation` template lint rules — the style value is
-     * constructed entirely in JS and marked safe before being bound.
-     *
-     * @returns {SafeString}
-     */
+    @tracked searchQuery = '';
+
     get positionStyle() {
         const top = this.args.top ?? 0;
         const left = this.args.left ?? 0;
-        return htmlSafe(`top: ${top}px; left: ${left}px;`);
+        return htmlSafe('top: ' + top + 'px; left: ' + left + 'px;');
     }
 
-    /**
-     * Handle a custom onClick item: invoke the item's handler then close the
-     * dropdown.  Receives the full `menuItem` object so we can call
-     * `menuItem.onClick(menuItem)` matching the pattern used elsewhere in the
-     * Fleetbase console.
-     *
-     * @param {Object} menuItem
-     * @param {Event}  event
-     */
+    get filteredItems() {
+        const query = (this.searchQuery || '').trim().toLowerCase();
+        const items = this.args.items ?? [];
+        if (!query) {
+            return items;
+        }
+        return items.filter((item) => {
+            if ((item.title || '').toLowerCase().includes(query)) return true;
+            if (item.description && item.description.toLowerCase().includes(query)) return true;
+            if (Array.isArray(item.shortcuts)) {
+                return item.shortcuts.some((sc) => (sc.title || '').toLowerCase().includes(query));
+            }
+            return false;
+        });
+    }
+
+    get hasNoResults() {
+        return this.searchQuery.trim().length > 0 && this.filteredItems.length === 0;
+    }
+
+    @action updateSearch(event) {
+        this.searchQuery = event.target.value;
+    }
+
+    @action clearSearch() {
+        this.searchQuery = '';
+    }
+
     @action handleItemClick(menuItem, event) {
         event?.preventDefault();
         if (menuItem && typeof menuItem.onClick === 'function') {
             menuItem.onClick(menuItem);
         }
+        if (typeof this.args.onClose === 'function') {
+            this.args.onClose();
+        }
+    }
+
+    @action handleShortcutClick() {
         if (typeof this.args.onClose === 'function') {
             this.args.onClose();
         }

--- a/addon/components/layout/header/smart-nav-menu/dropdown.js
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 import { dasherize } from '@ember/string';
 import { isArray } from '@ember/array';
 import { htmlSafe } from '@ember/template';
@@ -16,7 +17,15 @@ import { htmlSafe } from '@ember/template';
  * (muted style, no pin button).
  */
 export default class LayoutHeaderSmartNavMenuDropdownComponent extends Component {
+    @service router;
+    @service hostRouter;
+
     @tracked searchQuery = '';
+
+    /** Returns whichever router service is available. */
+    get _router() {
+        return this.router ?? this.hostRouter;
+    }
 
     get positionStyle() {
         const top = this.args.top ?? 0;
@@ -117,6 +126,22 @@ export default class LayoutHeaderSmartNavMenuDropdownComponent extends Component
         }
         if (typeof this.args.onClose === 'function') {
             this.args.onClose();
+        }
+    }
+
+    /**
+     * Navigate to a route-based menu item programmatically.
+     * Closes the dropdown first, then transitions via the router service so
+     * the Ember router handles the navigation (no full page reload).
+     */
+    @action navigateTo(menuItem, event) {
+        event?.preventDefault();
+        if (typeof this.args.onClose === 'function') {
+            this.args.onClose();
+        }
+        const route = menuItem?.route;
+        if (route && this._router) {
+            this._router.transitionTo(route);
         }
     }
 }

--- a/addon/components/layout/header/smart-nav-menu/dropdown.js
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { htmlSafe } from '@ember/template';
 
 /**
  * `Layout::Header::SmartNavMenu::Dropdown`
@@ -20,6 +21,20 @@ import { action } from '@ember/object';
  * @extends Component
  */
 export default class LayoutHeaderSmartNavMenuDropdownComponent extends Component {
+    /**
+     * Computes the fixed-position style string for the dropdown panel.
+     * Uses `htmlSafe()` to satisfy the `no-inline-styles` and
+     * `style-concatenation` template lint rules — the style value is
+     * constructed entirely in JS and marked safe before being bound.
+     *
+     * @returns {SafeString}
+     */
+    get positionStyle() {
+        const top = this.args.top ?? 0;
+        const left = this.args.left ?? 0;
+        return htmlSafe(`top: ${top}px; left: ${left}px;`);
+    }
+
     /**
      * Handle a custom onClick item: invoke the item's handler then close the
      * dropdown.  Receives the full `menuItem` object so we can call

--- a/addon/components/layout/header/smart-nav-menu/dropdown.js
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.js
@@ -39,15 +39,43 @@ export default class LayoutHeaderSmartNavMenuDropdownComponent extends Component
             result.push(item);
             if (isArray(item.shortcuts)) {
                 for (const sc of item.shortcuts) {
+                    const scId = sc.id ?? dasherize(item.id + '-sc-' + sc.title);
                     result.push({
-                        id: sc.id ?? dasherize(item.id + '-sc-' + sc.title),
+                        // ── Identity ────────────────────────────────────────
+                        id: scId,
+                        slug: sc.slug ?? scId,
                         title: sc.title,
-                        route: sc.route,
-                        icon: sc.icon ?? 'arrow-right',
-                        iconPrefix: sc.iconPrefix,
+                        text: sc.text ?? sc.title,
+                        label: sc.label ?? sc.title,
+
+                        // ── Routing ──────────────────────────────────────────
+                        route: sc.route ?? item.route,
+                        queryParams: sc.queryParams ?? {},
+                        routeParams: sc.routeParams ?? [],
+
+                        // ── Icons (full surface) ─────────────────────────────
+                        icon: sc.icon ?? item.icon ?? 'arrow-right',
+                        iconPrefix: sc.iconPrefix ?? item.iconPrefix ?? null,
+                        iconSize: sc.iconSize ?? null,
+                        iconClass: sc.iconClass ?? null,
+                        iconComponent: sc.iconComponent ?? null,
+                        iconComponentOptions: sc.iconComponentOptions ?? {},
+
+                        // ── Metadata ─────────────────────────────────────────
                         description: sc.description ?? null,
+                        tags: isArray(sc.tags) ? sc.tags : (isArray(item.tags) ? item.tags : null),
+
+                        // ── Behaviour ────────────────────────────────────────
+                        onClick: sc.onClick ?? null,
+                        disabled: sc.disabled ?? false,
+
+                        // ── Styling ───────────────────────────────────────────
+                        class: sc.class ?? null,
+
+                        // ── Internal flags ────────────────────────────────────
                         _isShortcut: true,
                         _parentTitle: item.title,
+                        _parentId: item.id,
                     });
                 }
             }

--- a/addon/components/layout/header/smart-nav-menu/dropdown.js
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.js
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { dasherize } from '@ember/string';
+import { isArray } from '@ember/array';
 import { htmlSafe } from '@ember/template';
 
 /**
@@ -36,7 +37,7 @@ export default class LayoutHeaderSmartNavMenuDropdownComponent extends Component
         const result = [];
         for (const item of items) {
             result.push(item);
-            if (Array.isArray(item.shortcuts)) {
+            if (isArray(item.shortcuts)) {
                 for (const sc of item.shortcuts) {
                     result.push({
                         id: sc.id ?? dasherize(item.id + '-sc-' + sc.title),
@@ -63,6 +64,8 @@ export default class LayoutHeaderSmartNavMenuDropdownComponent extends Component
             if ((item.title || '').toLowerCase().includes(query)) return true;
             if (item.description && item.description.toLowerCase().includes(query)) return true;
             if (item._parentTitle && item._parentTitle.toLowerCase().includes(query)) return true;
+            // Match against any of the item's tags
+            if (isArray(item.tags) && item.tags.some((t) => t.toLowerCase().includes(query))) return true;
             return false;
         });
     }

--- a/addon/components/layout/header/smart-nav-menu/dropdown.js
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.js
@@ -1,16 +1,18 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 
 /**
  * `Layout::Header::SmartNavMenu::Dropdown`
  *
- * The "More" overflow dropdown panel.  Displays all extension items that
- * could not fit in the visible bar, plus a footer link to open the
- * customiser panel.
+ * The "More" overflow dropdown panel.  Each item mirrors the same dual-branch
+ * pattern used by SmartNavMenu::Item: if the item defines an `onClick` handler
+ * it is invoked directly; otherwise a `<LinkToExternal />` route link is
+ * rendered — identical behaviour to the original next-catalog-menu-items.
  *
  * Args:
  *   @items            {MenuItem[]} Items to render in the dropdown.
+ *   @top              {Number}     Fixed-position top coordinate in px.
+ *   @left             {Number}     Fixed-position left coordinate in px.
  *   @onClose          {Function}  Called when the dropdown should close.
  *   @onOpenCustomizer {Function}  Called when the customiser should open.
  *
@@ -18,16 +20,17 @@ import { action } from '@ember/object';
  * @extends Component
  */
 export default class LayoutHeaderSmartNavMenuDropdownComponent extends Component {
-    @service router;
-    @service hostRouter;
-
     /**
-     * Handle a custom onClick item and close the dropdown.
-     * Receives the full `menuItem` object so we can call `menuItem.onClick`.
+     * Handle a custom onClick item: invoke the item's handler then close the
+     * dropdown.  Receives the full `menuItem` object so we can call
+     * `menuItem.onClick(menuItem)` matching the pattern used elsewhere in the
+     * Fleetbase console.
      *
      * @param {Object} menuItem
+     * @param {Event}  event
      */
-    @action handleItemClick(menuItem) {
+    @action handleItemClick(menuItem, event) {
+        event?.preventDefault();
         if (menuItem && typeof menuItem.onClick === 'function') {
             menuItem.onClick(menuItem);
         }

--- a/addon/components/layout/header/smart-nav-menu/item.hbs
+++ b/addon/components/layout/header/smart-nav-menu/item.hbs
@@ -14,6 +14,7 @@
 {{#if @item.onClick}}
     <a
         href="javascript:;"
+        id={{concat (dasherize (or @item.route @item.id "nav")) "-header-button"}}
         role="menuitem"
         class="snm-item next-view-header-item truncate {{@item.class}} {{if this.isActive 'active'}}"
         title={{@item.title}}

--- a/addon/components/layout/header/smart-nav-menu/item.hbs
+++ b/addon/components/layout/header/smart-nav-menu/item.hbs
@@ -1,9 +1,15 @@
 {{! Layout::Header::SmartNavMenu::Item
+    ─────────────────────────────────────────────────────────────────────────
     Renders a single extension link in the header bar.
-    Supports:
-      - Standard Ember route links via LinkToExternal
-      - Custom onClick handlers
-      - Icon components (lazy-loaded engine components) or FontAwesome icons
+
+    If the item defines an `onClick` handler it is used directly (for
+    programmatic navigation or custom actions).  Otherwise the item renders
+    as a `<LinkToExternal />` route link — the standard pattern used by the
+    original next-catalog-menu-items implementation.
+
+    Supports icon components (lazy-loaded engine components) or FontAwesome
+    icons, falling back to "circle-dot" if no icon is specified.
+    ─────────────────────────────────────────────────────────────────────────
 }}
 {{#if @item.onClick}}
     <a

--- a/addon/components/layout/header/smart-nav-menu/item.hbs
+++ b/addon/components/layout/header/smart-nav-menu/item.hbs
@@ -1,0 +1,42 @@
+{{! Layout::Header::SmartNavMenu::Item
+    Renders a single extension link in the header bar.
+    Supports:
+      - Standard Ember route links via LinkToExternal
+      - Custom onClick handlers
+      - Icon components (lazy-loaded engine components) or FontAwesome icons
+}}
+{{#if @item.onClick}}
+    <a
+        href="javascript:;"
+        role="menuitem"
+        class="snm-item next-view-header-item truncate {{@item.class}} {{if this.isActive 'active'}}"
+        title={{@item.title}}
+        {{on "click" @item.onClick}}
+    >
+        <div class="w-6 flex-shrink-0">
+            {{#if @item.iconComponent}}
+                {{component (lazy-engine-component @item.iconComponent) options=@item.iconComponentOptions}}
+            {{else}}
+                <FaIcon @icon={{or @item.icon "circle-dot"}} @prefix={{@item.iconPrefix}} @size="sm" />
+            {{/if}}
+        </div>
+        <span class="truncate">{{@item.title}}</span>
+    </a>
+{{else}}
+    <LinkToExternal
+        @route={{@item.route}}
+        id={{concat (dasherize (or @item.route @item.id "nav")) "-header-button"}}
+        class="snm-item next-view-header-item truncate {{@item.class}} {{if this.isActive 'active'}}"
+        role="menuitem"
+        title={{@item.title}}
+    >
+        <div class="w-6 flex-shrink-0">
+            {{#if @item.iconComponent}}
+                {{component (lazy-engine-component @item.iconComponent) options=@item.iconComponentOptions}}
+            {{else}}
+                <FaIcon @icon={{or @item.icon "circle-dot"}} @prefix={{@item.iconPrefix}} @size="sm" />
+            {{/if}}
+        </div>
+        <span class="truncate">{{@item.title}}</span>
+    </LinkToExternal>
+{{/if}}

--- a/addon/components/layout/header/smart-nav-menu/item.js
+++ b/addon/components/layout/header/smart-nav-menu/item.js
@@ -4,8 +4,9 @@ import { inject as service } from '@ember/service';
 /**
  * `Layout::Header::SmartNavMenu::Item`
  *
- * Renders a single extension navigation link inside the SmartNavMenu bar.
- * Handles both standard route links and custom `onClick` handlers.
+ * Renders a single extension navigation link inside the SmartNavMenu bar
+ * using `<LinkToExternal />`, matching the original next-catalog-menu-items
+ * implementation exactly.
  *
  * @class LayoutHeaderSmartNavMenuItemComponent
  * @extends Component

--- a/addon/components/layout/header/smart-nav-menu/item.js
+++ b/addon/components/layout/header/smart-nav-menu/item.js
@@ -1,0 +1,28 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
+
+/**
+ * `Layout::Header::SmartNavMenu::Item`
+ *
+ * Renders a single extension navigation link inside the SmartNavMenu bar.
+ * Handles both standard route links and custom `onClick` handlers.
+ *
+ * @class LayoutHeaderSmartNavMenuItemComponent
+ * @extends Component
+ */
+export default class LayoutHeaderSmartNavMenuItemComponent extends Component {
+    @service router;
+    @service hostRouter;
+
+    /**
+     * Whether the item's route matches the current route, making it "active".
+     */
+    @computed('args.item.route', 'router.currentRouteName', 'hostRouter.currentRouteName')
+    get isActive() {
+        const route = this.args.item?.route;
+        if (!route) return false;
+        const current = (this.router ?? this.hostRouter).currentRouteName ?? '';
+        return current.startsWith(route);
+    }
+}

--- a/addon/components/layout/header/smart-nav-menu/item.js
+++ b/addon/components/layout/header/smart-nav-menu/item.js
@@ -1,6 +1,5 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { computed } from '@ember/object';
 
 /**
  * `Layout::Header::SmartNavMenu::Item`
@@ -17,12 +16,14 @@ export default class LayoutHeaderSmartNavMenuItemComponent extends Component {
 
     /**
      * Whether the item's route matches the current route, making it "active".
+     * Defined as a native getter so Glimmer's auto-tracking picks up router
+     * changes without needing the classic `@computed` decorator.
      */
-    @computed('args.item.route', 'router.currentRouteName', 'hostRouter.currentRouteName')
     get isActive() {
         const route = this.args.item?.route;
         if (!route) return false;
-        const current = (this.router ?? this.hostRouter).currentRouteName ?? '';
+        const r = this.router ?? this.hostRouter;
+        const current = r?.currentRouteName ?? '';
         return current.startsWith(route);
     }
 }

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -52,6 +52,7 @@
 @import 'components/report-builder.css';
 @import 'components/query-builder.css';
 @import 'components/activity-log.css';
+@import 'components/smart-nav-menu.css';
 
 /** Third party */
 @import "ember-basic-dropdown/vendor/ember-basic-dropdown.css";

--- a/addon/styles/components/smart-nav-menu.css
+++ b/addon/styles/components/smart-nav-menu.css
@@ -100,7 +100,7 @@
     border: none;
     border-bottom: 1px solid #374151; /* gray-700 */
     border-radius: 0;
-    padding: 0 4px 1px;
+    padding: 0 4px 1px 10px;
     gap: 4px;
 }
 

--- a/addon/styles/components/smart-nav-menu.css
+++ b/addon/styles/components/smart-nav-menu.css
@@ -70,7 +70,7 @@
     z-index: 9999;
     /* Default narrow width (fallback for non-wide variant) */
     width: 320px;
-    max-height: 50vh;
+    max-height: 60vh;
     min-height: 200px;
     display: flex;
     flex-direction: column;
@@ -485,7 +485,7 @@
     z-index: 710;
     width: 680px;
     max-width: calc(100vw - 2rem);
-    max-height: 50vh;
+    max-height: 60vh;
     border-radius: 8px;
     overflow: hidden;
     @apply bg-gray-900 border border-gray-700 shadow-next-nav;

--- a/addon/styles/components/smart-nav-menu.css
+++ b/addon/styles/components/smart-nav-menu.css
@@ -68,9 +68,8 @@
 .snm-dropdown {
     position: fixed;
     z-index: 9999;
-    /* Width: comfortable reading width, similar to AWS console services menu */
+    /* Default narrow width (fallback for non-wide variant) */
     width: 320px;
-    /* Height: auto up to a generous max so many items are visible at once */
     max-height: calc(100vh - 80px);
     min-height: 200px;
     display: flex;
@@ -81,6 +80,233 @@
     background-color: #1f2937; /* gray-800 */
     border: 1px solid #374151; /* gray-700 */
     box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5), 0 4px 16px rgba(0, 0, 0, 0.3);
+}
+
+/* Phase 2: wide multi-column variant ─────────────────────────────────────── */
+.snm-dropdown--wide {
+    /* Wide enough for 3 card columns + gutters */
+    width: 800px;
+    max-width: calc(100vw - 16px);
+}
+
+/* ── Search bar ─────────────────────────────────────────────────────────────── */
+
+.snm-dropdown-search-bar {
+    @apply flex items-center flex-shrink-0;
+    padding: 8px 12px;
+    border-bottom: 1px solid #374151; /* gray-700 */
+    background-color: #111827; /* gray-900 */
+    gap: 8px;
+}
+
+.snm-dropdown-search-icon {
+    @apply flex-shrink-0;
+    color: #6b7280; /* gray-500 */
+}
+
+.snm-dropdown-search-input {
+    @apply flex-1 bg-transparent text-sm text-gray-100 outline-none;
+    border: none;
+    padding: 0;
+    min-width: 0;
+}
+
+.snm-dropdown-search-input::placeholder {
+    color: #6b7280; /* gray-500 */
+}
+
+.snm-dropdown-search-clear {
+    @apply flex-shrink-0 flex items-center justify-center w-5 h-5 rounded transition-colors duration-100;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: #6b7280; /* gray-500 */
+    padding: 0;
+}
+
+.snm-dropdown-search-clear:hover {
+    background-color: #374151; /* gray-700 */
+    color: #f9fafb; /* gray-50 */
+}
+
+/* ── Card grid ──────────────────────────────────────────────────────────────── */
+
+.snm-dropdown-grid {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding: 12px;
+    display: grid;
+    /* 3 equal columns; fall back to 2 when the panel is narrower */
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+    align-content: start;
+    scrollbar-width: thin;
+    scrollbar-color: #4b5563 transparent;
+}
+
+.snm-dropdown-grid::-webkit-scrollbar {
+    width: 4px;
+}
+
+.snm-dropdown-grid::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.snm-dropdown-grid::-webkit-scrollbar-thumb {
+    background-color: #4b5563;
+    border-radius: 2px;
+}
+
+/* ── Extension card ─────────────────────────────────────────────────────────── */
+
+.snm-dropdown-card {
+    @apply flex flex-col rounded-lg;
+    padding: 10px 12px;
+    background-color: #111827; /* gray-900 */
+    border: 1px solid #374151; /* gray-700 */
+    transition: border-color 0.15s ease, background-color 0.15s ease;
+    position: relative;
+}
+
+.snm-dropdown-card:hover {
+    border-color: #4b5563; /* gray-600 */
+    background-color: #1a2332; /* slightly lighter than gray-900 */
+}
+
+/* Card header row: icon + title link + pin button */
+.snm-dropdown-card-header {
+    @apply flex items-center;
+    gap: 0;
+    margin-bottom: 0;
+}
+
+/* The main extension link inside a card */
+.snm-dropdown-card-link {
+    @apply flex items-center flex-1 text-sm font-medium;
+    color: #e5e7eb; /* gray-200 */
+    text-decoration: none;
+    min-width: 0;
+    cursor: pointer;
+    border: none;
+    background: none;
+    padding: 0;
+}
+
+.snm-dropdown-card-link:hover {
+    color: #f9fafb; /* gray-50 */
+}
+
+.snm-dropdown-card-link-wrapper {
+    @apply flex flex-1;
+    min-width: 0;
+}
+
+.snm-dropdown-card-link-wrapper .snm-dropdown-card-link {
+    width: 100%;
+}
+
+.snm-dropdown-card-icon {
+    @apply flex-shrink-0;
+    width: 1.125rem;
+    margin-right: 7px;
+    text-align: center;
+    color: #9ca3af; /* gray-400 */
+}
+
+.snm-dropdown-card-link:hover .snm-dropdown-card-icon {
+    color: #60a5fa; /* blue-400 */
+}
+
+.snm-dropdown-card-title {
+    @apply flex-1 truncate;
+    font-size: 0.8125rem; /* 13px */
+    line-height: 1.4;
+}
+
+/* Pin button on card – hidden until card is hovered */
+.snm-dropdown-card .snm-dropdown-pin-btn {
+    opacity: 0;
+    pointer-events: none;
+}
+
+.snm-dropdown-card:hover .snm-dropdown-pin-btn {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+/* ── Card description ───────────────────────────────────────────────────────── */
+
+.snm-dropdown-card-description {
+    @apply text-xs;
+    color: #6b7280; /* gray-500 */
+    margin: 4px 0 6px 0;
+    line-height: 1.4;
+    /* Clamp to 2 lines */
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+/* ── Shortcuts list ─────────────────────────────────────────────────────────── */
+
+.snm-dropdown-shortcuts {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    margin-top: 4px;
+    border-top: 1px solid #1f2937; /* gray-800 – subtle divider */
+    padding-top: 4px;
+}
+
+.snm-dropdown-shortcut-item {
+    display: block;
+}
+
+.snm-dropdown-shortcut-link {
+    @apply flex items-center text-xs rounded;
+    padding: 3px 4px;
+    color: #9ca3af; /* gray-400 */
+    text-decoration: none;
+    transition: color 0.1s ease, background-color 0.1s ease;
+}
+
+.snm-dropdown-shortcut-link:hover {
+    color: #60a5fa; /* blue-400 */
+    background-color: #1f2937; /* gray-800 */
+}
+
+.snm-dropdown-shortcut-icon {
+    @apply flex-shrink-0;
+    width: 0.875rem;
+    margin-right: 5px;
+    text-align: center;
+    opacity: 0.7;
+}
+
+.snm-dropdown-shortcut-title {
+    @apply flex-1 truncate;
+}
+
+/* ── Empty state (no search results) ───────────────────────────────────────── */
+
+.snm-dropdown-empty {
+    @apply flex flex-col items-center justify-center;
+    /* Span all grid columns */
+    grid-column: 1 / -1;
+    padding: 32px 16px;
+    color: #6b7280; /* gray-500 */
+    text-align: center;
+}
+
+.snm-dropdown-empty-icon {
+    @apply mb-3;
+    opacity: 0.5;
+}
+
+.snm-dropdown-empty-text {
+    @apply text-sm m-0;
+    color: #6b7280; /* gray-500 */
 }
 
 /* ── Dropdown header ────────────────────────────────────────────────────────── */
@@ -511,6 +737,89 @@ body[data-theme='light'] .snm-dropdown-customise-link:hover {
 body[data-theme='light'] .snm-dropdown-items::-webkit-scrollbar-thumb {
     background-color: #d1d5db; /* gray-300 */
 }
+
+/* Phase 2 – light theme: search bar */
+body[data-theme='light'] .snm-dropdown-search-bar {
+    background-color: #f9fafb; /* gray-50 */
+    border-bottom-color: #e5e7eb; /* gray-200 */
+}
+
+body[data-theme='light'] .snm-dropdown-search-icon {
+    color: #9ca3af; /* gray-400 */
+}
+
+body[data-theme='light'] .snm-dropdown-search-input {
+    color: #111827; /* gray-900 */
+}
+
+body[data-theme='light'] .snm-dropdown-search-input::placeholder {
+    color: #9ca3af; /* gray-400 */
+}
+
+body[data-theme='light'] .snm-dropdown-search-clear {
+    color: #9ca3af; /* gray-400 */
+}
+
+body[data-theme='light'] .snm-dropdown-search-clear:hover {
+    background-color: #f3f4f6; /* gray-100 */
+    color: #111827; /* gray-900 */
+}
+
+/* Phase 2 – light theme: card grid */
+body[data-theme='light'] .snm-dropdown-grid::-webkit-scrollbar-thumb {
+    background-color: #d1d5db; /* gray-300 */
+}
+
+body[data-theme='light'] .snm-dropdown-card {
+    background-color: #f9fafb; /* gray-50 */
+    border-color: #e5e7eb; /* gray-200 */
+}
+
+body[data-theme='light'] .snm-dropdown-card:hover {
+    border-color: #d1d5db; /* gray-300 */
+    background-color: #f3f4f6; /* gray-100 */
+}
+
+body[data-theme='light'] .snm-dropdown-card-link {
+    color: #374151; /* gray-700 */
+}
+
+body[data-theme='light'] .snm-dropdown-card-link:hover {
+    color: #111827; /* gray-900 */
+}
+
+body[data-theme='light'] .snm-dropdown-card-icon {
+    color: #6b7280; /* gray-500 */
+}
+
+body[data-theme='light'] .snm-dropdown-card-link:hover .snm-dropdown-card-icon {
+    color: #2563eb; /* blue-600 */
+}
+
+body[data-theme='light'] .snm-dropdown-card-description {
+    color: #9ca3af; /* gray-400 */
+}
+
+body[data-theme='light'] .snm-dropdown-shortcuts {
+    border-top-color: #e5e7eb; /* gray-200 */
+}
+
+body[data-theme='light'] .snm-dropdown-shortcut-link {
+    color: #6b7280; /* gray-500 */
+}
+
+body[data-theme='light'] .snm-dropdown-shortcut-link:hover {
+    color: #2563eb; /* blue-600 */
+    background-color: #f3f4f6; /* gray-100 */
+}
+
+body[data-theme='light'] .snm-dropdown-empty {
+    color: #9ca3af; /* gray-400 */
+}
+
+body[data-theme='light'] .snm-dropdown-empty-text {
+    color: #9ca3af; /* gray-400 */
+}
 body[data-theme='light'] .snm-dropdown-pin-btn {
     color: #9ca3af; /* gray-400 */
 }
@@ -612,6 +921,11 @@ body[data-theme='light'] .snm-customizer-backdrop {
         border-radius: 0;
         border-left: none;
         border-right: none;
+    }
+
+    /* Single-column card grid on mobile */
+    .snm-dropdown-grid {
+        grid-template-columns: 1fr;
     }
 
     .snm-customizer-panel {

--- a/addon/styles/components/smart-nav-menu.css
+++ b/addon/styles/components/smart-nav-menu.css
@@ -228,9 +228,25 @@
 }
 
 .snm-dropdown-card-title {
-    @apply flex-1 truncate;
+    @apply truncate;
     font-size: 0.8125rem; /* 13px */
     line-height: 1.4;
+}
+
+/* Title + muted parent-label wrapper */
+.snm-dropdown-card-title-group {
+    @apply flex items-baseline flex-1 min-w-0;
+    gap: 4px;
+}
+
+/* Muted "· ParentName" label shown inline next to the shortcut title */
+.snm-dropdown-card-parent-label {
+    @apply flex-shrink-0 truncate;
+    font-size: 0.6875rem; /* 11px */
+    font-weight: 400;
+    color: #4b5563; /* gray-600 – clearly muted */
+    line-height: 1.4;
+    letter-spacing: 0;
 }
 
 /* Pin button on card – always visible at low opacity, brightens on hover */

--- a/addon/styles/components/smart-nav-menu.css
+++ b/addon/styles/components/smart-nav-menu.css
@@ -171,9 +171,9 @@
 
 .snm-dropdown-card {
     @apply flex flex-col rounded-lg;
-    padding: 10px 12px;
+    padding: 7px 10px;
     background-color: #111827; /* gray-900 */
-    border: 1px solid #374151; /* gray-700 */
+    border: 1px solid #1f2937; /* gray-800 – darker but lighter than bg */
     transition: border-color 0.15s ease, background-color 0.15s ease;
     position: relative;
 }
@@ -257,47 +257,17 @@
     overflow: hidden;
 }
 
-/* ── Shortcut sibling card (AWS-style flat item) ────────────────────────────── */
-/* Shortcut cards are visually lighter than primary extension cards */
-.snm-dropdown-card--shortcut {
-    background-color: #0f172a; /* slate-900 – slightly darker to distinguish */
-    border-color: #1e293b; /* slate-800 */
-}
-
-.snm-dropdown-card--shortcut:hover {
-    border-color: #334155; /* slate-700 */
-    background-color: #1e293b;
-}
-
-/* Shortcut cards use a smaller icon and muted link colour */
-.snm-dropdown-card--shortcut .snm-dropdown-card-icon {
-    color: #6b7280; /* gray-500 */
-}
-
-.snm-dropdown-card--shortcut .snm-dropdown-card-link:hover .snm-dropdown-card-icon {
-    color: #60a5fa; /* blue-400 */
-}
-
-.snm-dropdown-card--shortcut .snm-dropdown-card-title {
-    font-size: 0.75rem; /* 12px – slightly smaller than primary */
-    color: #9ca3af; /* gray-400 */
-}
-
-.snm-dropdown-card--shortcut .snm-dropdown-card-link:hover .snm-dropdown-card-title {
-    color: #f9fafb; /* gray-50 */
-}
-
-/* No pin button on shortcut cards */
-.snm-dropdown-card--shortcut .snm-dropdown-pin-btn {
-    display: none;
-}
-
-/* Parent label shown beneath the shortcut title */
-.snm-dropdown-card-parent-label {
-    @apply text-xs truncate;
+/* ── Inline · From attribution on shortcut cards ────────────────────────── */
+/* Shown inline after the shortcut title: “Live Map · Fleet-Ops” */
+.snm-dropdown-card-from {
+    @apply flex-shrink-0 text-xs;
     color: #4b5563; /* gray-600 */
-    margin: 2px 0 0 0;
-    padding-left: calc(1.125rem + 7px); /* align with card-title (icon width + margin) */
+    margin-left: 5px;
+    white-space: nowrap;
+}
+
+.snm-dropdown-card-link:hover .snm-dropdown-card-from {
+    color: #6b7280; /* gray-500 – slightly brighter on hover */
 }
 
 /* ── Empty state (no search results) ───────────────────────────────────────── */
@@ -817,21 +787,7 @@ body[data-theme='light'] .snm-dropdown-card-description {
     color: #9ca3af; /* gray-400 */
 }
 
-body[data-theme='light'] .snm-dropdown-card--shortcut {
-    background-color: #f8fafc; /* slate-50 */
-    border-color: #e2e8f0; /* slate-200 */
-}
-
-body[data-theme='light'] .snm-dropdown-card--shortcut:hover {
-    border-color: #cbd5e1; /* slate-300 */
-    background-color: #f1f5f9; /* slate-100 */
-}
-
-body[data-theme='light'] .snm-dropdown-card--shortcut .snm-dropdown-card-title {
-    color: #6b7280; /* gray-500 */
-}
-
-body[data-theme='light'] .snm-dropdown-card-parent-label {
+body[data-theme='light'] .snm-dropdown-card-from {
     color: #9ca3af; /* gray-400 */
 }
 

--- a/addon/styles/components/smart-nav-menu.css
+++ b/addon/styles/components/smart-nav-menu.css
@@ -546,6 +546,9 @@ body[data-theme='light'] .snm-customizer-close {
 body[data-theme='light'] .snm-customizer-col-header {
     @apply bg-gray-50 border-gray-200;
 }
+body[data-theme='light'] .snm-customizer-col-pinned {
+    @apply border-gray-200;
+}
 
 body[data-theme='light'] .snm-customizer-col-title {
     @apply text-gray-500;

--- a/addon/styles/components/smart-nav-menu.css
+++ b/addon/styles/components/smart-nav-menu.css
@@ -12,10 +12,12 @@
 /* ── Container ──────────────────────────────────────────────────────────────── */
 
 .snm-container {
-    @apply flex items-center overflow-hidden;
-    /* Allow the container to shrink when the header is narrow */
+    @apply flex items-center;
+    /* Allow the container to shrink when the header is narrow.
+       Do NOT set overflow:hidden here – that would clip the dropdown panel. */
     min-width: 0;
     flex: 1 1 auto;
+    position: relative;
 }
 
 /* ── Bar items (inherit .next-view-header-item base styles) ─────────────────── */
@@ -39,8 +41,10 @@
 }
 
 .snm-more-btn {
-    @apply flex items-center;
-    white-space: nowrap;
+    @apply flex items-center justify-center flex-shrink-0;
+    width: 28px;
+    height: 28px;
+    padding: 0;
 }
 
 /* ── Customise (gear) button ────────────────────────────────────────────────── */

--- a/addon/styles/components/smart-nav-menu.css
+++ b/addon/styles/components/smart-nav-menu.css
@@ -618,7 +618,17 @@
 }
 
 .snm-customizer-item-title {
-    @apply flex-1 truncate;
+    @apply truncate;
+    /* flex-1 removed – parent label sits inline after the title */
+    min-width: 0;
+}
+
+/* Muted "· ParentName" suffix shown next to shortcut titles in the customiser */
+.snm-customizer-item-parent-label {
+    @apply flex-shrink-0 ml-1;
+    font-size: 0.6875rem; /* 11px */
+    color: #4b5563; /* gray-600 */
+    white-space: nowrap;
 }
 
 /* Unpin button */

--- a/addon/styles/components/smart-nav-menu.css
+++ b/addon/styles/components/smart-nav-menu.css
@@ -98,7 +98,7 @@
     border: none;
     border-bottom: 1px solid #374151; /* gray-700 */
     border-radius: 0;
-    padding: 6px 10px;
+    padding: 0 10px;
     gap: 6px;
 }
 

--- a/addon/styles/components/smart-nav-menu.css
+++ b/addon/styles/components/smart-nav-menu.css
@@ -70,7 +70,7 @@
     z-index: 9999;
     /* Default narrow width (fallback for non-wide variant) */
     width: 320px;
-    max-height: calc(100vh - 80px);
+    max-height: 50vh;
     min-height: 200px;
     display: flex;
     flex-direction: column;
@@ -521,7 +521,7 @@
     z-index: 710;
     width: 680px;
     max-width: calc(100vw - 2rem);
-    max-height: calc(100vh - 80px);
+    max-height: 50vh;
     border-radius: 8px;
     overflow: hidden;
     @apply bg-gray-900 border border-gray-700 shadow-next-nav;

--- a/addon/styles/components/smart-nav-menu.css
+++ b/addon/styles/components/smart-nav-menu.css
@@ -7,6 +7,11 @@
    Class naming convention:  snm-*
    All colours use Tailwind @apply where possible so they inherit the project's
    design tokens and respond correctly to the dark-mode `data-theme` attribute.
+
+   The overflow dropdown (.snm-dropdown) uses position:fixed and is rendered
+   via EmberWormhole into #application-root-wormhole so it escapes the 57px
+   header height constraint entirely.  Coordinates are injected as inline
+   style from JS (getBoundingClientRect on the "More" button).
    ============================================================================ */
 
 /* ── Container ──────────────────────────────────────────────────────────────── */
@@ -23,8 +28,6 @@
 /* ── Bar items (inherit .next-view-header-item base styles) ─────────────────── */
 
 .snm-item {
-    /* Inherit all base styles from the existing header item class.
-       Additional overrides below. */
     @apply flex-shrink-0;
     max-width: 160px;
 }
@@ -35,11 +38,6 @@
 
 /* ── "More" overflow button ─────────────────────────────────────────────────── */
 
-.snm-more-wrapper {
-    @apply flex-shrink-0;
-    position: relative;
-}
-
 .snm-more-btn {
     @apply flex items-center justify-center flex-shrink-0;
     width: 28px;
@@ -47,7 +45,11 @@
     padding: 0;
 }
 
-/* ── Customise (gear) button ────────────────────────────────────────────────── */
+.snm-more-btn.is-open {
+    @apply bg-gray-700 text-white rounded;
+}
+
+/* ── Customise (sliders) button ─────────────────────────────────────────────── */
 
 .snm-customise-btn {
     @apply flex items-center justify-center flex-shrink-0;
@@ -57,53 +59,142 @@
 }
 
 /* ── Overflow dropdown panel ────────────────────────────────────────────────── */
+/*
+   Rendered via EmberWormhole into #application-root-wormhole.
+   Uses position:fixed with coordinates injected as inline style from JS.
+   This completely bypasses the 57px header height constraint.
+*/
 
 .snm-dropdown {
-    position: absolute;
-    top: calc(100% + 6px);
-    left: 0;
-    z-index: 600;
-    min-width: 220px;
-    max-width: 320px;
-    /* Inherits bg, border, shadow from .next-dd-menu */
-    padding: 0.375rem 0;
+    position: fixed;
+    z-index: 9999;
+    /* Width: comfortable reading width, similar to AWS console services menu */
+    width: 320px;
+    /* Height: auto up to a generous max so many items are visible at once */
+    max-height: calc(100vh - 80px);
+    min-height: 200px;
+    display: flex;
+    flex-direction: column;
+    border-radius: 8px;
+    overflow: hidden;
+    /* Dark theme defaults (matches .next-dd-menu dark bg) */
+    background-color: #1f2937; /* gray-800 */
+    border: 1px solid #374151; /* gray-700 */
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5), 0 4px 16px rgba(0, 0, 0, 0.3);
 }
 
+/* ── Dropdown header ────────────────────────────────────────────────────────── */
+
 .snm-dropdown-header {
-    @apply flex items-center px-3 py-2 border-b border-gray-700;
+    @apply flex items-center justify-between flex-shrink-0;
+    padding: 10px 14px 10px 14px;
+    border-bottom: 1px solid #374151; /* gray-700 */
+    background-color: #111827; /* gray-900 */
 }
 
 .snm-dropdown-title {
-    @apply text-xs font-semibold uppercase tracking-wider text-gray-400;
+    @apply flex items-center text-xs font-semibold uppercase tracking-wider;
+    color: #9ca3af; /* gray-400 */
 }
+
+.snm-dropdown-close {
+    @apply flex items-center justify-center w-6 h-6 rounded transition-colors duration-150;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: #6b7280; /* gray-500 */
+    padding: 0;
+}
+
+.snm-dropdown-close:hover {
+    background-color: #374151; /* gray-700 */
+    color: #f9fafb; /* gray-50 */
+}
+
+/* ── Dropdown items list ────────────────────────────────────────────────────── */
 
 .snm-dropdown-items {
-    @apply py-1;
-    max-height: calc(100vh - 130px);
+    flex: 1 1 auto;
     overflow-y: auto;
+    padding: 6px;
+    /* Scrollbar styling to match the rest of the app */
+    scrollbar-width: thin;
+    scrollbar-color: #4b5563 transparent;
 }
 
+.snm-dropdown-items::-webkit-scrollbar {
+    width: 4px;
+}
+
+.snm-dropdown-items::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.snm-dropdown-items::-webkit-scrollbar-thumb {
+    background-color: #4b5563;
+    border-radius: 2px;
+}
+
+/* ── Individual dropdown item ───────────────────────────────────────────────── */
+
 .snm-dropdown-item {
-    @apply flex items-center px-3 py-1.5 text-sm;
-    /* Inherits hover/active from .next-dd-item */
+    @apply flex items-center w-full text-sm rounded-md transition-colors duration-100;
+    padding: 8px 10px;
+    color: #d1d5db; /* gray-300 */
+    text-decoration: none;
+    cursor: pointer;
+    border: none;
+    background: none;
+    margin-bottom: 2px;
+}
+
+.snm-dropdown-item:hover {
+    background-color: #374151; /* gray-700 */
+    color: #f9fafb; /* gray-50 */
+}
+
+.snm-dropdown-item:last-child {
+    margin-bottom: 0;
 }
 
 .snm-dropdown-item-icon {
-    @apply flex-shrink-0 mr-2.5;
+    @apply flex-shrink-0;
     width: 1.25rem;
+    margin-right: 10px;
     text-align: center;
+    color: #9ca3af; /* gray-400 */
 }
 
+.snm-dropdown-item:hover .snm-dropdown-item-icon {
+    color: #60a5fa; /* blue-400 */
+}
+
+.snm-dropdown-item-title {
+    @apply flex-1 truncate;
+    font-size: 0.8125rem; /* 13px */
+    line-height: 1.4;
+}
+
+/* ── Dropdown footer ────────────────────────────────────────────────────────── */
+
 .snm-dropdown-footer {
-    @apply flex items-center px-3 py-2 border-t border-gray-700 mt-1;
+    @apply flex items-center flex-shrink-0;
+    padding: 8px 14px;
+    border-top: 1px solid #374151; /* gray-700 */
+    background-color: #111827; /* gray-900 */
 }
 
 .snm-dropdown-customise-link {
-    @apply flex items-center text-xs text-gray-400 hover:text-blue-400 transition-colors duration-150;
+    @apply flex items-center text-xs transition-colors duration-150;
     background: none;
     border: none;
     cursor: pointer;
     padding: 0;
+    color: #6b7280; /* gray-500 */
+}
+
+.snm-dropdown-customise-link:hover {
+    color: #60a5fa; /* blue-400 */
 }
 
 /* ── Customiser panel ───────────────────────────────────────────────────────── */
@@ -293,6 +384,70 @@
 
 /* ── Light theme overrides ──────────────────────────────────────────────────── */
 
+/* Dropdown panel – light theme */
+body[data-theme='light'] .snm-dropdown {
+    background-color: #ffffff;
+    border-color: #e5e7eb; /* gray-200 */
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15), 0 4px 16px rgba(0, 0, 0, 0.1);
+}
+
+body[data-theme='light'] .snm-dropdown-header {
+    background-color: #f9fafb; /* gray-50 */
+    border-bottom-color: #e5e7eb; /* gray-200 */
+}
+
+body[data-theme='light'] .snm-dropdown-title {
+    color: #6b7280; /* gray-500 */
+}
+
+body[data-theme='light'] .snm-dropdown-close {
+    color: #9ca3af; /* gray-400 */
+}
+
+body[data-theme='light'] .snm-dropdown-close:hover {
+    background-color: #f3f4f6; /* gray-100 */
+    color: #111827; /* gray-900 */
+}
+
+body[data-theme='light'] .snm-dropdown-item {
+    color: #374151; /* gray-700 */
+}
+
+body[data-theme='light'] .snm-dropdown-item:hover {
+    background-color: #f3f4f6; /* gray-100 */
+    color: #111827; /* gray-900 */
+}
+
+body[data-theme='light'] .snm-dropdown-item-icon {
+    color: #6b7280; /* gray-500 */
+}
+
+body[data-theme='light'] .snm-dropdown-item:hover .snm-dropdown-item-icon {
+    color: #2563eb; /* blue-600 */
+}
+
+body[data-theme='light'] .snm-dropdown-footer {
+    background-color: #f9fafb; /* gray-50 */
+    border-top-color: #e5e7eb; /* gray-200 */
+}
+
+body[data-theme='light'] .snm-dropdown-customise-link {
+    color: #9ca3af; /* gray-400 */
+}
+
+body[data-theme='light'] .snm-dropdown-customise-link:hover {
+    color: #2563eb; /* blue-600 */
+}
+
+body[data-theme='light'] .snm-dropdown-items::-webkit-scrollbar-thumb {
+    background-color: #d1d5db; /* gray-300 */
+}
+
+body[data-theme='light'] .snm-more-btn.is-open {
+    @apply bg-gray-200 text-gray-900 rounded;
+}
+
+/* Customiser panel – light theme */
 body[data-theme='light'] .snm-customizer-panel {
     @apply bg-white border-gray-200;
 }
@@ -357,27 +512,6 @@ body[data-theme='light'] .snm-drag-handle {
     @apply text-gray-400;
 }
 
-body[data-theme='light'] .snm-dropdown {
-    /* .next-dd-menu already handles dark bg; override for light theme */
-    @apply bg-white border-gray-200;
-}
-
-body[data-theme='light'] .snm-dropdown-header {
-    @apply border-gray-200;
-}
-
-body[data-theme='light'] .snm-dropdown-title {
-    @apply text-gray-500;
-}
-
-body[data-theme='light'] .snm-dropdown-footer {
-    @apply border-gray-200;
-}
-
-body[data-theme='light'] .snm-dropdown-customise-link {
-    @apply text-gray-500 hover:text-blue-600;
-}
-
 body[data-theme='light'] .snm-customizer-backdrop {
     background: rgba(0, 0, 0, 0.2);
 }
@@ -385,6 +519,19 @@ body[data-theme='light'] .snm-customizer-backdrop {
 /* ── Responsive / mobile ────────────────────────────────────────────────────── */
 
 @media (max-width: 768px) {
+    .snm-dropdown {
+        /* On mobile, pin to the top of the viewport edge-to-edge */
+        position: fixed !important;
+        top: 57px !important;
+        left: 0 !important;
+        right: 0 !important;
+        width: 100% !important;
+        max-width: 100% !important;
+        border-radius: 0;
+        border-left: none;
+        border-right: none;
+    }
+
     .snm-customizer-panel {
         top: 0;
         left: 0;

--- a/addon/styles/components/smart-nav-menu.css
+++ b/addon/styles/components/smart-nav-menu.css
@@ -1,0 +1,407 @@
+/* ============================================================================
+   Smart Nav Menu  –  Layout::Header::SmartNavMenu
+   ============================================================================
+   Styles for the overflow-aware, user-customisable extension navigation bar
+   that replaces the static `next-catalog-menu-items` container.
+
+   Class naming convention:  snm-*
+   All colours use Tailwind @apply where possible so they inherit the project's
+   design tokens and respond correctly to the dark-mode `data-theme` attribute.
+   ============================================================================ */
+
+/* ── Container ──────────────────────────────────────────────────────────────── */
+
+.snm-container {
+    @apply flex items-center overflow-hidden;
+    /* Allow the container to shrink when the header is narrow */
+    min-width: 0;
+    flex: 1 1 auto;
+}
+
+/* ── Bar items (inherit .next-view-header-item base styles) ─────────────────── */
+
+.snm-item {
+    /* Inherit all base styles from the existing header item class.
+       Additional overrides below. */
+    @apply flex-shrink-0;
+    max-width: 160px;
+}
+
+.snm-item span {
+    @apply truncate;
+}
+
+/* ── "More" overflow button ─────────────────────────────────────────────────── */
+
+.snm-more-wrapper {
+    @apply flex-shrink-0;
+    position: relative;
+}
+
+.snm-more-btn {
+    @apply flex items-center;
+    white-space: nowrap;
+}
+
+/* ── Customise (gear) button ────────────────────────────────────────────────── */
+
+.snm-customise-btn {
+    @apply flex items-center justify-center flex-shrink-0;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+}
+
+/* ── Overflow dropdown panel ────────────────────────────────────────────────── */
+
+.snm-dropdown {
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 0;
+    z-index: 600;
+    min-width: 220px;
+    max-width: 320px;
+    /* Inherits bg, border, shadow from .next-dd-menu */
+    padding: 0.375rem 0;
+}
+
+.snm-dropdown-header {
+    @apply flex items-center px-3 py-2 border-b border-gray-700;
+}
+
+.snm-dropdown-title {
+    @apply text-xs font-semibold uppercase tracking-wider text-gray-400;
+}
+
+.snm-dropdown-items {
+    @apply py-1;
+    max-height: calc(100vh - 130px);
+    overflow-y: auto;
+}
+
+.snm-dropdown-item {
+    @apply flex items-center px-3 py-1.5 text-sm;
+    /* Inherits hover/active from .next-dd-item */
+}
+
+.snm-dropdown-item-icon {
+    @apply flex-shrink-0 mr-2.5;
+    width: 1.25rem;
+    text-align: center;
+}
+
+.snm-dropdown-footer {
+    @apply flex items-center px-3 py-2 border-t border-gray-700 mt-1;
+}
+
+.snm-dropdown-customise-link {
+    @apply flex items-center text-xs text-gray-400 hover:text-blue-400 transition-colors duration-150;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+}
+
+/* ── Customiser panel ───────────────────────────────────────────────────────── */
+
+/* Semi-transparent backdrop */
+.snm-customizer-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 700;
+    background: rgba(0, 0, 0, 0.35);
+}
+
+/* The panel itself */
+.snm-customizer-panel {
+    @apply flex flex-col;
+    position: fixed;
+    top: 57px; /* height of .next-view-header */
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 710;
+    width: 680px;
+    max-width: calc(100vw - 2rem);
+    max-height: calc(100vh - 80px);
+    border-radius: 8px;
+    overflow: hidden;
+    @apply bg-gray-900 border border-gray-700 shadow-next-nav;
+}
+
+/* Header bar */
+.snm-customizer-header {
+    @apply flex items-center justify-between px-4 py-3 border-b border-gray-700 bg-gray-800 flex-shrink-0;
+}
+
+.snm-customizer-header-left {
+    @apply flex items-center;
+}
+
+.snm-customizer-title {
+    @apply text-sm font-semibold text-white m-0;
+}
+
+.snm-customizer-close {
+    @apply flex items-center justify-center w-7 h-7 rounded text-gray-400 hover:text-white hover:bg-gray-700 transition-colors duration-150;
+    background: none;
+    border: none;
+    cursor: pointer;
+}
+
+/* Body – two-column layout */
+.snm-customizer-body {
+    @apply flex flex-1 overflow-hidden;
+}
+
+.snm-customizer-col {
+    @apply flex flex-col overflow-hidden;
+    flex: 1 1 50%;
+}
+
+.snm-customizer-col-pinned {
+    @apply border-r border-gray-700;
+}
+
+.snm-customizer-col-header {
+    @apply flex items-center justify-between px-4 py-2.5 border-b border-gray-700 bg-gray-800 flex-shrink-0;
+}
+
+.snm-customizer-col-title {
+    @apply text-xs font-semibold uppercase tracking-wider text-gray-400 flex items-center;
+}
+
+.snm-customizer-col-badge {
+    @apply text-xs font-mono px-1.5 py-0.5 rounded bg-gray-700 text-gray-300;
+}
+
+.snm-customizer-col-badge.at-limit {
+    @apply bg-amber-600 text-white;
+}
+
+/* Drag-sort list */
+.snm-customizer-drag-list {
+    @apply flex-1 overflow-y-auto p-2;
+}
+
+.snm-customizer-pinned-item {
+    @apply flex items-center px-2 py-1.5 rounded-md mb-1 bg-gray-800 border border-gray-700 cursor-default;
+}
+
+.snm-customizer-pinned-item:hover {
+    @apply border-gray-600;
+}
+
+.snm-drag-handle {
+    @apply flex-shrink-0 mr-2 text-gray-500 cursor-grab;
+}
+
+.snm-drag-handle:active {
+    cursor: grabbing;
+}
+
+/* All-extensions list */
+.snm-customizer-all-list {
+    @apply flex-1 overflow-y-auto p-2;
+}
+
+.snm-customizer-all-item {
+    @apply flex items-center w-full px-2 py-1.5 rounded-md mb-1 text-sm text-gray-300 text-left;
+    @apply bg-transparent border border-transparent cursor-pointer;
+    @apply transition-colors duration-100;
+}
+
+.snm-customizer-all-item:hover:not(.is-disabled) {
+    @apply bg-gray-800 border-gray-700;
+}
+
+.snm-customizer-all-item.is-pinned {
+    @apply bg-blue-900 border-blue-700 text-white;
+}
+
+.snm-customizer-all-item.is-disabled {
+    @apply opacity-40 cursor-not-allowed;
+}
+
+.snm-customizer-pinned-check {
+    @apply text-blue-400;
+}
+
+/* Shared icon + title layout inside customiser items */
+.snm-customizer-item-icon {
+    @apply flex-shrink-0 mr-2.5;
+    width: 1.25rem;
+    text-align: center;
+}
+
+.snm-customizer-item-title {
+    @apply flex-1 truncate;
+}
+
+/* Unpin button */
+.snm-customizer-unpin-btn {
+    @apply flex-shrink-0 ml-auto flex items-center justify-center w-5 h-5 rounded text-gray-500 hover:text-red-400 hover:bg-gray-700 transition-colors duration-150;
+    background: none;
+    border: none;
+    cursor: pointer;
+}
+
+/* Empty state */
+.snm-customizer-empty-state {
+    @apply flex flex-col items-center justify-center flex-1 p-6 text-gray-500 text-sm text-center;
+}
+
+/* Divider between columns */
+.snm-customizer-divider {
+    /* handled by border-r on the left column */
+    display: none;
+}
+
+/* Footer */
+.snm-customizer-footer {
+    @apply flex items-center justify-between px-4 py-3 border-t border-gray-700 bg-gray-800 flex-shrink-0;
+}
+
+.snm-customizer-reset-btn {
+    @apply flex items-center text-xs text-gray-400 hover:text-gray-200 transition-colors duration-150;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+}
+
+.snm-customizer-footer-actions {
+    @apply flex items-center space-x-2;
+}
+
+/* Generic button helpers */
+.snm-btn {
+    @apply inline-flex items-center px-3 py-1.5 rounded text-sm font-medium transition-colors duration-150 cursor-pointer;
+    border: none;
+}
+
+.snm-btn-secondary {
+    @apply bg-gray-700 text-gray-200 hover:bg-gray-600;
+}
+
+.snm-btn-primary {
+    @apply bg-blue-600 text-white hover:bg-blue-500;
+}
+
+/* ── Light theme overrides ──────────────────────────────────────────────────── */
+
+body[data-theme='light'] .snm-customizer-panel {
+    @apply bg-white border-gray-200;
+}
+
+body[data-theme='light'] .snm-customizer-header {
+    @apply bg-gray-100 border-gray-200;
+}
+
+body[data-theme='light'] .snm-customizer-title {
+    @apply text-gray-900;
+}
+
+body[data-theme='light'] .snm-customizer-close {
+    @apply text-gray-500 hover:text-gray-900 hover:bg-gray-200;
+}
+
+body[data-theme='light'] .snm-customizer-col-header {
+    @apply bg-gray-50 border-gray-200;
+}
+
+body[data-theme='light'] .snm-customizer-col-title {
+    @apply text-gray-500;
+}
+
+body[data-theme='light'] .snm-customizer-col-badge {
+    @apply bg-gray-200 text-gray-700;
+}
+
+body[data-theme='light'] .snm-customizer-pinned-item {
+    @apply bg-gray-50 border-gray-200;
+}
+
+body[data-theme='light'] .snm-customizer-pinned-item:hover {
+    @apply border-gray-300;
+}
+
+body[data-theme='light'] .snm-customizer-all-item {
+    @apply text-gray-700;
+}
+
+body[data-theme='light'] .snm-customizer-all-item:hover:not(.is-disabled) {
+    @apply bg-gray-100 border-gray-200;
+}
+
+body[data-theme='light'] .snm-customizer-all-item.is-pinned {
+    @apply bg-blue-50 border-blue-300 text-blue-900;
+}
+
+body[data-theme='light'] .snm-customizer-footer {
+    @apply bg-gray-50 border-gray-200;
+}
+
+body[data-theme='light'] .snm-customizer-reset-btn {
+    @apply text-gray-500 hover:text-gray-800;
+}
+
+body[data-theme='light'] .snm-btn-secondary {
+    @apply bg-gray-200 text-gray-700 hover:bg-gray-300;
+}
+
+body[data-theme='light'] .snm-drag-handle {
+    @apply text-gray-400;
+}
+
+body[data-theme='light'] .snm-dropdown {
+    /* .next-dd-menu already handles dark bg; override for light theme */
+    @apply bg-white border-gray-200;
+}
+
+body[data-theme='light'] .snm-dropdown-header {
+    @apply border-gray-200;
+}
+
+body[data-theme='light'] .snm-dropdown-title {
+    @apply text-gray-500;
+}
+
+body[data-theme='light'] .snm-dropdown-footer {
+    @apply border-gray-200;
+}
+
+body[data-theme='light'] .snm-dropdown-customise-link {
+    @apply text-gray-500 hover:text-blue-600;
+}
+
+body[data-theme='light'] .snm-customizer-backdrop {
+    background: rgba(0, 0, 0, 0.2);
+}
+
+/* ── Responsive / mobile ────────────────────────────────────────────────────── */
+
+@media (max-width: 768px) {
+    .snm-customizer-panel {
+        top: 0;
+        left: 0;
+        right: 0;
+        transform: none;
+        width: 100%;
+        max-width: 100%;
+        max-height: 100vh;
+        border-radius: 0;
+    }
+
+    .snm-customizer-body {
+        @apply flex-col;
+    }
+
+    .snm-customizer-col-pinned {
+        @apply border-r-0 border-b border-gray-700;
+        max-height: 40vh;
+    }
+
+    .snm-customizer-col-all {
+        max-height: 40vh;
+    }
+}

--- a/addon/styles/components/smart-nav-menu.css
+++ b/addon/styles/components/smart-nav-menu.css
@@ -175,6 +175,70 @@
     line-height: 1.4;
 }
 
+/* ── Dropdown item row (wraps link + pin button) ─────────────────────────────
+   Each row is a flex container so the link takes all available space and
+   the pin button sits flush to the right edge without affecting link width. */
+
+.snm-dropdown-item-row {
+    @apply flex items-center;
+    position: relative;
+    margin-bottom: 2px;
+}
+
+.snm-dropdown-item-row .snm-dropdown-item {
+    margin-bottom: 0; /* row handles the margin */
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+/* The link wrapper is a transparent pass-through div — it captures the click
+   to close the dropdown but does NOT call preventDefault, so the router
+   transition fires normally. */
+.snm-dropdown-item-link-wrapper {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+}
+
+.snm-dropdown-item-link-wrapper .snm-dropdown-item {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: 100%;
+}
+
+/* ── Inline pin button ────────────────────────────────────────────────────────
+   Appears on the right of each dropdown item row when the bar has capacity.
+   Hidden by default; revealed on row hover so it stays out of the way. */
+
+.snm-dropdown-pin-btn {
+    @apply flex-shrink-0 flex items-center justify-center transition-all duration-150;
+    width: 24px;
+    height: 24px;
+    margin-left: 4px;
+    border-radius: 4px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    color: #4b5563; /* gray-600 – subtle until hovered */
+    opacity: 0;
+    pointer-events: none;
+}
+
+.snm-dropdown-item-row:hover .snm-dropdown-pin-btn {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.snm-dropdown-pin-btn:hover {
+    background-color: #374151; /* gray-700 */
+    color: #60a5fa; /* blue-400 */
+}
+
+.snm-dropdown-pin-btn:active {
+    background-color: #1d4ed8; /* blue-700 */
+    color: #fff;
+}
+
 /* ── Dropdown footer ────────────────────────────────────────────────────────── */
 
 .snm-dropdown-footer {
@@ -447,7 +511,17 @@ body[data-theme='light'] .snm-dropdown-customise-link:hover {
 body[data-theme='light'] .snm-dropdown-items::-webkit-scrollbar-thumb {
     background-color: #d1d5db; /* gray-300 */
 }
-
+body[data-theme='light'] .snm-dropdown-pin-btn {
+    color: #9ca3af; /* gray-400 */
+}
+body[data-theme='light'] .snm-dropdown-pin-btn:hover {
+    background-color: #f3f4f6; /* gray-100 */
+    color: #2563eb; /* blue-600 */
+}
+body[data-theme='light'] .snm-dropdown-pin-btn:active {
+    background-color: #dbeafe; /* blue-100 */
+    color: #1d4ed8; /* blue-700 */
+}
 body[data-theme='light'] .snm-more-btn.is-open {
     @apply bg-gray-200 text-gray-900 rounded;
 }

--- a/addon/styles/components/smart-nav-menu.css
+++ b/addon/styles/components/smart-nav-menu.css
@@ -259,44 +259,47 @@
     overflow: hidden;
 }
 
-/* ── Shortcuts list ─────────────────────────────────────────────────────────── */
-
-.snm-dropdown-shortcuts {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    margin-top: 4px;
-    border-top: 1px solid #1f2937; /* gray-800 – subtle divider */
-    padding-top: 4px;
+/* ── Shortcut sibling card (AWS-style flat item) ────────────────────────────── */
+/* Shortcut cards are visually lighter than primary extension cards */
+.snm-dropdown-card--shortcut {
+    background-color: #0f172a; /* slate-900 – slightly darker to distinguish */
+    border-color: #1e293b; /* slate-800 */
 }
 
-.snm-dropdown-shortcut-item {
-    display: block;
+.snm-dropdown-card--shortcut:hover {
+    border-color: #334155; /* slate-700 */
+    background-color: #1e293b;
 }
 
-.snm-dropdown-shortcut-link {
-    @apply flex items-center text-xs rounded;
-    padding: 3px 4px;
-    color: #9ca3af; /* gray-400 */
-    text-decoration: none;
-    transition: color 0.1s ease, background-color 0.1s ease;
+/* Shortcut cards use a smaller icon and muted link colour */
+.snm-dropdown-card--shortcut .snm-dropdown-card-icon {
+    color: #6b7280; /* gray-500 */
 }
 
-.snm-dropdown-shortcut-link:hover {
+.snm-dropdown-card--shortcut .snm-dropdown-card-link:hover .snm-dropdown-card-icon {
     color: #60a5fa; /* blue-400 */
-    background-color: #1f2937; /* gray-800 */
 }
 
-.snm-dropdown-shortcut-icon {
-    @apply flex-shrink-0;
-    width: 0.875rem;
-    margin-right: 5px;
-    text-align: center;
-    opacity: 0.7;
+.snm-dropdown-card--shortcut .snm-dropdown-card-title {
+    font-size: 0.75rem; /* 12px – slightly smaller than primary */
+    color: #9ca3af; /* gray-400 */
 }
 
-.snm-dropdown-shortcut-title {
-    @apply flex-1 truncate;
+.snm-dropdown-card--shortcut .snm-dropdown-card-link:hover .snm-dropdown-card-title {
+    color: #f9fafb; /* gray-50 */
+}
+
+/* No pin button on shortcut cards */
+.snm-dropdown-card--shortcut .snm-dropdown-pin-btn {
+    display: none;
+}
+
+/* Parent label shown beneath the shortcut title */
+.snm-dropdown-card-parent-label {
+    @apply text-xs truncate;
+    color: #4b5563; /* gray-600 */
+    margin: 2px 0 0 0;
+    padding-left: calc(1.125rem + 7px); /* align with card-title (icon width + margin) */
 }
 
 /* ── Empty state (no search results) ───────────────────────────────────────── */
@@ -816,17 +819,22 @@ body[data-theme='light'] .snm-dropdown-card-description {
     color: #9ca3af; /* gray-400 */
 }
 
-body[data-theme='light'] .snm-dropdown-shortcuts {
-    border-top-color: #e5e7eb; /* gray-200 */
+body[data-theme='light'] .snm-dropdown-card--shortcut {
+    background-color: #f8fafc; /* slate-50 */
+    border-color: #e2e8f0; /* slate-200 */
 }
 
-body[data-theme='light'] .snm-dropdown-shortcut-link {
+body[data-theme='light'] .snm-dropdown-card--shortcut:hover {
+    border-color: #cbd5e1; /* slate-300 */
+    background-color: #f1f5f9; /* slate-100 */
+}
+
+body[data-theme='light'] .snm-dropdown-card--shortcut .snm-dropdown-card-title {
     color: #6b7280; /* gray-500 */
 }
 
-body[data-theme='light'] .snm-dropdown-shortcut-link:hover {
-    color: #2563eb; /* blue-600 */
-    background-color: #f3f4f6; /* gray-100 */
+body[data-theme='light'] .snm-dropdown-card-parent-label {
+    color: #9ca3af; /* gray-400 */
 }
 
 body[data-theme='light'] .snm-dropdown-empty {

--- a/addon/styles/components/smart-nav-menu.css
+++ b/addon/styles/components/smart-nav-menu.css
@@ -100,8 +100,8 @@
     border: none;
     border-bottom: 1px solid #374151; /* gray-700 */
     border-radius: 0;
-    padding: 2px 4px;
-    gap: 6px;
+    padding: 0 4px 1px;
+    gap: 4px;
 }
 
 .snm-dropdown-search-icon {
@@ -111,8 +111,8 @@
 
 .snm-dropdown-search-input {
     @apply flex-1 outline-none;
-    font-size: 0.75rem; /* 12px – compact */
-    line-height: 1.4;
+    font-size: 0.6875rem; /* 11px – very compact */
+    line-height: 1.2;
     color: #e5e7eb; /* gray-200 */
     background: none !important;
     border: none !important;
@@ -324,10 +324,10 @@
 
 .snm-dropdown-header {
     @apply flex items-center flex-shrink-0;
-    padding: 8px 10px 8px 14px;
+    padding: 6px 8px 6px 12px;
     border-bottom: 1px solid #374151; /* gray-700 */
     background-color: #111827; /* gray-900 */
-    gap: 10px;
+    gap: 8px;
 }
 
 .snm-dropdown-title {

--- a/addon/styles/components/smart-nav-menu.css
+++ b/addon/styles/components/smart-nav-menu.css
@@ -257,17 +257,11 @@
     overflow: hidden;
 }
 
-/* ── Inline · From attribution on shortcut cards ────────────────────────── */
-/* Shown inline after the shortcut title: “Live Map · Fleet-Ops” */
-.snm-dropdown-card-from {
-    @apply flex-shrink-0 text-xs;
-    color: #4b5563; /* gray-600 */
-    margin-left: 5px;
-    white-space: nowrap;
-}
-
-.snm-dropdown-card-link:hover .snm-dropdown-card-from {
-    color: #6b7280; /* gray-500 – slightly brighter on hover */
+/* ── Italic “from Parent” attribution on shortcut cards ───────────────────── */
+/* Shown as a description-style line below the shortcut title */
+.snm-dropdown-card-description--from {
+    color: #4b5563; /* gray-600 – slightly more muted than regular description */
+    margin-bottom: 0;
 }
 
 /* ── Empty state (no search results) ───────────────────────────────────────── */
@@ -787,7 +781,7 @@ body[data-theme='light'] .snm-dropdown-card-description {
     color: #9ca3af; /* gray-400 */
 }
 
-body[data-theme='light'] .snm-dropdown-card-from {
+body[data-theme='light'] .snm-dropdown-card-description--from {
     color: #9ca3af; /* gray-400 */
 }
 

--- a/addon/styles/components/smart-nav-menu.css
+++ b/addon/styles/components/smart-nav-menu.css
@@ -95,11 +95,12 @@
     @apply flex items-center;
     flex: 1 1 auto;
     min-width: 0;
-    /* Pill-shaped container inside the header */
-    background-color: #1f2937; /* gray-800 – slightly lighter than header */
-    border: 1px solid #374151; /* gray-700 */
-    border-radius: 6px;
-    padding: 4px 8px;
+    /* Flat bottom-border underline style – no pill */
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid #374151; /* gray-700 */
+    border-radius: 0;
+    padding: 2px 4px;
     gap: 6px;
 }
 
@@ -145,7 +146,7 @@
 .snm-dropdown-grid {
     flex: 1 1 auto;
     overflow-y: auto;
-    padding: 12px;
+    padding: 8px 6px;
     display: grid;
     /* 2 equal columns */
     grid-template-columns: repeat(2, 1fr);
@@ -335,7 +336,8 @@
 }
 
 .snm-dropdown-close {
-    @apply flex items-center justify-center w-6 h-6 rounded transition-colors duration-150;
+    @apply flex-shrink-0 flex items-center justify-center w-6 h-6 rounded transition-colors duration-150;
+    margin-left: auto; /* push to far right of the header flex row */
     background: none;
     border: none;
     cursor: pointer;
@@ -751,8 +753,8 @@ body[data-theme='light'] .snm-dropdown-items::-webkit-scrollbar-thumb {
 
 /* Phase 2 – light theme: search bar */
 body[data-theme='light'] .snm-dropdown-search-bar {
-    background-color: #f3f4f6; /* gray-100 */
-    border-color: #d1d5db; /* gray-300 */
+    background: transparent;
+    border-bottom-color: #d1d5db; /* gray-300 */
 }
 
 body[data-theme='light'] .snm-dropdown-search-icon {

--- a/addon/styles/components/smart-nav-menu.css
+++ b/addon/styles/components/smart-nav-menu.css
@@ -92,16 +92,14 @@
 /* ── Search bar ─────────────────────────────────────────────────────────────── */
 
 .snm-dropdown-search-bar {
-    @apply flex items-center;
-    flex: 1 1 auto;
-    min-width: 0;
-    /* Flat bottom-border underline style – no pill */
+    @apply flex items-center flex-shrink-0;
+    /* Full-width row with a flat bottom border */
     background: transparent;
     border: none;
     border-bottom: 1px solid #374151; /* gray-700 */
     border-radius: 0;
-    padding: 0 4px 1px 10px;
-    gap: 4px;
+    padding: 6px 10px;
+    gap: 6px;
 }
 
 .snm-dropdown-search-icon {

--- a/addon/styles/components/smart-nav-menu.css
+++ b/addon/styles/components/smart-nav-menu.css
@@ -84,19 +84,23 @@
 
 /* Phase 2: wide multi-column variant ─────────────────────────────────────── */
 .snm-dropdown--wide {
-    /* Wide enough for 3 card columns + gutters */
-    width: 800px;
+    /* Wide enough for 2 card columns + gutters */
+    width: 680px;
     max-width: calc(100vw - 16px);
 }
 
 /* ── Search bar ─────────────────────────────────────────────────────────────── */
 
 .snm-dropdown-search-bar {
-    @apply flex items-center flex-shrink-0;
-    padding: 8px 12px;
-    border-bottom: 1px solid #374151; /* gray-700 */
-    background-color: #111827; /* gray-900 */
-    gap: 8px;
+    @apply flex items-center;
+    flex: 1 1 auto;
+    min-width: 0;
+    /* Pill-shaped container inside the header */
+    background-color: #1f2937; /* gray-800 – slightly lighter than header */
+    border: 1px solid #374151; /* gray-700 */
+    border-radius: 6px;
+    padding: 4px 8px;
+    gap: 6px;
 }
 
 .snm-dropdown-search-icon {
@@ -105,10 +109,17 @@
 }
 
 .snm-dropdown-search-input {
-    @apply flex-1 bg-transparent text-sm text-gray-100 outline-none;
-    border: none;
+    @apply flex-1 outline-none;
+    font-size: 0.75rem; /* 12px – compact */
+    line-height: 1.4;
+    color: #e5e7eb; /* gray-200 */
+    background: none !important;
+    border: none !important;
+    box-shadow: none !important;
     padding: 0;
     min-width: 0;
+    -webkit-appearance: none;
+    appearance: none;
 }
 
 .snm-dropdown-search-input::placeholder {
@@ -136,8 +147,8 @@
     overflow-y: auto;
     padding: 12px;
     display: grid;
-    /* 3 equal columns; fall back to 2 when the panel is narrower */
-    grid-template-columns: repeat(3, 1fr);
+    /* 2 equal columns */
+    grid-template-columns: repeat(2, 1fr);
     gap: 8px;
     align-content: start;
     scrollbar-width: thin;
@@ -223,15 +234,14 @@
     line-height: 1.4;
 }
 
-/* Pin button on card – hidden until card is hovered */
+/* Pin button on card – always visible at low opacity, brightens on hover */
 .snm-dropdown-card .snm-dropdown-pin-btn {
-    opacity: 0;
-    pointer-events: none;
+    opacity: 0.35;
+    pointer-events: auto;
 }
 
 .snm-dropdown-card:hover .snm-dropdown-pin-btn {
     opacity: 1;
-    pointer-events: auto;
 }
 
 /* ── Card description ───────────────────────────────────────────────────────── */
@@ -312,10 +322,11 @@
 /* ── Dropdown header ────────────────────────────────────────────────────────── */
 
 .snm-dropdown-header {
-    @apply flex items-center justify-between flex-shrink-0;
-    padding: 10px 14px 10px 14px;
+    @apply flex items-center flex-shrink-0;
+    padding: 8px 10px 8px 14px;
     border-bottom: 1px solid #374151; /* gray-700 */
     background-color: #111827; /* gray-900 */
+    gap: 10px;
 }
 
 .snm-dropdown-title {
@@ -740,8 +751,8 @@ body[data-theme='light'] .snm-dropdown-items::-webkit-scrollbar-thumb {
 
 /* Phase 2 – light theme: search bar */
 body[data-theme='light'] .snm-dropdown-search-bar {
-    background-color: #f9fafb; /* gray-50 */
-    border-bottom-color: #e5e7eb; /* gray-200 */
+    background-color: #f3f4f6; /* gray-100 */
+    border-color: #d1d5db; /* gray-300 */
 }
 
 body[data-theme='light'] .snm-dropdown-search-icon {
@@ -749,7 +760,10 @@ body[data-theme='light'] .snm-dropdown-search-icon {
 }
 
 body[data-theme='light'] .snm-dropdown-search-input {
-    color: #111827; /* gray-900 */
+    color: #374151; /* gray-700 */
+    background: none !important;
+    border: none !important;
+    box-shadow: none !important;
 }
 
 body[data-theme='light'] .snm-dropdown-search-input::placeholder {

--- a/addon/styles/components/smart-nav-menu.css
+++ b/addon/styles/components/smart-nav-menu.css
@@ -258,7 +258,12 @@
 }
 
 .snm-customizer-col-header {
-    @apply flex items-center justify-between px-4 py-2.5 border-b border-gray-700 bg-gray-800 flex-shrink-0;
+    @apply flex items-center justify-between px-4 border-b border-gray-700 bg-gray-800 flex-shrink-0;
+    /* Fixed height ensures both column headers are always the same size
+       regardless of whether the left column has a badge and the right does not. */
+    height: 40px;
+    min-height: 40px;
+    box-sizing: border-box;
 }
 
 .snm-customizer-col-title {

--- a/addon/styles/layout/next.css
+++ b/addon/styles/layout/next.css
@@ -1228,7 +1228,7 @@ body[data-theme='light']
 }
 
 .next-view-header .next-view-header-right {
-    flex: 1;
+    flex: 0 0 auto;
     display: flex;
     box-align: center;
     align-items: center;

--- a/app/components/layout/header/smart-nav-menu.js
+++ b/app/components/layout/header/smart-nav-menu.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/ember-ui/components/layout/header/smart-nav-menu';

--- a/app/components/layout/header/smart-nav-menu/customizer.js
+++ b/app/components/layout/header/smart-nav-menu/customizer.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/ember-ui/components/layout/header/smart-nav-menu/customizer';

--- a/app/components/layout/header/smart-nav-menu/dropdown.js
+++ b/app/components/layout/header/smart-nav-menu/dropdown.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/ember-ui/components/layout/header/smart-nav-menu/dropdown';

--- a/app/components/layout/header/smart-nav-menu/item.js
+++ b/app/components/layout/header/smart-nav-menu/item.js
@@ -1,0 +1,1 @@
+export { default } from '@fleetbase/ember-ui/components/layout/header/smart-nav-menu/item';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,10 +6,10 @@ settings:
 
 patchedDependencies:
   ember-gridstack@4.0.0:
-    hash: 7645d189e07b959521021078148e949087a85750095e8b5801d642c1eb63394f
+    hash: fwahdwiexnnbxgjkolq2q4epju
     path: patches/ember-gridstack@4.0.0.patch
   ember-leaflet@5.1.3:
-    hash: d6d0f5063ed21bb2e9c77217fbf9589696bed5db253fcd8b1251660740d12177
+    hash: trgxwa66vvs57bpftjxcvx5u3m
     path: patches/ember-leaflet@5.1.3.patch
 
 importers:
@@ -180,13 +180,13 @@ importers:
         version: 2.1.1
       ember-gridstack:
         specifier: 4.0.0
-        version: 4.0.0(patch_hash=7645d189e07b959521021078148e949087a85750095e8b5801d642c1eb63394f)(@babel/core@7.28.3)(ember-source@5.4.1(@babel/core@7.28.3)(@glimmer/component@1.1.2(@babel/core@7.28.3))(rsvp@4.8.5)(webpack@5.101.3))(webpack@5.101.3)
+        version: 4.0.0(patch_hash=fwahdwiexnnbxgjkolq2q4epju)(@babel/core@7.28.3)(ember-source@5.4.1(@babel/core@7.28.3)(@glimmer/component@1.1.2(@babel/core@7.28.3))(rsvp@4.8.5)(webpack@5.101.3))(webpack@5.101.3)
       ember-inflector:
         specifier: ^4.0.2
         version: 4.0.3(ember-source@5.4.1(@babel/core@7.28.3)(@glimmer/component@1.1.2(@babel/core@7.28.3))(rsvp@4.8.5)(webpack@5.101.3))
       ember-leaflet:
         specifier: ^5.1.3
-        version: 5.1.3(patch_hash=d6d0f5063ed21bb2e9c77217fbf9589696bed5db253fcd8b1251660740d12177)(@babel/core@7.28.3)(ember-source@5.4.1(@babel/core@7.28.3)(@glimmer/component@1.1.2(@babel/core@7.28.3))(rsvp@4.8.5)(webpack@5.101.3))(leaflet@1.9.4)(webpack@5.101.3)
+        version: 5.1.3(patch_hash=trgxwa66vvs57bpftjxcvx5u3m)(@babel/core@7.28.3)(ember-source@5.4.1(@babel/core@7.28.3)(@glimmer/component@1.1.2(@babel/core@7.28.3))(rsvp@4.8.5)(webpack@5.101.3))(leaflet@1.9.4)(webpack@5.101.3)
       ember-loading:
         specifier: ^2.0.0
         version: 2.0.0(@babel/core@7.28.3)
@@ -13590,7 +13590,7 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  ember-gridstack@4.0.0(patch_hash=7645d189e07b959521021078148e949087a85750095e8b5801d642c1eb63394f)(@babel/core@7.28.3)(ember-source@5.4.1(@babel/core@7.28.3)(@glimmer/component@1.1.2(@babel/core@7.28.3))(rsvp@4.8.5)(webpack@5.101.3))(webpack@5.101.3):
+  ember-gridstack@4.0.0(patch_hash=fwahdwiexnnbxgjkolq2q4epju)(@babel/core@7.28.3)(ember-source@5.4.1(@babel/core@7.28.3)(@glimmer/component@1.1.2(@babel/core@7.28.3))(rsvp@4.8.5)(webpack@5.101.3))(webpack@5.101.3):
     dependencies:
       '@ember/render-modifiers': 2.1.0(@babel/core@7.28.3)(ember-source@5.4.1(@babel/core@7.28.3)(@glimmer/component@1.1.2(@babel/core@7.28.3))(rsvp@4.8.5)(webpack@5.101.3))
       ember-auto-import: 2.10.0(webpack@5.101.3)
@@ -13621,7 +13621,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-leaflet@5.1.3(patch_hash=d6d0f5063ed21bb2e9c77217fbf9589696bed5db253fcd8b1251660740d12177)(@babel/core@7.28.3)(ember-source@5.4.1(@babel/core@7.28.3)(@glimmer/component@1.1.2(@babel/core@7.28.3))(rsvp@4.8.5)(webpack@5.101.3))(leaflet@1.9.4)(webpack@5.101.3):
+  ember-leaflet@5.1.3(patch_hash=trgxwa66vvs57bpftjxcvx5u3m)(@babel/core@7.28.3)(ember-source@5.4.1(@babel/core@7.28.3)(@glimmer/component@1.1.2(@babel/core@7.28.3))(rsvp@4.8.5)(webpack@5.101.3))(leaflet@1.9.4)(webpack@5.101.3):
     dependencies:
       '@glimmer/component': 1.1.2(@babel/core@7.28.3)
       '@glimmer/tracking': 1.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,10 +6,10 @@ settings:
 
 patchedDependencies:
   ember-gridstack@4.0.0:
-    hash: fwahdwiexnnbxgjkolq2q4epju
+    hash: 7645d189e07b959521021078148e949087a85750095e8b5801d642c1eb63394f
     path: patches/ember-gridstack@4.0.0.patch
   ember-leaflet@5.1.3:
-    hash: trgxwa66vvs57bpftjxcvx5u3m
+    hash: d6d0f5063ed21bb2e9c77217fbf9589696bed5db253fcd8b1251660740d12177
     path: patches/ember-leaflet@5.1.3.patch
 
 importers:
@@ -180,13 +180,13 @@ importers:
         version: 2.1.1
       ember-gridstack:
         specifier: 4.0.0
-        version: 4.0.0(patch_hash=fwahdwiexnnbxgjkolq2q4epju)(@babel/core@7.28.3)(ember-source@5.4.1(@babel/core@7.28.3)(@glimmer/component@1.1.2(@babel/core@7.28.3))(rsvp@4.8.5)(webpack@5.101.3))(webpack@5.101.3)
+        version: 4.0.0(patch_hash=7645d189e07b959521021078148e949087a85750095e8b5801d642c1eb63394f)(@babel/core@7.28.3)(ember-source@5.4.1(@babel/core@7.28.3)(@glimmer/component@1.1.2(@babel/core@7.28.3))(rsvp@4.8.5)(webpack@5.101.3))(webpack@5.101.3)
       ember-inflector:
         specifier: ^4.0.2
         version: 4.0.3(ember-source@5.4.1(@babel/core@7.28.3)(@glimmer/component@1.1.2(@babel/core@7.28.3))(rsvp@4.8.5)(webpack@5.101.3))
       ember-leaflet:
         specifier: ^5.1.3
-        version: 5.1.3(patch_hash=trgxwa66vvs57bpftjxcvx5u3m)(@babel/core@7.28.3)(ember-source@5.4.1(@babel/core@7.28.3)(@glimmer/component@1.1.2(@babel/core@7.28.3))(rsvp@4.8.5)(webpack@5.101.3))(leaflet@1.9.4)(webpack@5.101.3)
+        version: 5.1.3(patch_hash=d6d0f5063ed21bb2e9c77217fbf9589696bed5db253fcd8b1251660740d12177)(@babel/core@7.28.3)(ember-source@5.4.1(@babel/core@7.28.3)(@glimmer/component@1.1.2(@babel/core@7.28.3))(rsvp@4.8.5)(webpack@5.101.3))(leaflet@1.9.4)(webpack@5.101.3)
       ember-loading:
         specifier: ^2.0.0
         version: 2.0.0(@babel/core@7.28.3)
@@ -13590,7 +13590,7 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  ember-gridstack@4.0.0(patch_hash=fwahdwiexnnbxgjkolq2q4epju)(@babel/core@7.28.3)(ember-source@5.4.1(@babel/core@7.28.3)(@glimmer/component@1.1.2(@babel/core@7.28.3))(rsvp@4.8.5)(webpack@5.101.3))(webpack@5.101.3):
+  ember-gridstack@4.0.0(patch_hash=7645d189e07b959521021078148e949087a85750095e8b5801d642c1eb63394f)(@babel/core@7.28.3)(ember-source@5.4.1(@babel/core@7.28.3)(@glimmer/component@1.1.2(@babel/core@7.28.3))(rsvp@4.8.5)(webpack@5.101.3))(webpack@5.101.3):
     dependencies:
       '@ember/render-modifiers': 2.1.0(@babel/core@7.28.3)(ember-source@5.4.1(@babel/core@7.28.3)(@glimmer/component@1.1.2(@babel/core@7.28.3))(rsvp@4.8.5)(webpack@5.101.3))
       ember-auto-import: 2.10.0(webpack@5.101.3)
@@ -13621,7 +13621,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-leaflet@5.1.3(patch_hash=trgxwa66vvs57bpftjxcvx5u3m)(@babel/core@7.28.3)(ember-source@5.4.1(@babel/core@7.28.3)(@glimmer/component@1.1.2(@babel/core@7.28.3))(rsvp@4.8.5)(webpack@5.101.3))(leaflet@1.9.4)(webpack@5.101.3):
+  ember-leaflet@5.1.3(patch_hash=d6d0f5063ed21bb2e9c77217fbf9589696bed5db253fcd8b1251660740d12177)(@babel/core@7.28.3)(ember-source@5.4.1(@babel/core@7.28.3)(@glimmer/component@1.1.2(@babel/core@7.28.3))(rsvp@4.8.5)(webpack@5.101.3))(leaflet@1.9.4)(webpack@5.101.3):
     dependencies:
       '@glimmer/component': 1.1.2(@babel/core@7.28.3)
       '@glimmer/tracking': 1.1.2


### PR DESCRIPTION
## Summary

This PR introduces `<Layout::Header::SmartNavMenu />`, a smart, overflow-aware extension navigation component that replaces the static `next-catalog-menu-items` div inside `<Layout::Header />`.

The motivation is clear from the current state of the header: with Fleet-Ops, Ledger, Pallet, Storefront, Developers, IAM, and Extensions already installed, the navigation bar is at capacity. One additional extension will push the right-side controls (locale selector, notifications, chat, org/user menus) completely out of view.

---

## Problem

The existing implementation renders every registered extension as an inline `<LinkToExternal>` inside a flex container with no overflow handling. There is no cap, no collapse mechanism, and no way for users to choose which extensions they want visible.

---

## Solution

### Priority+ Overflow (automatic)

A `ResizeObserver` monitors the container width on every viewport resize. Items that exceed the available width — or that exceed the hard `@maxVisible` cap (default **5**) — are automatically moved into a **"More ▾"** dropdown. The "More" button only appears when there is actual overflow.

### User Customisation (AWS-console style)

A **⊞ gear button** opens a two-column customiser panel:

| Left column | Right column |
|---|---|
| **Pinned to bar** — current pinned items in drag-sortable order | **All extensions** — every available extension; click to toggle pin |
| Drag handles for reordering | Pinned items highlighted in blue |
| × button to unpin | Disabled when `@maxVisible` limit is reached |

The footer provides **Reset to default**, **Cancel**, and **Apply** actions.

Preferences (ordered pinned IDs) are persisted to `localStorage` via `currentUser.setOption` / `getOption`, scoped per user, and survive page refreshes.

---

## Component Architecture

```
Layout::Header::SmartNavMenu          ← container + ResizeObserver + preference management
  Layout::Header::SmartNavMenu::Item  ← single bar link (route or onClick handler)
  Layout::Header::SmartNavMenu::Dropdown  ← "More ▾" overflow panel
  Layout::Header::SmartNavMenu::Customizer ← two-column drag-sort preference panel
```

### New files

| File | Purpose |
|---|---|
| `addon/components/layout/header/smart-nav-menu.js` | Main component — ResizeObserver, preference load/save, item distribution |
| `addon/components/layout/header/smart-nav-menu.hbs` | Main template — bar items + More button + gear button + customiser |
| `addon/components/layout/header/smart-nav-menu/item.{js,hbs}` | Single bar item (route link or onClick) |
| `addon/components/layout/header/smart-nav-menu/dropdown.{js,hbs}` | Overflow "More" dropdown panel |
| `addon/components/layout/header/smart-nav-menu/customizer.{js,hbs}` | Two-column drag-sort customiser panel |
| `addon/styles/components/smart-nav-menu.css` | All `snm-*` scoped styles, light + dark theme, responsive |
| `app/components/layout/header/smart-nav-menu*.js` | App-level re-exports (4 files) |

### Modified files

| File | Change |
|---|---|
| `addon/components/layout/header.hbs` | Replace static `next-catalog-menu-items` div with `<Layout::Header::SmartNavMenu />` |
| `addon/components/layout/header.js` | Remove `menuItems` tracked property and `mergeMenuItems()` (now internal to SmartNavMenu) |
| `addon/styles/addon.css` | Add `@import 'components/smart-nav-menu.css'` |

---

## API / Usage

```hbs
{{! Default – cap of 5, auto overflow }}
<Layout::Header />

{{! Custom cap }}
<Layout::Header @maxVisibleNavItems={{7}} />

{{! Mutate items before render (same contract as before) }}
<Layout::Header @mutateMenuItems={{this.mutateMenuItems}} />
```

---

## Breaking Changes

- `<Layout::Header @menuItems={{...}} />` no longer controls the extension nav bar. Extension items are sourced exclusively from `universe.headerMenuItems` inside `SmartNavMenu`. The `@mutateMenuItems` callback is still forwarded.
- `this.menuItems` and `mergeMenuItems()` have been removed from `LayoutHeaderComponent`.

---

## Testing Checklist

- [ ] With ≤5 extensions: all items visible inline, no "More" button, gear icon present
- [ ] With >5 extensions: first 5 visible, "More ▾" button appears with remaining items
- [ ] Viewport resize causes items to move in/out of overflow correctly
- [ ] Customiser opens on gear click; drag-sort reorders pinned items
- [ ] Pinning/unpinning items in customiser updates the bar after Apply
- [ ] Reset to default restores first-N ordering
- [ ] Preferences persist across page refresh
- [ ] Light and dark themes render correctly
- [ ] Mobile viewport: SmartNavMenu is hidden (existing `{{#unless (media "isMobile")}}` guard)
