### PR TITLE
fix(smart-nav-menu): use parent extension id for shortcut permission check

### DIFF
--- a/addon/components/layout/header/smart-nav-menu.js
+++ b/addon/components/layout/header/smart-nav-menu.js
@@ -161,8 +161,14 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
         const raw = this.universe.headerMenuItems ?? [];
         const visible = [];
         for (const item of raw) {
+            // Shortcuts are not standalone extensions — they should be visible
+            // if and only if their parent extension is visible.  Use _parentId
+            // for the ability check so the shortcut inherits the parent's
+            // permission rather than being checked against its own (non-existent)
+            // extension ability, which would always throw and default to visible.
+            const abilityId = item._isShortcut && item._parentId ? item._parentId : item.id;
             try {
-                if (this.abilities.can(`${item.id} see extension`)) {
+                if (this.abilities.can(`${abilityId} see extension`)) {
                     visible.push(item);
                 }
             } catch (_) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fleetbase/ember-ui",
-    "version": "0.3.24",
+    "version": "0.3.25",
     "description": "Fleetbase UI provides all the interface components, helpers, services and utilities for building a Fleetbase extension into the Console.",
     "keywords": [
         "fleetbase-ui",


### PR DESCRIPTION
## Problem

Shortcuts registered via `registerHeaderMenuItem()` are stored as first-class items in the universe registry with `_isShortcut: true` and `_parentId` pointing to the parent extension.

The `allItems` getter in `smart-nav-menu.js` was running the ability check against the shortcut's own `id` (e.g. `ledger-sc-transactions see extension`), which has no registered ability. This caused every shortcut to always fall through to the `catch` block and be unconditionally included — regardless of whether the user actually has permission to see the parent extension.

## Fix

When an item is a shortcut (`_isShortcut && _parentId`), use `_parentId` as the ability subject instead of `item.id`:

```js
const abilityId = item._isShortcut && item._parentId ? item._parentId : item.id;
if (this.abilities.can(`${abilityId} see extension`)) { ... }
```

This means a shortcut is visible **if and only if its parent extension is visible**, which is the correct behaviour. If the parent extension has no registered ability (catch block), the shortcut is also included by default — consistent with how parent extensions are handled.