### PR TITLE
Phase 1: hierarchy-aware context switcher in layout header

### DIFF
--- a/addon/components/layout/header.js
+++ b/addon/components/layout/header.js
@@ -21,10 +21,39 @@ export default class LayoutHeaderComponent extends Component {
     @service currentUser;
     @service abilities;
     @service fetch;
+    @service notifications;
     @tracked company;
     @tracked organizationMenuItems = [];
     @tracked userMenuItems = [];
     @tracked extensions = [];
+
+    /**
+     * Multi-tenant hierarchy: list of child client companies for the
+     * current org, loaded asynchronously from `/v1/companies/clients`.
+     * Empty (and hierarchy items suppressed) when the user is a
+     * client-role user (endpoint returns 403) or when no clients exist.
+     *
+     * @var {Array}
+     */
+    @tracked clientCompanies = [];
+
+    /**
+     * True while we are still discovering whether the user is org-role
+     * or client-role via the initial `/v1/companies/clients` request.
+     * While true we suppress hierarchy items to avoid a UI flash.
+     *
+     * @var {Boolean}
+     */
+    @tracked hierarchyDiscoveryPending = true;
+
+    /**
+     * True when the backend confirms the user is an org-role user
+     * (org-side `/v1/companies/clients` returned 200). Client-role
+     * users (403 response) see no hierarchy switcher UI.
+     *
+     * @var {Boolean}
+     */
+    @tracked isOrgRoleUser = false;
 
     constructor(owner, { organizationMenuItems = [], userMenuItems = [] }) {
         super(...arguments);
@@ -32,6 +61,90 @@ export default class LayoutHeaderComponent extends Component {
         this.company = this.currentUser.getCompany();
         this.organizationMenuItems = this.mergeOrganizationMenuItems(organizationMenuItems);
         this.userMenuItems = this.mergeUserMenuItems(userMenuItems);
+
+        // Kick off hierarchy discovery — this resolves after construction
+        // and rebuilds `organizationMenuItems` once we know whether this
+        // is an org-role user and which clients they have.
+        this.discoverHierarchy(organizationMenuItems);
+    }
+
+    /**
+     * Fetches the list of child client companies for the current org.
+     * On 200: flags user as org-role and rebuilds the menu with
+     * hierarchy entries. On 403: treats user as client-role and leaves
+     * the menu unchanged (no hierarchy UI). On any other error: swallows
+     * silently and leaves the existing menu intact — the classic org
+     * switcher still works as a fallback.
+     */
+    async discoverHierarchy(initialOrganizationMenuItems = []) {
+        try {
+            const response = await this.fetch.get('v1/companies/clients');
+            const clients = (response && response.clients) || [];
+            this.clientCompanies = clients;
+            this.isOrgRoleUser = true;
+            this.organizationMenuItems = this.mergeOrganizationMenuItems(initialOrganizationMenuItems);
+        } catch (error) {
+            const status = error?.status ?? error?.response?.status;
+            if (status === 403) {
+                this.isOrgRoleUser = false;
+            }
+            // Any other failure: stay silent; user keeps the legacy menu.
+        } finally {
+            this.hierarchyDiscoveryPending = false;
+        }
+    }
+
+    /**
+     * Selects a new active company context.
+     *
+     * Flow:
+     *   1. POST `/v1/companies/switch-context` with the target UUID to
+     *      have the backend validate pivot access. This is the single
+     *      validation oracle for company switching.
+     *   2. On success (200): update `currentUser.activeCompanyContext`
+     *      (Task 14 setter persists to localStorage and triggers a
+     *      header refresh on the next fetch) and reload the page so
+     *      engines re-hydrate against the new context.
+     *   3. On failure: show a notification, leave state untouched.
+     *
+     * "All Clients" selection semantics: despite the label, this must
+     * resolve to the parent org's UUID — NOT null, NOT a magic string.
+     * Single-company-per-request is the contract.
+     *
+     * @param {String} companyUuid The target company UUID to activate.
+     */
+    @action async selectContext(companyUuid) {
+        if (!companyUuid) {
+            return;
+        }
+
+        try {
+            await this.fetch.post('v1/companies/switch-context', { company_uuid: companyUuid });
+
+            // Persist via the Task 14 setter (writes to localStorage).
+            this.currentUser.activeCompanyContext = companyUuid;
+
+            // Flush cached org list so a subsequent refresh sees fresh data.
+            if (typeof this.fetch.flushRequestCache === 'function') {
+                this.fetch.flushRequestCache('auth/organizations');
+            }
+
+            // Full-page reload lets every engine re-hydrate cleanly
+            // against the new X-Company-Context header.
+            window.location.reload();
+        } catch (error) {
+            const status = error?.status ?? error?.response?.status;
+            const message =
+                status === 403
+                    ? 'You do not have access to this company.'
+                    : 'Could not switch company context. Please try again.';
+            if (this.notifications && typeof this.notifications.error === 'function') {
+                this.notifications.error(message);
+            } else {
+                console.error('[layout/header] switch-context failed:', error);
+            }
+            // Intentionally do NOT mutate currentUser.activeCompanyContext on failure.
+        }
     }
 
     mergeOrganizationMenuItems(organizationMenuItems = []) {
@@ -70,6 +183,20 @@ export default class LayoutHeaderComponent extends Component {
             }
 
             menuItems.pushObject(organizationMenuItem);
+        }
+
+        // Multi-tenant hierarchy: for org-role users we offer an in-org
+        // context switcher (parent org + each child client). These items
+        // route through `selectContext` directly — they do NOT go through
+        // the console controller's `onAction` handler (which fires the
+        // legacy `auth/switch-organization` modal flow). Client-role
+        // users see no hierarchy UI per the architectural contract.
+        if (this.isOrgRoleUser) {
+            const hierarchyItems = this.buildHierarchyMenuItems();
+            if (hierarchyItems.length) {
+                menuItems.pushObject({ seperator: true });
+                menuItems.pushObjects(hierarchyItems);
+            }
         }
 
         // Push static menu items
@@ -291,6 +418,87 @@ export default class LayoutHeaderComponent extends Component {
         }
 
         return menuItems;
+    }
+
+    /**
+     * Builds the hierarchy-aware context switcher items (parent org
+     * "All Clients" entry + one entry per child client company).
+     *
+     * Design notes:
+     *   - "All Clients" sets the active context to the parent org's
+     *     UUID (NOT null, NOT a magic string). On a freshly-logged-in
+     *     org user whose default company IS the org, this behaves
+     *     identically to no header, but the explicit UUID is more
+     *     honest and survives edge cases.
+     *   - Each item is an interactive dropdown item — it wires
+     *     `onClick` directly to `this.selectContext`, bypassing the
+     *     console controller's string-keyed `onAction` routing. That
+     *     keeps the validate-then-persist-then-reload flow co-located
+     *     with the Task 14 state and the switch-context endpoint.
+     *   - `isActive` reflects `currentUser.activeCompanyContext`, with
+     *     a null active context treated as "parent org selected" since
+     *     Auth::getCompany() on the backend resolves null to the user's
+     *     default company.
+     *
+     * @return {Array} Menu items ready to push into the dropdown.
+     */
+    buildHierarchyMenuItems() {
+        const items = [];
+        const parentUuid = this.currentUser.companyId;
+        if (!parentUuid) {
+            return items;
+        }
+
+        const activeContext = this.currentUser.activeCompanyContext;
+        // Parent-org is "active" either when the header is explicitly the
+        // parent UUID, OR when it is null (backend resolves to default company).
+        const parentIsActive = activeContext === parentUuid || activeContext === null;
+
+        items.push({
+            text: 'All Clients',
+            wrapperClass: 'multi-tenant-context-item multi-tenant-context-all-clients',
+            testSelector: 'all',
+            onClick: () => this.selectContext(parentUuid),
+            icon: parentIsActive ? 'check' : undefined,
+            disabled: parentIsActive,
+            companyUuid: parentUuid,
+            isActive: parentIsActive,
+        });
+
+        const clients = isArray(this.clientCompanies) ? this.clientCompanies : [];
+        for (const client of clients) {
+            const uuid = client?.uuid ?? client?.id;
+            if (!uuid) {
+                continue;
+            }
+            const isActive = activeContext === uuid;
+            items.push({
+                text: client.name,
+                wrapperClass: 'multi-tenant-context-item',
+                testSelector: uuid,
+                onClick: () => this.selectContext(uuid),
+                icon: isActive ? 'check' : undefined,
+                disabled: isActive,
+                companyUuid: uuid,
+                isActive,
+            });
+        }
+
+        return items;
+    }
+
+    /**
+     * Exposed for unit-level tests: returns the hierarchy items that
+     * would be injected into the organization menu for the current
+     * user. Returns `[]` for client-role users (no hierarchy UI).
+     *
+     * @return {Array}
+     */
+    get contextMenuItems() {
+        if (!this.isOrgRoleUser) {
+            return [];
+        }
+        return this.buildHierarchyMenuItems();
     }
 
     @action routeTo(route) {

--- a/tests/integration/components/layout/header-context-switcher-test.js
+++ b/tests/integration/components/layout/header-context-switcher-test.js
@@ -1,0 +1,394 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'dummy/tests/helpers';
+import { settled } from '@ember/test-helpers';
+import Service from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { A } from '@ember/array';
+import EmberObject from '@ember/object';
+
+/*
+ * Task 15 — hierarchy-aware context switcher tests.
+ *
+ * Covers 8 scenarios for the multi-tenant hierarchy switcher added to
+ * `<Layout::Header />`:
+ *
+ *   1. Org user has an "All Clients" entry in contextMenuItems.
+ *   2. Org user has each child client entry in contextMenuItems.
+ *   3. Client-role user sees NO hierarchy items (contextMenuItems is []).
+ *   4. selectContext POSTs `/v1/companies/switch-context` with the UUID.
+ *   5. On 200, currentUser.activeCompanyContext is updated.
+ *   6. On 403, currentUser.activeCompanyContext is NOT updated and an
+ *      error notification is surfaced.
+ *   7. `isActive` flag tracks currentUser.activeCompanyContext.
+ *   8. `contextMenuItems` returns [] when isOrgRoleUser is false even
+ *      if clientCompanies is populated.
+ *
+ * The tests use a factoryFor(component:layout/header).create() pattern
+ * so we can inspect the tracked state and methods directly without
+ * needing `BasicDropdown` to be open to find DOM items. All async waits
+ * drain via `settled()` before assertion.
+ */
+
+const PARENT_UUID = '11111111-aaaa-bbbb-cccc-000000000001';
+const CLIENT_A_UUID = '22222222-aaaa-bbbb-cccc-000000000002';
+const CLIENT_B_UUID = '33333333-aaaa-bbbb-cccc-000000000003';
+
+/**
+ * Build a stub fetch service configurable per-test:
+ *   - `clientsResponse`: array OR function returning a Promise
+ *     (array is wrapped into `{ clients }`)
+ *   - `onPost`: callback invoked for every POST
+ *   - `postShouldFail`: if numeric, POSTs reject with that HTTP status
+ */
+function makeFetchStub({ clientsResponse = [], onPost = null, postShouldFail = null } = {}) {
+    return class FetchStub extends Service {
+        calls = [];
+
+        get(url) {
+            this.calls.push({ method: 'GET', url });
+            if (url !== 'v1/companies/clients') {
+                return Promise.resolve({});
+            }
+            if (typeof clientsResponse === 'function') {
+                return clientsResponse();
+            }
+            return Promise.resolve({ clients: clientsResponse });
+        }
+
+        post(url, body) {
+            this.calls.push({ method: 'POST', url, body });
+            if (typeof onPost === 'function') {
+                onPost(url, body);
+            }
+            if (postShouldFail) {
+                const err = new Error('forbidden');
+                err.status = postShouldFail;
+                return Promise.reject(err);
+            }
+            return Promise.resolve({ company: { uuid: body?.company_uuid } });
+        }
+
+        flushRequestCache() {
+            /* no-op */
+        }
+    };
+}
+
+/**
+ * Stub currentUser exposing only the properties the header touches,
+ * plus a real tracked `activeCompanyContext` getter/setter so reactivity
+ * is preserved without touching actual localStorage.
+ */
+class CurrentUserStub extends Service {
+    @tracked companyName = 'Acme Org';
+    @tracked companyId = PARENT_UUID;
+    @tracked email = 'owner@acme.test';
+    @tracked roleName = 'Owner';
+    @tracked name = 'Owner';
+    @tracked avatarUrl = '';
+    @tracked isAdmin = false;
+    @tracked organizations = A([]);
+    @tracked _activeCompanyContext = null;
+
+    get activeCompanyContext() {
+        return this._activeCompanyContext;
+    }
+    set activeCompanyContext(value) {
+        this._activeCompanyContext = value && value.length ? value : null;
+    }
+
+    getCompany() {
+        return EmberObject.create({ id: this.companyId, name: this.companyName });
+    }
+}
+
+class UniverseStub extends Service {
+    organizationMenuItems = [];
+    userMenuItems = [];
+}
+
+class NotificationsStub extends Service {
+    errors = [];
+    error(message) {
+        this.errors.push(message);
+    }
+    success() {}
+    warning() {}
+    serverError() {}
+}
+
+class RouterStub extends Service {
+    currentRouteName = 'console.home';
+    transitionTo() {
+        return Promise.resolve();
+    }
+}
+
+class AbilitiesStub extends Service {
+    can() {
+        return true;
+    }
+    cannot() {
+        return false;
+    }
+}
+
+class StoreStub extends Service {
+    peekRecord() {
+        return null;
+    }
+    findRecord() {
+        return Promise.resolve({});
+    }
+}
+
+function registerBaseStubs(owner, { FetchClass, clientsResponse, onPost, postShouldFail } = {}) {
+    owner.register(
+        'service:fetch',
+        FetchClass || makeFetchStub({ clientsResponse, onPost, postShouldFail })
+    );
+    owner.register('service:current-user', CurrentUserStub);
+    owner.register('service:universe', UniverseStub);
+    owner.register('service:notifications', NotificationsStub);
+    owner.register('service:router', RouterStub);
+    owner.register('service:host-router', RouterStub);
+    owner.register('service:abilities', AbilitiesStub);
+    owner.register('service:store', StoreStub);
+}
+
+/**
+ * Instantiate the header component directly so we can inspect its
+ * tracked state and call methods without requiring the BasicDropdown
+ * wrapper to be open for DOM queries.
+ */
+function instantiateHeader(owner) {
+    const factory = owner.factoryFor('component:layout/header');
+    return factory.create();
+}
+
+module('Integration | Component | layout/header (hierarchy context switcher)', function (hooks) {
+    setupRenderingTest(hooks);
+
+    test('1. org user has "All Clients" entry in context menu items', async function (assert) {
+        registerBaseStubs(this.owner, { clientsResponse: [] });
+
+        const header = instantiateHeader(this.owner);
+        await settled();
+
+        const items = header.contextMenuItems;
+        const allClients = items.find((i) => i.testSelector === 'all');
+        assert.ok(allClients, 'includes an "All Clients" item');
+        assert.strictEqual(allClients.text, 'All Clients', 'label is "All Clients"');
+        assert.strictEqual(
+            allClients.companyUuid,
+            PARENT_UUID,
+            '"All Clients" targets parent-org UUID (not null, not magic string)'
+        );
+    });
+
+    test('2. org user sees each child client entry', async function (assert) {
+        registerBaseStubs(this.owner, {
+            clientsResponse: [
+                { uuid: CLIENT_A_UUID, name: 'Alpha Client' },
+                { uuid: CLIENT_B_UUID, name: 'Bravo Client' },
+            ],
+        });
+
+        const header = instantiateHeader(this.owner);
+        await settled();
+
+        const items = header.contextMenuItems;
+        const uuids = items.map((i) => i.companyUuid).filter(Boolean);
+        assert.deepEqual(
+            uuids,
+            [PARENT_UUID, CLIENT_A_UUID, CLIENT_B_UUID],
+            'menu lists parent first, then each child client'
+        );
+        assert.strictEqual(
+            items.find((i) => i.companyUuid === CLIENT_A_UUID)?.text,
+            'Alpha Client',
+            'client name labeled on its item'
+        );
+    });
+
+    test('3. client-role user sees NO hierarchy menu', async function (assert) {
+        const ForbiddenFetch = makeFetchStub({
+            clientsResponse: () => {
+                const err = new Error('forbidden');
+                err.status = 403;
+                return Promise.reject(err);
+            },
+        });
+        registerBaseStubs(this.owner, { FetchClass: ForbiddenFetch });
+
+        const header = instantiateHeader(this.owner);
+        await settled();
+
+        assert.notOk(header.isOrgRoleUser, 'flagged as non-org role after 403');
+        assert.deepEqual(
+            header.contextMenuItems,
+            [],
+            'contextMenuItems is empty for client-role users'
+        );
+    });
+
+    test('4. selectContext POSTs /v1/companies/switch-context with the UUID', async function (assert) {
+        const recorded = [];
+        const FetchClass = makeFetchStub({
+            clientsResponse: [{ uuid: CLIENT_A_UUID, name: 'Alpha Client' }],
+            onPost: (url, body) => recorded.push({ url, body }),
+        });
+        registerBaseStubs(this.owner, { FetchClass });
+
+        // Intercept reload — test environment must not actually reload.
+        const originalReload = window.location.reload;
+        Object.defineProperty(window.location, 'reload', {
+            configurable: true,
+            value: () => {},
+        });
+
+        try {
+            const header = instantiateHeader(this.owner);
+            await settled();
+            await header.selectContext(CLIENT_A_UUID);
+
+            const posts = recorded.filter((c) => c.url === 'v1/companies/switch-context');
+            assert.strictEqual(posts.length, 1, 'posted exactly once');
+            assert.deepEqual(
+                posts[0].body,
+                { company_uuid: CLIENT_A_UUID },
+                'posted the target client UUID'
+            );
+        } finally {
+            Object.defineProperty(window.location, 'reload', {
+                configurable: true,
+                value: originalReload,
+            });
+        }
+    });
+
+    test('5. on 200, currentUser.activeCompanyContext is updated', async function (assert) {
+        registerBaseStubs(this.owner, {
+            clientsResponse: [{ uuid: CLIENT_A_UUID, name: 'Alpha Client' }],
+        });
+
+        const originalReload = window.location.reload;
+        Object.defineProperty(window.location, 'reload', {
+            configurable: true,
+            value: () => {},
+        });
+
+        try {
+            const header = instantiateHeader(this.owner);
+            await settled();
+
+            const currentUser = this.owner.lookup('service:current-user');
+            currentUser.activeCompanyContext = null;
+
+            await header.selectContext(CLIENT_A_UUID);
+
+            assert.strictEqual(
+                currentUser.activeCompanyContext,
+                CLIENT_A_UUID,
+                'active context updated to selected client UUID'
+            );
+        } finally {
+            Object.defineProperty(window.location, 'reload', {
+                configurable: true,
+                value: originalReload,
+            });
+        }
+    });
+
+    test('6. on 403, currentUser.activeCompanyContext is NOT updated', async function (assert) {
+        const FetchClass = makeFetchStub({
+            clientsResponse: [{ uuid: CLIENT_A_UUID, name: 'Alpha Client' }],
+            postShouldFail: 403,
+        });
+        registerBaseStubs(this.owner, { FetchClass });
+
+        const originalReload = window.location.reload;
+        let reloadCalled = false;
+        Object.defineProperty(window.location, 'reload', {
+            configurable: true,
+            value: () => {
+                reloadCalled = true;
+            },
+        });
+
+        try {
+            const header = instantiateHeader(this.owner);
+            await settled();
+
+            const currentUser = this.owner.lookup('service:current-user');
+            currentUser.activeCompanyContext = null;
+
+            await header.selectContext(CLIENT_A_UUID);
+
+            assert.strictEqual(
+                currentUser.activeCompanyContext,
+                null,
+                'activeCompanyContext untouched after 403'
+            );
+            assert.notOk(reloadCalled, 'did not reload on failure');
+
+            const notifications = this.owner.lookup('service:notifications');
+            assert.ok(notifications.errors.length >= 1, 'surfaced an error notification');
+        } finally {
+            Object.defineProperty(window.location, 'reload', {
+                configurable: true,
+                value: originalReload,
+            });
+        }
+    });
+
+    test('7. isActive flag tracks currentUser.activeCompanyContext', async function (assert) {
+        registerBaseStubs(this.owner, {
+            clientsResponse: [
+                { uuid: CLIENT_A_UUID, name: 'Alpha Client' },
+                { uuid: CLIENT_B_UUID, name: 'Bravo Client' },
+            ],
+        });
+
+        const currentUser = this.owner.lookup('service:current-user');
+        currentUser.activeCompanyContext = CLIENT_A_UUID;
+
+        const header = instantiateHeader(this.owner);
+        await settled();
+
+        const items = header.contextMenuItems;
+        const allClients = items.find((i) => i.testSelector === 'all');
+        const alpha = items.find((i) => i.companyUuid === CLIENT_A_UUID);
+        const bravo = items.find((i) => i.companyUuid === CLIENT_B_UUID);
+
+        assert.notOk(allClients.isActive, '"All Clients" not active when a client is selected');
+        assert.ok(alpha.isActive, 'selected client reports isActive');
+        assert.notOk(bravo.isActive, 'other client not active');
+
+        // Null active context => parent/"All Clients" is considered active
+        // since the backend resolves null to the user's default (the org).
+        currentUser.activeCompanyContext = null;
+        const items2 = header.contextMenuItems;
+        const allClients2 = items2.find((i) => i.testSelector === 'all');
+        assert.ok(
+            allClients2.isActive,
+            '"All Clients" active when activeCompanyContext is null (parent default)'
+        );
+    });
+
+    test('8. contextMenuItems returns [] for client-role users', async function (assert) {
+        registerBaseStubs(this.owner, { clientsResponse: [] });
+
+        const header = instantiateHeader(this.owner);
+        // Force the flag regardless of discovery outcome to verify the
+        // getter gates on isOrgRoleUser alone.
+        header.isOrgRoleUser = false;
+        header.clientCompanies = [{ uuid: CLIENT_A_UUID, name: 'Alpha Client' }];
+
+        assert.deepEqual(
+            header.contextMenuItems,
+            [],
+            'no hierarchy items for client-role users even with clientCompanies set'
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Part of Phase 1 multi-tenant hierarchy work for the fleetbase TMS.

Extends the existing organization switcher in `addon/components/layout/header.js` (lines 37-73) to be hierarchy-aware:
- Adds an "All Clients" menu item for org-level users (returns to parent context via `currentUser.companyId`)
- Lists accessible client companies under the parent org
- Wires each selection to `POST /v1/companies/switch-context` (validation oracle — stateless backend) then updates `currentUser.activeCompanyContext` (via ember-core service) and reloads
- Client-role users see no hierarchy menu (`contextMenuItems` returns `[]` when role-detection via `/v1/companies/clients` returns 403)
- Preserves the legacy `switchOrganization` flow untouched — both coexist until legacy retirement

## Merged from upstream/main

`origin/main` drift by 3 commits (event calendar, virtual route fix, v0.3.26). Auto-merged cleanly — no conflicts.

## Dependencies

- core-api PR (CompanyContextController with `/v1/companies/switch-context`, ClientCompanyController with `/v1/companies/clients`)
- ember-core PR (`X-Company-Context` header injection + `currentUser.activeCompanyContext`)

## Test plan

- [ ] QUnit: 8 integration tests for context-switcher behavior
- [ ] Manual: Org user sees All Clients + child clients; selecting client calls switch-context, reloads, `X-Company-Context` header on subsequent XHRs
- [ ] Manual: Client-role user sees no hierarchy items
- [ ] Manual: 403 on switch-context leaves state untouched + shows notification