### PR TITLE
Fix sidebar navigator initial sync

### DIFF
--- a/addon/components/layout/sidebar/navigator.js
+++ b/addon/components/layout/sidebar/navigator.js
@@ -28,12 +28,11 @@ export default class LayoutSidebarNavigatorComponent extends Component {
     openSearchTimer;
     openSearchFrame;
     searchToken = 0;
-    hasHandledInitialRouteSync = false;
 
     constructor() {
         super(...arguments);
 
-        this.hasHandledInitialRouteSync = this.syncInitialViewStackToRoute();
+        this.syncInitialViewStackToRoute();
 
         this.router?.on?.('routeDidChange', this.syncViewStackToRoute);
 
@@ -203,12 +202,6 @@ export default class LayoutSidebarNavigatorComponent extends Component {
     }
 
     @action syncViewStackToRoute() {
-        if (!this.hasHandledInitialRouteSync) {
-            this.syncInitialViewStackToRoute();
-            this.hasHandledInitialRouteSync = true;
-            return;
-        }
-
         const activePath = this.sidebarNavigator.activePath(this.items);
 
         this.applyActivePath(activePath);
@@ -217,7 +210,13 @@ export default class LayoutSidebarNavigatorComponent extends Component {
     syncInitialViewStackToRoute() {
         const activePath = this.sidebarNavigator.activePath(this.items);
 
+        if (!this.initialActiveParentSyncEnabled) {
+            this.viewStack = [];
+            return false;
+        }
+
         if (!this.shouldSyncInitialActiveParent(activePath)) {
+            this.viewStack = [];
             return false;
         }
 
@@ -226,10 +225,6 @@ export default class LayoutSidebarNavigatorComponent extends Component {
     }
 
     shouldSyncInitialActiveParent(activePath = []) {
-        if (!this.initialActiveParentSyncEnabled) {
-            return false;
-        }
-
         const predicate = this.args.shouldSyncInitialActiveParent;
 
         if (typeof predicate !== 'function') {

--- a/addon/services/sidebar-navigator.js
+++ b/addon/services/sidebar-navigator.js
@@ -22,14 +22,23 @@ export default class SidebarNavigatorService extends Service {
             return [];
         }
 
-        return items
-            .filter((item) => this.isVisible(item))
-            .map((item) => {
-                return {
-                    ...item,
-                    children: this.normalizeItems(item.children ?? []),
-                };
-            });
+        return items.reduce((normalizedItems, item) => {
+            if (!this.isVisible(item)) {
+                return normalizedItems;
+            }
+
+            const normalizedItem = {
+                ...item,
+                children: this.normalizeItems(item.children ?? []),
+            };
+
+            if (!this.hasVisibleTarget(normalizedItem) || !this.hasRequiredVisibleChildren(normalizedItem)) {
+                return normalizedItems;
+            }
+
+            normalizedItems.push(normalizedItem);
+            return normalizedItems;
+        }, []);
     }
 
     isVisible(item = {}) {
@@ -37,15 +46,35 @@ export default class SidebarNavigatorService extends Service {
             return false;
         }
 
+        if (item.visiblePermission && !this.can(item.visiblePermission)) {
+            return false;
+        }
+
         if (item.permission) {
-            try {
-                return this.abilities.can(item.permission);
-            } catch (_) {
-                return true;
-            }
+            return this.can(item.permission);
         }
 
         return true;
+    }
+
+    can(permission) {
+        try {
+            return this.abilities.can(permission);
+        } catch (_) {
+            return false;
+        }
+    }
+
+    hasVisibleTarget(item = {}) {
+        return Boolean(item.route || item.url || item.onClick || item.children?.length);
+    }
+
+    hasRequiredVisibleChildren(item = {}) {
+        if (!item.requiresVisibleChildren) {
+            return true;
+        }
+
+        return item.children?.some((child) => child.isNavigationHub !== true) === true;
     }
 
     flattenItems(items = [], trail = []) {

--- a/addon/styles/components/badge.css
+++ b/addon/styles/components/badge.css
@@ -312,6 +312,7 @@
 .status-badge.dispatched-status-badge > span,
 .status-badge.matched-status-badge > span,
 .status-badge.assigned-status-badge > span,
+.status-badge.recently-offline-status-badge > span,
 /* ── Transaction type labels ── */
 .status-badge.invoice-payment-status-badge > span,
 .status-badge.revenue-recognition-status-badge > span,
@@ -325,6 +326,7 @@
 .status-badge.dispatched-status-badge > span svg,
 .status-badge.matched-status-badge > span svg,
 .status-badge.assigned-status-badge > span svg,
+.status-badge.recently-offline-status-badge > span svg,
 .status-badge.invoice-payment-status-badge > span svg,
 .status-badge.revenue-recognition-status-badge > span svg,
 .status-badge.journal-entry-status-badge > span svg {

--- a/addon/utils/format-currency.js
+++ b/addon/utils/format-currency.js
@@ -2,7 +2,13 @@ import getCurrency from './get-currency';
 import formatMoney from '@fleetbase/ember-accounting/utils/format-money';
 
 export default function formatCurrency(amount = 0, currencyCode = 'USD') {
-    let currency = getCurrency(currencyCode);
+    let currency = getCurrency(currencyCode) ?? {
+        code: currencyCode,
+        symbol: `${currencyCode} `,
+        precision: 2,
+        thousandSeparator: ',',
+        decimalSeparator: '.',
+    };
 
     return formatMoney(!currency.decimalSeparator ? amount : amount / 100, currency.symbol, currency.precision, currency.thousandSeparator, currency.decimalSeparator);
 }

--- a/addon/utils/get-currency.js
+++ b/addon/utils/get-currency.js
@@ -1,5 +1,16 @@
 export const currencies = [
     {
+        code: 'KUDOS',
+        title: 'GNU Taler KUDO Currency',
+        symbol: 'KUDOS ',
+        precision: 2,
+        thousandSeparator: ',',
+        decimalSeparator: '.',
+        symbolPlacement: 'before',
+        name: 'GNU Taler KUDO Currency',
+        hidden: true,
+    },
+    {
         iso2: 'AW',
         name: 'Aruba',
         emoji: '🇦🇼',
@@ -1560,20 +1571,29 @@ export const currencies = [
     },
 ];
 
-export default function getCurrency(code) {
+export default function getCurrency(code, options = {}) {
+    const includeHidden = options.includeHidden === true;
+    const availableCurrencies = includeHidden ? currencies : currencies.filter((currency) => !currency.hidden);
+
     if (!code) {
-        return currencies;
+        return availableCurrencies;
     }
 
+    const normalizedCode = code.toLowerCase();
+
     return currencies.find((currency) => {
+        if (currency.code?.toLowerCase() === normalizedCode) {
+            return true;
+        }
+
         if (code.length === 2) {
-            return currency.iso2.toLowerCase() === code.toLowerCase();
+            return currency.iso2?.toLowerCase() === normalizedCode;
         }
 
         if (code.length === 3) {
-            return currency.code.toLowerCase() === code.toLowerCase();
+            return currency.code?.toLowerCase() === normalizedCode;
         }
 
-        return currency.name.toLowerCase() === code.toLowerCase();
+        return currency.name?.toLowerCase() === normalizedCode;
     });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fleetbase/ember-ui",
-    "version": "0.3.37",
+    "version": "0.3.38",
     "description": "Fleetbase UI provides all the interface components, helpers, services and utilities for building a Fleetbase extension into the Console.",
     "keywords": [
         "fleetbase-ui",

--- a/tests/integration/components/layout/sidebar/navigator-test.js
+++ b/tests/integration/components/layout/sidebar/navigator-test.js
@@ -4,10 +4,28 @@ import { click, fillIn, render, settled, triggerEvent, triggerKeyEvent, waitFor 
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 
+class AbilitiesStub extends Service {
+    denied = new Set();
+    throwFor = new Set();
+
+    can(permission) {
+        if (this.throwFor.has(permission)) {
+            throw new Error(`Permission check failed for ${permission}`);
+        }
+
+        return !this.denied.has(permission);
+    }
+
+    cannot(permission) {
+        return !this.can(permission);
+    }
+}
+
 module('Integration | Component | layout/sidebar/navigator', function (hooks) {
     setupRenderingTest(hooks);
 
     hooks.beforeEach(function () {
+        this.owner.register('service:abilities', AbilitiesStub);
         this.wormholeRoot = document.getElementById('application-root-wormhole');
 
         if (!this.wormholeRoot) {
@@ -51,6 +69,140 @@ module('Integration | Component | layout/sidebar/navigator', function (hooks) {
         if (this.createdWormholeRoot) {
             this.wormholeRoot.remove();
         }
+    });
+
+    test('it hides items with denied visiblePermission and prunes empty branches', async function (assert) {
+        const abilities = this.owner.lookup('service:abilities');
+        abilities.denied.add('fleet-ops see service-rate');
+        abilities.denied.add('fleet-ops see hidden-section');
+
+        this.set('items', [
+            {
+                label: 'Operations',
+                children: [
+                    {
+                        label: 'Orders',
+                        visiblePermission: 'fleet-ops see order',
+                        onClick: () => this.set('selected', 'orders'),
+                    },
+                    {
+                        label: 'Service Rates',
+                        visiblePermission: 'fleet-ops see service-rate',
+                        permission: 'fleet-ops list service-rate',
+                        keywords: ['rates'],
+                        onClick: () => this.set('selected', 'service-rates'),
+                    },
+                ],
+            },
+            {
+                label: 'Hidden Section',
+                children: [
+                    {
+                        label: 'Hidden Child',
+                        visiblePermission: 'fleet-ops see hidden-section',
+                        onClick: () => this.set('selected', 'hidden'),
+                    },
+                ],
+            },
+        ]);
+
+        await render(hbs`<Layout::Sidebar::Navigator @items={{this.items}} />`);
+
+        assert.dom('.next-sidebar-navigator').includesText('Operations');
+        assert.dom('.next-sidebar-navigator').doesNotIncludeText('Hidden Section');
+
+        await click('.next-sidebar-navigator-view-in .next-sidebar-navigator-item:first-of-type');
+
+        assert.dom('.next-sidebar-navigator').includesText('Orders');
+        assert.dom('.next-sidebar-navigator').doesNotIncludeText('Service Rates');
+
+        await fillIn('.next-sidebar-navigator-search input', 'rates');
+        await settled();
+
+        assert.dom('.next-sidebar-navigator-search-result').doesNotExist('hidden items are excluded from search');
+    });
+
+    test('it fails closed when an explicit permission check throws', async function (assert) {
+        const abilities = this.owner.lookup('service:abilities');
+        abilities.throwFor.add('fleet-ops list service-rate');
+
+        this.set('items', [
+            {
+                label: 'Orders',
+                onClick: () => this.set('selected', 'orders'),
+            },
+            {
+                label: 'Service Rates',
+                permission: 'fleet-ops list service-rate',
+                onClick: () => this.set('selected', 'service-rates'),
+            },
+        ]);
+
+        await render(hbs`<Layout::Sidebar::Navigator @items={{this.items}} />`);
+
+        assert.dom('.next-sidebar-navigator').includesText('Orders');
+        assert.dom('.next-sidebar-navigator').doesNotIncludeText('Service Rates');
+    });
+
+    test('it can require a branch to have visible non-hub children', async function (assert) {
+        const abilities = this.owner.lookup('service:abilities');
+        abilities.denied.add('fleet-ops see work-order');
+
+        this.set('items', [
+            {
+                label: 'Maintenance',
+                requiresVisibleChildren: true,
+                children: [
+                    {
+                        label: 'Maintenance Hub',
+                        isNavigationHub: true,
+                        route: 'console.fleet-ops.maintenance.index',
+                    },
+                    {
+                        label: 'Work Orders',
+                        visiblePermission: 'fleet-ops see work-order',
+                        route: 'console.fleet-ops.maintenance.work-orders',
+                    },
+                ],
+            },
+            {
+                label: 'Regular Section',
+                children: [
+                    {
+                        label: 'Regular Hub',
+                        isNavigationHub: true,
+                        route: 'console.regular.index',
+                    },
+                ],
+            },
+            {
+                label: 'Resources',
+                requiresVisibleChildren: true,
+                children: [
+                    {
+                        label: 'Resources Hub',
+                        isNavigationHub: true,
+                        route: 'console.fleet-ops.management.index',
+                    },
+                    {
+                        label: 'Drivers',
+                        visiblePermission: 'fleet-ops see driver',
+                        route: 'console.fleet-ops.management.drivers',
+                    },
+                ],
+            },
+        ]);
+
+        await render(hbs`<Layout::Sidebar::Navigator @items={{this.items}} />`);
+
+        assert.dom('.next-sidebar-navigator').doesNotIncludeText('Maintenance', 'hub-only required branch is hidden');
+        assert.dom('.next-sidebar-navigator').includesText('Regular Section', 'normal branches keep existing behavior');
+        assert.dom('.next-sidebar-navigator').includesText('Resources', 'branch with a visible real child remains visible');
+
+        await click('.next-sidebar-navigator-view-in .next-sidebar-navigator-item:nth-of-type(2)');
+
+        assert.dom('.next-sidebar-navigator').includesText('Resources Hub');
+        assert.dom('.next-sidebar-navigator').includesText('Drivers');
     });
 
     test('it transitions between root and nested menus with directional classes', async function (assert) {
@@ -140,7 +292,7 @@ module('Integration | Component | layout/sidebar/navigator', function (hooks) {
         assert.dom('.next-sidebar-navigator-view-in .next-sidebar-navigator-item').hasClass('is-active');
     });
 
-    test('it lets an initial active parent predicate suppress initial nested sync through the first route event', async function (assert) {
+    test('it lets an initial active parent predicate suppress initial nested sync once', async function (assert) {
         class RouterStub extends Service {
             currentRouteName = 'console.settings.index';
             currentURL = '/settings';
@@ -190,12 +342,6 @@ module('Integration | Component | layout/sidebar/navigator', function (hooks) {
         assert.dom('.next-sidebar-navigator-view-in').includesText('Settings');
 
         const router = this.owner.lookup('service:router');
-        router.triggerRouteDidChange();
-        await settled();
-
-        assert.dom('.next-sidebar-navigator-back').doesNotExist('first route event is still treated as initial entry');
-        assert.dom('.next-sidebar-navigator-view-in').includesText('Settings');
-
         router.currentRouteName = 'console.settings.security';
         router.currentURL = '/settings/security';
         this.set('items', [
@@ -217,8 +363,8 @@ module('Integration | Component | layout/sidebar/navigator', function (hooks) {
         await settled();
 
         assert.dom('.next-sidebar-navigator-back').includesText('Settings', 'later route changes sync nested state normally');
-        assert.dom('.next-sidebar-navigator-view-in .next-sidebar-navigator-item').includesText('General');
-        assert.dom('.next-sidebar-navigator-view-in .next-sidebar-navigator-item').includesText('Security');
+        assert.dom('.next-sidebar-navigator-view-in').includesText('General');
+        assert.dom('.next-sidebar-navigator-view-in').includesText('Security');
     });
 
     test('it syncs initial nested state when the active parent predicate allows it', async function (assert) {

--- a/tests/integration/components/layout/sidebar/navigator-test.js
+++ b/tests/integration/components/layout/sidebar/navigator-test.js
@@ -117,7 +117,6 @@ module('Integration | Component | layout/sidebar/navigator', function (hooks) {
         assert.dom('.next-sidebar-navigator').doesNotIncludeText('Service Rates');
 
         await fillIn('.next-sidebar-navigator-search input', 'rates');
-        await settled();
 
         assert.dom('.next-sidebar-navigator-search-result').doesNotExist('hidden items are excluded from search');
     });

--- a/tests/unit/utils/format-currency-test.js
+++ b/tests/unit/utils/format-currency-test.js
@@ -2,8 +2,18 @@ import formatCurrency from 'dummy/utils/format-currency';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | format-currency', function () {
-    test('it works', function (assert) {
+    test('it formats USD by default', function (assert) {
         let result = formatCurrency(10000);
         assert.strictEqual(result, '$100.00');
+    });
+
+    test('it formats KUDOS', function (assert) {
+        let result = formatCurrency(500, 'KUDOS');
+        assert.strictEqual(result, 'KUDOS 5.00');
+    });
+
+    test('it does not throw for unknown long currency codes', function (assert) {
+        let result = formatCurrency(500, 'DEMOX');
+        assert.strictEqual(result, 'DEMOX 5.00');
     });
 });

--- a/tests/unit/utils/get-currency-test.js
+++ b/tests/unit/utils/get-currency-test.js
@@ -2,9 +2,21 @@ import getCurrency from 'dummy/utils/get-currency';
 import { module, test } from 'qunit';
 
 module('Unit | Utility | get-currency', function () {
-    test('it works', function (assert) {
-        let currency = 'SGD';
-        let result = getCurrency(currency);
+    test('it returns normal currencies by code', function (assert) {
+        let result = getCurrency('SGD');
         assert.ok(result);
+        assert.strictEqual(result.code, 'SGD');
+    });
+
+    test('it returns KUDOS by code', function (assert) {
+        let result = getCurrency('KUDOS');
+        assert.ok(result);
+        assert.strictEqual(result.code, 'KUDOS');
+        assert.strictEqual(result.title, 'GNU Taler KUDO Currency');
+    });
+
+    test('it hides KUDOS from the default currency list', function (assert) {
+        let result = getCurrency();
+        assert.false(result.some((currency) => currency.code === 'KUDOS'));
     });
 });


### PR DESCRIPTION
## Summary
- simplify the sidebar navigator initial active-parent sync back to a one-time render check
- support permission-safe navigator filtering with visible permissions and required visible children
- fix FleetOps root-entry behavior by allowing modules to suppress initial nested sync from root URLs while preserving later route sync

## Why
FleetOps can resolve the module root URL to a deeply nested route like `console.fleet-ops.operations.orders.index.index`. Exact route-name matching caused the sidebar to open the Operations nested menu on first module entry, which made the root sections harder to discover.

## Verification
- `git diff --cached --check`
- `pnpm exec ember test --filter "initial active parent predicate"`