### PR TITLE
fix(smart-nav-menu/dropdown): fix shortcut duplication and full-card click area

### DIFF
--- a/addon/components/layout/header/smart-nav-menu/dropdown.hbs
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.hbs
@@ -17,10 +17,12 @@
       @atPinnedLimit    - Boolean: true when the bar is full (pin button hidden)
 
     Click-area pattern:
-      The card itself IS the <LinkToExternal> (or <a> for onClick items) so
-      the entire card surface is clickable.  The pin button sits inside the
-      card with `position: relative; z-index: 1` so it receives its own clicks
-      without being swallowed by the card link.
+      Each card is wrapped in a `snm-dropdown-card-wrap` div (position: relative).
+      The card itself is the <LinkToExternal> (or <a> for onClick items), making
+      the entire card surface clickable.  The pin button is a sibling of the card
+      inside the wrapper, absolutely positioned in the top-right corner so it
+      sits above the card link and receives its own clicks without violating the
+      no-nested-interactive rule.
 }}
 <div
     class="snm-dropdown snm-dropdown--wide"
@@ -79,88 +81,11 @@
         {{else}}
             {{#each this.filteredItems as |item|}}
                 {{#if item._isShortcut}}
-                    {{! ── Shortcut card — entire card is the link ─────────── }}
-                    <LinkToExternal
-                        @route={{item.route}}
-                        id={{concat (dasherize (or item.route item.id "sc")) "-dropdown-card"}}
-                        class="snm-dropdown-card"
-                        title={{item.title}}
-                    >
-                        <div class="snm-dropdown-card-header">
-                            <span class="snm-dropdown-card-icon">
-                                {{#if item.iconComponent}}
-                                    {{component (lazy-engine-component item.iconComponent) options=item.iconComponentOptions}}
-                                {{else}}
-                                    <FaIcon @icon={{or item.icon "circle-dot"}} @prefix={{item.iconPrefix}} @size="sm" />
-                                {{/if}}
-                            </span>
-                            <span class="snm-dropdown-card-title-group">
-                                <span class="snm-dropdown-card-title">{{item.title}}</span>
-                                {{#if item._parentTitle}}
-                                    <span class="snm-dropdown-card-parent-label" aria-label="from {{item._parentTitle}}">· {{item._parentTitle}}</span>
-                                {{/if}}
-                            </span>
-                            {{#unless @atPinnedLimit}}
-                                <button
-                                    type="button"
-                                    class="snm-dropdown-pin-btn"
-                                    title="Pin to navigation bar"
-                                    aria-label="Pin {{item.title}} to navigation bar"
-                                    {{on "click" (fn @onQuickPin item)}}
-                                >
-                                    <FaIcon @icon="thumbtack" @size="xs" />
-                                </button>
-                            {{/unless}}
-                        </div>
-                        {{#if item.description}}
-                            <p class="snm-dropdown-card-description">{{item.description}}</p>
-                        {{else if item._parentTitle}}
-                            <p class="snm-dropdown-card-description snm-dropdown-card-description--from"><em>from {{item._parentTitle}}</em></p>
-                        {{/if}}
-                    </LinkToExternal>
-                {{else}}
-                    {{! ── Primary extension card — entire card is the link ── }}
-                    {{#if item.onClick}}
-                        <a
-                            href="javascript:;"
-                            class="snm-dropdown-card"
-                            title={{item.title}}
-                            {{on "click" (fn this.handleItemClick item)}}
-                        >
-                            <div class="snm-dropdown-card-header">
-                                <span class="snm-dropdown-card-icon">
-                                    {{#if item.iconComponent}}
-                                        {{component (lazy-engine-component item.iconComponent) options=item.iconComponentOptions}}
-                                    {{else}}
-                                        <FaIcon @icon={{or item.icon "circle-dot"}} @prefix={{item.iconPrefix}} @size="sm" />
-                                    {{/if}}
-                                </span>
-                                <span class="snm-dropdown-card-title-group">
-                                    <span class="snm-dropdown-card-title">{{item.title}}</span>
-                                    {{#if item._parentTitle}}
-                                        <span class="snm-dropdown-card-parent-label" aria-label="from {{item._parentTitle}}">· {{item._parentTitle}}</span>
-                                    {{/if}}
-                                </span>
-                                {{#unless @atPinnedLimit}}
-                                    <button
-                                        type="button"
-                                        class="snm-dropdown-pin-btn"
-                                        title="Pin to navigation bar"
-                                        aria-label="Pin {{item.title}} to navigation bar"
-                                        {{on "click" (fn @onQuickPin item)}}
-                                    >
-                                        <FaIcon @icon="thumbtack" @size="xs" />
-                                    </button>
-                                {{/unless}}
-                            </div>
-                            {{#if item.description}}
-                                <p class="snm-dropdown-card-description">{{item.description}}</p>
-                            {{/if}}
-                        </a>
-                    {{else}}
+                    {{! ── Shortcut card ───────────────────────────────────── }}
+                    <div class="snm-dropdown-card-wrap">
                         <LinkToExternal
                             @route={{item.route}}
-                            id={{concat (dasherize (or item.route item.id "nav")) "-dropdown-card"}}
+                            id={{concat (dasherize (or item.route item.id "sc")) "-dropdown-card"}}
                             class="snm-dropdown-card"
                             title={{item.title}}
                         >
@@ -178,23 +103,93 @@
                                         <span class="snm-dropdown-card-parent-label" aria-label="from {{item._parentTitle}}">· {{item._parentTitle}}</span>
                                     {{/if}}
                                 </span>
-                                {{#unless @atPinnedLimit}}
-                                    <button
-                                        type="button"
-                                        class="snm-dropdown-pin-btn"
-                                        title="Pin to navigation bar"
-                                        aria-label="Pin {{item.title}} to navigation bar"
-                                        {{on "click" (fn @onQuickPin item)}}
-                                    >
-                                        <FaIcon @icon="thumbtack" @size="xs" />
-                                    </button>
-                                {{/unless}}
                             </div>
                             {{#if item.description}}
                                 <p class="snm-dropdown-card-description">{{item.description}}</p>
+                            {{else if item._parentTitle}}
+                                <p class="snm-dropdown-card-description snm-dropdown-card-description--from"><em>from {{item._parentTitle}}</em></p>
                             {{/if}}
                         </LinkToExternal>
-                    {{/if}}
+                        {{#unless @atPinnedLimit}}
+                            <button
+                                type="button"
+                                class="snm-dropdown-pin-btn"
+                                title="Pin to navigation bar"
+                                aria-label="Pin {{item.title}} to navigation bar"
+                                {{on "click" (fn @onQuickPin item)}}
+                            >
+                                <FaIcon @icon="thumbtack" @size="xs" />
+                            </button>
+                        {{/unless}}
+                    </div>
+                {{else}}
+                    {{! ── Primary extension card ──────────────────────────── }}
+                    <div class="snm-dropdown-card-wrap">
+                        {{#if item.onClick}}
+                            <a
+                                href="javascript:;"
+                                class="snm-dropdown-card"
+                                title={{item.title}}
+                                {{on "click" (fn this.handleItemClick item)}}
+                            >
+                                <div class="snm-dropdown-card-header">
+                                    <span class="snm-dropdown-card-icon">
+                                        {{#if item.iconComponent}}
+                                            {{component (lazy-engine-component item.iconComponent) options=item.iconComponentOptions}}
+                                        {{else}}
+                                            <FaIcon @icon={{or item.icon "circle-dot"}} @prefix={{item.iconPrefix}} @size="sm" />
+                                        {{/if}}
+                                    </span>
+                                    <span class="snm-dropdown-card-title-group">
+                                        <span class="snm-dropdown-card-title">{{item.title}}</span>
+                                        {{#if item._parentTitle}}
+                                            <span class="snm-dropdown-card-parent-label" aria-label="from {{item._parentTitle}}">· {{item._parentTitle}}</span>
+                                        {{/if}}
+                                    </span>
+                                </div>
+                                {{#if item.description}}
+                                    <p class="snm-dropdown-card-description">{{item.description}}</p>
+                                {{/if}}
+                            </a>
+                        {{else}}
+                            <LinkToExternal
+                                @route={{item.route}}
+                                id={{concat (dasherize (or item.route item.id "nav")) "-dropdown-card"}}
+                                class="snm-dropdown-card"
+                                title={{item.title}}
+                            >
+                                <div class="snm-dropdown-card-header">
+                                    <span class="snm-dropdown-card-icon">
+                                        {{#if item.iconComponent}}
+                                            {{component (lazy-engine-component item.iconComponent) options=item.iconComponentOptions}}
+                                        {{else}}
+                                            <FaIcon @icon={{or item.icon "circle-dot"}} @prefix={{item.iconPrefix}} @size="sm" />
+                                        {{/if}}
+                                    </span>
+                                    <span class="snm-dropdown-card-title-group">
+                                        <span class="snm-dropdown-card-title">{{item.title}}</span>
+                                        {{#if item._parentTitle}}
+                                            <span class="snm-dropdown-card-parent-label" aria-label="from {{item._parentTitle}}">· {{item._parentTitle}}</span>
+                                        {{/if}}
+                                    </span>
+                                </div>
+                                {{#if item.description}}
+                                    <p class="snm-dropdown-card-description">{{item.description}}</p>
+                                {{/if}}
+                            </LinkToExternal>
+                        {{/if}}
+                        {{#unless @atPinnedLimit}}
+                            <button
+                                type="button"
+                                class="snm-dropdown-pin-btn"
+                                title="Pin to navigation bar"
+                                aria-label="Pin {{item.title}} to navigation bar"
+                                {{on "click" (fn @onQuickPin item)}}
+                            >
+                                <FaIcon @icon="thumbtack" @size="xs" />
+                            </button>
+                        {{/unless}}
+                    </div>
                 {{/if}}
             {{/each}}
         {{/if}}

--- a/addon/components/layout/header/smart-nav-menu/dropdown.hbs
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.hbs
@@ -2,9 +2,10 @@
     Layout::Header::SmartNavMenu::Dropdown
     Phase 2: multi-column card grid with search filter.
 
-    Shortcuts are expanded as independent sibling items in the grid (AWS-style).
-    The JS getter `expandedItems` interleaves parent MenuItems and their
-    shortcut objects so each appears as its own flat card.
+    Shortcuts are already registered as first-class items in the universe
+    registry by menu-service.registerHeaderMenuItem(), so @items already
+    contains both parent extension items and their shortcut siblings.
+    No client-side expansion is needed.
 
     Args:
       @items            - Array of MenuItem objects to display
@@ -15,9 +16,11 @@
       @onQuickPin       - Action to pin an item directly from the dropdown
       @atPinnedLimit    - Boolean: true when the bar is full (pin button hidden)
 
-    NOTE: Route-based cards use <LinkToExternal> with no click handler.
-    The dropdown is closed via the routeDidChange listener in smart-nav-menu.js
-    which sets isMoreOpen = false on every route transition.
+    Click-area pattern:
+      The card itself IS the <LinkToExternal> (or <a> for onClick items) so
+      the entire card surface is clickable.  The pin button sits inside the
+      card with `position: relative; z-index: 1` so it receives its own clicks
+      without being swallowed by the card link.
 }}
 <div
     class="snm-dropdown snm-dropdown--wide"
@@ -38,7 +41,7 @@
         </button>
     </div>
 
-    {{! ── Search bar (own row) ────────────────────────────────────────────── }}
+    {{! ── Search bar ──────────────────────────────────────────────────────── }}
     <div class="snm-dropdown-search-bar">
         <span class="snm-dropdown-search-icon" aria-hidden="true">
             <FaIcon @icon="magnifying-glass" @size="xs" />
@@ -76,30 +79,27 @@
         {{else}}
             {{#each this.filteredItems as |item|}}
                 {{#if item._isShortcut}}
-                    {{! ── Shortcut sibling card (AWS-style flat item) ─────── }}
-                    <div class="snm-dropdown-card" role="presentation">
+                    {{! ── Shortcut card — entire card is the link ─────────── }}
+                    <LinkToExternal
+                        @route={{item.route}}
+                        id={{concat (dasherize (or item.route item.id "sc")) "-dropdown-card"}}
+                        class="snm-dropdown-card"
+                        title={{item.title}}
+                    >
                         <div class="snm-dropdown-card-header">
-                            <LinkToExternal
-                                @route={{item.route}}
-                                id={{concat (dasherize (or item.route item.id "sc")) "-dropdown-card"}}
-                                class="snm-dropdown-card-link"
-                                title={{item.title}}
-                            >
-                                <span class="snm-dropdown-card-icon">
-                                    {{#if item.iconComponent}}
-                                        {{component (lazy-engine-component item.iconComponent) options=item.iconComponentOptions}}
-                                    {{else}}
-                                        <FaIcon @icon={{or item.icon "circle-dot"}} @prefix={{item.iconPrefix}} @size="sm" />
-                                    {{/if}}
-                                </span>
-                                {{! Title row: shortcut name + always-visible muted parent attribution }}
-                                <span class="snm-dropdown-card-title-group">
-                                    <span class="snm-dropdown-card-title">{{item.title}}</span>
-                                    {{#if item._parentTitle}}
-                                        <span class="snm-dropdown-card-parent-label" aria-label="from {{item._parentTitle}}">· {{item._parentTitle}}</span>
-                                    {{/if}}
-                                </span>
-                            </LinkToExternal>
+                            <span class="snm-dropdown-card-icon">
+                                {{#if item.iconComponent}}
+                                    {{component (lazy-engine-component item.iconComponent) options=item.iconComponentOptions}}
+                                {{else}}
+                                    <FaIcon @icon={{or item.icon "circle-dot"}} @prefix={{item.iconPrefix}} @size="sm" />
+                                {{/if}}
+                            </span>
+                            <span class="snm-dropdown-card-title-group">
+                                <span class="snm-dropdown-card-title">{{item.title}}</span>
+                                {{#if item._parentTitle}}
+                                    <span class="snm-dropdown-card-parent-label" aria-label="from {{item._parentTitle}}">· {{item._parentTitle}}</span>
+                                {{/if}}
+                            </span>
                             {{#unless @atPinnedLimit}}
                                 <button
                                     type="button"
@@ -117,70 +117,84 @@
                         {{else if item._parentTitle}}
                             <p class="snm-dropdown-card-description snm-dropdown-card-description--from"><em>from {{item._parentTitle}}</em></p>
                         {{/if}}
-                    </div>
+                    </LinkToExternal>
                 {{else}}
-                    {{! ── Primary extension card ──────────────────────────── }}
-                    <div class="snm-dropdown-card" role="presentation">
-                        <div class="snm-dropdown-card-header">
-                            {{#if item.onClick}}
-                                <a
-                                    href="javascript:;"
-                                    class="snm-dropdown-card-link"
-                                    title={{item.title}}
-                                    {{on "click" (fn this.handleItemClick item)}}
-                                >
-                                    <span class="snm-dropdown-card-icon">
-                                        {{#if item.iconComponent}}
-                                            {{component (lazy-engine-component item.iconComponent) options=item.iconComponentOptions}}
-                                        {{else}}
-                                            <FaIcon @icon={{or item.icon "circle-dot"}} @prefix={{item.iconPrefix}} @size="sm" />
-                                        {{/if}}
-                                    </span>
-                                    <span class="snm-dropdown-card-title-group">
-                                        <span class="snm-dropdown-card-title">{{item.title}}</span>
-                                        {{#if item._parentTitle}}
-                                            <span class="snm-dropdown-card-parent-label" aria-label="from {{item._parentTitle}}">· {{item._parentTitle}}</span>
-                                        {{/if}}
-                                    </span>
-                                </a>
-                            {{else}}
-                                <LinkToExternal
-                                    @route={{item.route}}
-                                    id={{concat (dasherize (or item.route item.id "nav")) "-dropdown-card"}}
-                                    class="snm-dropdown-card-link"
-                                    title={{item.title}}
-                                >
-                                    <span class="snm-dropdown-card-icon">
-                                        {{#if item.iconComponent}}
-                                            {{component (lazy-engine-component item.iconComponent) options=item.iconComponentOptions}}
-                                        {{else}}
-                                            <FaIcon @icon={{or item.icon "circle-dot"}} @prefix={{item.iconPrefix}} @size="sm" />
-                                        {{/if}}
-                                    </span>
-                                    <span class="snm-dropdown-card-title-group">
-                                        <span class="snm-dropdown-card-title">{{item.title}}</span>
-                                        {{#if item._parentTitle}}
-                                            <span class="snm-dropdown-card-parent-label" aria-label="from {{item._parentTitle}}">· {{item._parentTitle}}</span>
-                                        {{/if}}
-                                    </span>
-                                </LinkToExternal>
+                    {{! ── Primary extension card — entire card is the link ── }}
+                    {{#if item.onClick}}
+                        <a
+                            href="javascript:;"
+                            class="snm-dropdown-card"
+                            title={{item.title}}
+                            {{on "click" (fn this.handleItemClick item)}}
+                        >
+                            <div class="snm-dropdown-card-header">
+                                <span class="snm-dropdown-card-icon">
+                                    {{#if item.iconComponent}}
+                                        {{component (lazy-engine-component item.iconComponent) options=item.iconComponentOptions}}
+                                    {{else}}
+                                        <FaIcon @icon={{or item.icon "circle-dot"}} @prefix={{item.iconPrefix}} @size="sm" />
+                                    {{/if}}
+                                </span>
+                                <span class="snm-dropdown-card-title-group">
+                                    <span class="snm-dropdown-card-title">{{item.title}}</span>
+                                    {{#if item._parentTitle}}
+                                        <span class="snm-dropdown-card-parent-label" aria-label="from {{item._parentTitle}}">· {{item._parentTitle}}</span>
+                                    {{/if}}
+                                </span>
+                                {{#unless @atPinnedLimit}}
+                                    <button
+                                        type="button"
+                                        class="snm-dropdown-pin-btn"
+                                        title="Pin to navigation bar"
+                                        aria-label="Pin {{item.title}} to navigation bar"
+                                        {{on "click" (fn @onQuickPin item)}}
+                                    >
+                                        <FaIcon @icon="thumbtack" @size="xs" />
+                                    </button>
+                                {{/unless}}
+                            </div>
+                            {{#if item.description}}
+                                <p class="snm-dropdown-card-description">{{item.description}}</p>
                             {{/if}}
-                            {{#unless @atPinnedLimit}}
-                                <button
-                                    type="button"
-                                    class="snm-dropdown-pin-btn"
-                                    title="Pin to navigation bar"
-                                    aria-label="Pin {{item.title}} to navigation bar"
-                                    {{on "click" (fn @onQuickPin item)}}
-                                >
-                                    <FaIcon @icon="thumbtack" @size="xs" />
-                                </button>
-                            {{/unless}}
-                        </div>
-                        {{#if item.description}}
-                            <p class="snm-dropdown-card-description">{{item.description}}</p>
-                        {{/if}}
-                    </div>
+                        </a>
+                    {{else}}
+                        <LinkToExternal
+                            @route={{item.route}}
+                            id={{concat (dasherize (or item.route item.id "nav")) "-dropdown-card"}}
+                            class="snm-dropdown-card"
+                            title={{item.title}}
+                        >
+                            <div class="snm-dropdown-card-header">
+                                <span class="snm-dropdown-card-icon">
+                                    {{#if item.iconComponent}}
+                                        {{component (lazy-engine-component item.iconComponent) options=item.iconComponentOptions}}
+                                    {{else}}
+                                        <FaIcon @icon={{or item.icon "circle-dot"}} @prefix={{item.iconPrefix}} @size="sm" />
+                                    {{/if}}
+                                </span>
+                                <span class="snm-dropdown-card-title-group">
+                                    <span class="snm-dropdown-card-title">{{item.title}}</span>
+                                    {{#if item._parentTitle}}
+                                        <span class="snm-dropdown-card-parent-label" aria-label="from {{item._parentTitle}}">· {{item._parentTitle}}</span>
+                                    {{/if}}
+                                </span>
+                                {{#unless @atPinnedLimit}}
+                                    <button
+                                        type="button"
+                                        class="snm-dropdown-pin-btn"
+                                        title="Pin to navigation bar"
+                                        aria-label="Pin {{item.title}} to navigation bar"
+                                        {{on "click" (fn @onQuickPin item)}}
+                                    >
+                                        <FaIcon @icon="thumbtack" @size="xs" />
+                                    </button>
+                                {{/unless}}
+                            </div>
+                            {{#if item.description}}
+                                <p class="snm-dropdown-card-description">{{item.description}}</p>
+                            {{/if}}
+                        </LinkToExternal>
+                    {{/if}}
                 {{/if}}
             {{/each}}
         {{/if}}

--- a/addon/components/layout/header/smart-nav-menu/dropdown.js
+++ b/addon/components/layout/header/smart-nav-menu/dropdown.js
@@ -1,7 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
-import { dasherize } from '@ember/string';
 import { isArray } from '@ember/array';
 import { htmlSafe } from '@ember/template';
 
@@ -25,62 +24,16 @@ export default class LayoutHeaderSmartNavMenuDropdownComponent extends Component
     }
 
     /**
-     * Expand every MenuItem's shortcuts array into sibling flat items.
-     * The resulting array interleaves parent items and their shortcuts in
-     * registration order, matching the AWS Console pattern.
+     * Returns the items array as-is for filtering.
      *
-     * Each shortcut is normalised to:
-     *   { title, route, icon, iconPrefix, id, _isShortcut: true, _parentTitle }
+     * Shortcuts are already registered as first-class items in the universe
+     * registry (with `_isShortcut: true` and `_parentTitle` set) by
+     * `menu-service.registerHeaderMenuItem()` at boot time.  There is no need
+     * to expand `item.shortcuts` here — doing so would produce a duplicate card
+     * for every shortcut (one from the registry, one from the expansion).
      */
     get expandedItems() {
-        const items = this.args.items ?? [];
-        const result = [];
-        for (const item of items) {
-            result.push(item);
-            if (isArray(item.shortcuts)) {
-                for (const sc of item.shortcuts) {
-                    const scId = sc.id ?? dasherize(item.id + '-sc-' + sc.title);
-                    result.push({
-                        // ── Identity ────────────────────────────────────────
-                        id: scId,
-                        slug: sc.slug ?? scId,
-                        title: sc.title,
-                        text: sc.text ?? sc.title,
-                        label: sc.label ?? sc.title,
-
-                        // ── Routing ──────────────────────────────────────────
-                        route: sc.route ?? item.route,
-                        queryParams: sc.queryParams ?? {},
-                        routeParams: sc.routeParams ?? [],
-
-                        // ── Icons (full surface) ─────────────────────────────
-                        icon: sc.icon ?? item.icon ?? 'arrow-right',
-                        iconPrefix: sc.iconPrefix ?? item.iconPrefix ?? null,
-                        iconSize: sc.iconSize ?? null,
-                        iconClass: sc.iconClass ?? null,
-                        iconComponent: sc.iconComponent ?? null,
-                        iconComponentOptions: sc.iconComponentOptions ?? {},
-
-                        // ── Metadata ─────────────────────────────────────────
-                        description: sc.description ?? null,
-                        tags: isArray(sc.tags) ? sc.tags : isArray(item.tags) ? item.tags : null,
-
-                        // ── Behaviour ────────────────────────────────────────
-                        onClick: sc.onClick ?? null,
-                        disabled: sc.disabled ?? false,
-
-                        // ── Styling ───────────────────────────────────────────
-                        class: sc.class ?? null,
-
-                        // ── Internal flags ────────────────────────────────────
-                        _isShortcut: true,
-                        _parentTitle: item.title,
-                        _parentId: item.id,
-                    });
-                }
-            }
-        }
-        return result;
+        return this.args.items ?? [];
     }
 
     get filteredItems() {

--- a/addon/styles/components/smart-nav-menu.css
+++ b/addon/styles/components/smart-nav-menu.css
@@ -183,36 +183,26 @@
     background-color: #1a2332; /* slightly lighter than gray-900 */
 }
 
-/* Card header row: icon + title link + pin button */
+/* Card header row: icon + title + pin button */
 .snm-dropdown-card-header {
     @apply flex items-center;
     gap: 0;
     margin-bottom: 0;
 }
 
-/* The main extension link inside a card */
-.snm-dropdown-card-link {
-    @apply flex items-center flex-1 text-sm font-medium;
-    color: #e5e7eb; /* gray-200 */
+/* Pin button must sit above the card link and receive its own clicks */
+.snm-dropdown-pin-btn {
+    position: relative;
+    z-index: 1;
+}
+
+/* Card-as-link: the card itself is the <LinkToExternal> or <a> */
+a.snm-dropdown-card,
+.snm-dropdown-card[href] {
+    display: flex;
     text-decoration: none;
-    min-width: 0;
+    color: inherit;
     cursor: pointer;
-    border: none;
-    background: none;
-    padding: 0;
-}
-
-.snm-dropdown-card-link:hover {
-    color: #f9fafb; /* gray-50 */
-}
-
-.snm-dropdown-card-link-wrapper {
-    @apply flex flex-1;
-    min-width: 0;
-}
-
-.snm-dropdown-card-link-wrapper .snm-dropdown-card-link {
-    width: 100%;
 }
 
 .snm-dropdown-card-icon {
@@ -787,11 +777,13 @@ body[data-theme='light'] .snm-dropdown-card:hover {
     background-color: #f3f4f6; /* gray-100 */
 }
 
-body[data-theme='light'] .snm-dropdown-card-link {
+body[data-theme='light'] a.snm-dropdown-card,
+body[data-theme='light'] .snm-dropdown-card[href] {
     color: #374151; /* gray-700 */
 }
 
-body[data-theme='light'] .snm-dropdown-card-link:hover {
+body[data-theme='light'] a.snm-dropdown-card:hover,
+body[data-theme='light'] .snm-dropdown-card[href]:hover {
     color: #111827; /* gray-900 */
 }
 
@@ -799,7 +791,8 @@ body[data-theme='light'] .snm-dropdown-card-icon {
     color: #6b7280; /* gray-500 */
 }
 
-body[data-theme='light'] .snm-dropdown-card-link:hover .snm-dropdown-card-icon {
+body[data-theme='light'] a.snm-dropdown-card:hover .snm-dropdown-card-icon,
+body[data-theme='light'] .snm-dropdown-card[href]:hover .snm-dropdown-card-icon {
     color: #2563eb; /* blue-600 */
 }
 

--- a/addon/styles/components/smart-nav-menu.css
+++ b/addon/styles/components/smart-nav-menu.css
@@ -169,13 +169,22 @@
 
 /* ── Extension card ─────────────────────────────────────────────────────────── */
 
+/* Wrapper that holds the card link + absolutely-positioned pin button */
+.snm-dropdown-card-wrap {
+    position: relative;
+}
+
 .snm-dropdown-card {
     @apply flex flex-col rounded-lg;
     padding: 7px 10px;
     background-color: #111827; /* gray-900 */
     border: 1px solid #1f2937; /* gray-800 – darker but lighter than bg */
     transition: border-color 0.15s ease, background-color 0.15s ease;
-    position: relative;
+    text-decoration: none;
+    color: inherit;
+    display: flex;
+    width: 100%;
+    box-sizing: border-box;
 }
 
 .snm-dropdown-card:hover {
@@ -190,9 +199,12 @@
     margin-bottom: 0;
 }
 
-/* Pin button must sit above the card link and receive its own clicks */
+/* Pin button is a sibling of the card link, absolutely positioned top-right
+   so it floats above the card and receives its own clicks */
 .snm-dropdown-pin-btn {
-    position: relative;
+    position: absolute;
+    top: 6px;
+    right: 6px;
     z-index: 1;
 }
 
@@ -240,12 +252,13 @@ a.snm-dropdown-card,
 }
 
 /* Pin button on card – always visible at low opacity, brightens on hover */
-.snm-dropdown-card .snm-dropdown-pin-btn {
-    opacity: 0.35;
+.snm-dropdown-card-wrap .snm-dropdown-pin-btn {
+    opacity: 0;
     pointer-events: auto;
+    transition: opacity 0.15s ease;
 }
 
-.snm-dropdown-card:hover .snm-dropdown-pin-btn {
+.snm-dropdown-card-wrap:hover .snm-dropdown-pin-btn {
     opacity: 1;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fleetbase/ember-ui",
-    "version": "0.3.22",
+    "version": "0.3.23",
     "description": "Fleetbase UI provides all the interface components, helpers, services and utilities for building a Fleetbase extension into the Console.",
     "keywords": [
         "fleetbase-ui",


### PR DESCRIPTION
## Bug Fixes

### Bug 1 — Shortcut duplication

Shortcuts are registered as first-class items in the universe registry by `menu-service.registerHeaderMenuItem()` at boot time (with `_isShortcut: true` and `_parentTitle` set). The `expandedItems` getter was *also* iterating over `item.shortcuts` and pushing synthetic copies, producing a duplicate card for every shortcut.

**Fix:** `expandedItems` now simply returns `this.args.items` as-is — no client-side expansion is needed. The unused `dasherize` import is also removed.

### Bug 2 — Only card title triggering navigation

The `<LinkToExternal>` previously only wrapped the header row (icon + title), so clicking the description area did nothing.

**Fix:** The card element itself is now the `<LinkToExternal>` (or `<a>` for `onClick` items), making the entire card surface clickable. The pin button sits inside the card with `position: relative; z-index: 1` so it still receives its own click events independently.