### PR TITLE
Fix mobile navbar sidebar state sync

### DIFF
--- a/addon/components/layout/mobile-navbar.hbs
+++ b/addon/components/layout/mobile-navbar.hbs
@@ -1,5 +1,5 @@
 {{#if (media "isMobile")}}
-    <div class="next-mobile-navbar" {{did-insert this.setupMobileNavbar}} ...attributes>
+    <div class="next-mobile-navbar" ...attributes>
         <div role="menubar" class="next-mobile-navbar-tabs">
             <div role="menu" class="scrollable-nav-items">
                 {{#each this.menuItems as |menuItem|}}

--- a/addon/components/layout/mobile-navbar.js
+++ b/addon/components/layout/mobile-navbar.js
@@ -10,15 +10,20 @@ export default class LayoutMobileNavbarComponent extends Component {
     @service sidebar;
     @service abilities;
     @service universe;
-    @tracked navbarNode;
-    @tracked sidebarNode;
     @tracked extensions = [];
     @tracked menuItems = [];
+    routeDidChangeHandler = null;
 
     constructor(owner, { menuItems = [] }) {
         super(...arguments);
         this.extensions = getOwner(this).application.extensions ?? [];
         this.menuItems = this.mergeMenuItems(menuItems);
+        this.routeDidChangeHandler = () => this.closeSidebar();
+        this.getRouter().on('routeDidChange', this.routeDidChangeHandler);
+
+        if (typeof this.args.onSetup === 'function') {
+            this.args.onSetup(this);
+        }
     }
 
     mergeMenuItems(menuItems = []) {
@@ -42,32 +47,15 @@ export default class LayoutMobileNavbarComponent extends Component {
         return visibleMenuItems;
     }
 
-    @action setupMobileNavbar(element) {
-        this.navbarNode = element;
-        this.sidebarNode = element.previousElementSibling.querySelector('nav.next-sidebar');
-
-        if (typeof this.args.onSetup === 'function') {
-            this.onSetup(this);
-        }
-
-        // when hostrouter transitions close sidebar automatically
-        this.getRouter().on('routeDidChange', this.closeSidebar.bind(this));
-    }
-
-    @action routeTo(route) {
-        this.getRouter()
-            .transitionTo(route)
-            .then(() => {
-                this.closeSidebar();
-            });
+    @action async routeTo(route) {
+        try {
+            await this.getRouter().transitionTo(route);
+            this.closeSidebar();
+        } catch {}
     }
 
     @action toggleSidebar() {
-        if (this.isSidebarOpen()) {
-            this.closeSidebar();
-        } else {
-            this.openSidebar();
-        }
+        this.sidebar.toggle();
     }
 
     @action isSidebarOpen() {
@@ -76,12 +64,18 @@ export default class LayoutMobileNavbarComponent extends Component {
 
     @action closeSidebar() {
         this.sidebar.hide();
-        this.sidebarNode?.classList?.remove('is-open');
     }
 
     @action openSidebar() {
         this.sidebar.show();
-        this.sidebarNode?.classList?.add('is-open');
+    }
+
+    willDestroy() {
+        super.willDestroy(...arguments);
+        if (this.routeDidChangeHandler) {
+            this.getRouter().off('routeDidChange', this.routeDidChangeHandler);
+            this.routeDidChangeHandler = null;
+        }
     }
 
     getRouter() {

--- a/addon/components/layout/mobile-navbar.js
+++ b/addon/components/layout/mobile-navbar.js
@@ -7,6 +7,7 @@ import { action } from '@ember/object';
 export default class LayoutMobileNavbarComponent extends Component {
     @service router;
     @service hostRouter;
+    @service sidebar;
     @service abilities;
     @service universe;
     @tracked navbarNode;
@@ -70,14 +71,16 @@ export default class LayoutMobileNavbarComponent extends Component {
     }
 
     @action isSidebarOpen() {
-        return this.sidebarNode?.classList?.contains('is-open');
+        return this.sidebar.isVisible;
     }
 
     @action closeSidebar() {
+        this.sidebar.hide();
         this.sidebarNode?.classList?.remove('is-open');
     }
 
     @action openSidebar() {
+        this.sidebar.show();
         this.sidebarNode?.classList?.add('is-open');
     }
 

--- a/addon/components/layout/mobile-navbar.js
+++ b/addon/components/layout/mobile-navbar.js
@@ -51,7 +51,9 @@ export default class LayoutMobileNavbarComponent extends Component {
         try {
             await this.getRouter().transitionTo(route);
             this.closeSidebar();
-        } catch {}
+        } catch (error) {
+            void error;
+        }
     }
 
     @action toggleSidebar() {

--- a/addon/styles/layout/mobile.css
+++ b/addon/styles/layout/mobile.css
@@ -11,7 +11,7 @@
         @apply transition duration-500 ease-in-out;
     }
 
-    .next-sidebar:not(.sidebar-hidden):not(.sidebar-hide),
+    .next-sidebar:not(.sidebar-hidden, .sidebar-hide),
     .next-sidebar.sidebar-minimized {
         @apply opacity-100;
         transform: translateX(0px);

--- a/addon/styles/layout/mobile.css
+++ b/addon/styles/layout/mobile.css
@@ -11,7 +11,8 @@
         @apply transition duration-500 ease-in-out;
     }
 
-    .next-sidebar.is-open {
+    .next-sidebar:not(.sidebar-hidden):not(.sidebar-hide),
+    .next-sidebar.sidebar-minimized {
         @apply opacity-100;
         transform: translateX(0px);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fleetbase/ember-ui",
-    "version": "0.3.27",
+    "version": "0.3.28",
     "description": "Fleetbase UI provides all the interface components, helpers, services and utilities for building a Fleetbase extension into the Console.",
     "keywords": [
         "fleetbase-ui",


### PR DESCRIPTION
## Summary
- route the mobile navbar sidebar toggle through the shared sidebar service
- keep the existing mobile `is-open` class as the visual hook while aligning the underlying sidebar state
- bump `ember-ui` to `0.3.28`

## Problem
After the recent sidebar lifecycle changes, the mobile navbar was still opening and closing the sidebar by toggling its local `is-open` class directly. That left the sidebar service state out of sync with the actual mobile sidebar UI, which is why the closed mobile view could still reserve or expose the sidebar container after the contents slid away.

## Changes
- inject the shared `sidebar` service into `layout/mobile-navbar`
- use `sidebar.show()` when opening from the mobile menu
- use `sidebar.hide()` when closing from the mobile menu or route changes
- keep the `is-open` class toggle in the mobile navbar so the existing mobile CSS animation remains intact
- bump the package version to `0.3.28`

## Result
Mobile sidebar interactions now participate in the same shared sidebar state model as the rest of the app shell, while preserving the existing mobile animation behavior.
