### PR TITLE
Rebuild translations-editor around stable rows

### DIFF
--- a/addon/components/translations-editor.hbs
+++ b/addon/components/translations-editor.hbs
@@ -25,24 +25,41 @@
             </div>
         {{/if}}
         <div class="space-y-2">
-            {{#each-in this.loadedTranslations as |key value|}}
+            {{! Keyed on the row id, not the translation key: renaming a key must not tear down and
+                rebuild the input the user is typing in. The fields are one-way and commit on
+                `change`, so nothing writes back while an edit is in flight. }}
+            {{#each this.rows key="id" as |row|}}
                 <div class="flex flex-row">
                     <div class="flex-1">
-                        <Input @value={{key}} {{on "blur" (fn this.setTranslationKey key)}} aria-label="Translation Key" placeholder={{key}} class="form-input w-full" />
+                        <input
+                            type="text"
+                            value={{row.key}}
+                            {{on "change" (fn this.setTranslationKey row.id)}}
+                            aria-label="Translation Key"
+                            placeholder={{row.key}}
+                            class="form-input w-full"
+                        />
                     </div>
                     <div class="flex items-center justify-center">
                         <FaIcon @icon="equals" @prefix="fas" class="text-gray-500 mx-2" />
                     </div>
                     <div class="flex-1">
-                        <Input @value={{value}} {{on "blur" (fn this.setTranslationValue key)}} aria-label="Translation Value" placeholder={{key}} class="form-input w-full" />
+                        <input
+                            type="text"
+                            value={{row.value}}
+                            {{on "change" (fn this.setTranslationValue row.id)}}
+                            aria-label="Translation Value"
+                            placeholder={{row.key}}
+                            class="form-input w-full"
+                        />
                     </div>
                     <div class="flex items-center justify-center">
-                        <a href="javascript:;" class="text-danger" {{on "click" (fn this.removeTranslation key)}}>
+                        <a href="javascript:;" class="text-danger" {{on "click" (fn this.removeTranslation row.id)}}>
                             <FaIcon @icon="times" @prefix="fas" class="text-red-500 ml-2" />
                         </a>
                     </div>
                 </div>
-            {{/each-in}}
+            {{/each}}
         </div>
     </div>
 </div>

--- a/addon/components/translations-editor.js
+++ b/addon/components/translations-editor.js
@@ -1,117 +1,118 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
-import { action, computed } from '@ember/object';
+import { action } from '@ember/object';
 import { isArray } from '@ember/array';
 import { isBlank } from '@ember/utils';
 import { underscore } from '@ember/string';
 
-export default class TranslationsEditorComponent extends Component {
-    @tracked languages = [];
-    @tracked language;
-    @tracked translations = {};
+let ROW_SEQUENCE = 0;
 
-    @computed('translations', 'language') get loadedTranslations() {
-        return this.translations[this.language] ?? {};
-    }
+/**
+ * Edits translation key/value pairs, one set per language.
+ *
+ * The editor holds its state as ROWS — `{ id, key, value }` — rather than as the
+ * `{ language: { key: value } }` object it reads and reports. Two reasons:
+ *
+ *   1. A row's identity survives renaming its key. Keying the `{{#each}}` on the translation key
+ *      itself meant that typing in the key field destroyed the input and rebuilt it on the next
+ *      render, mid-edit.
+ *   2. Every edit builds a NEW structure and assigns it once. The previous version mutated
+ *      `this.translations` in place and then reassigned the same reference, which wrote to a
+ *      tracked property that the render was still consuming — the backtracking-rerender assertion
+ *      recorded in DEFECTS.md #26.
+ *
+ * The public surface is unchanged: `@value` in, `@onChange(translations)` out, both in the
+ * `{ language: { key: value } }` shape, plus `@defaultKeys` and `@label`/`@labelClass`.
+ */
+export default class TranslationsEditorComponent extends Component {
+    /** The language whose rows are on screen. */
+    @tracked language;
+
+    /** `{ en: [{ id, key, value }, …] }` — replaced wholesale on every edit, never mutated. */
+    @tracked rowsByLanguage = {};
 
     constructor() {
         super(...arguments);
 
-        // Derive the tabs from the SANITISED value: reading the raw argument gave an array
-        // `@value` one language tab per numeric index ('0', '1', '2'), even though
-        // `setDefaultKeys` correctly discards the array.
-        this.translations = this.setDefaultKeys(this.args.value, this.args.defaultKeys);
-        this.languages = Object.keys(this.translations ?? {});
+        this.rowsByLanguage = this.#toRows(this.setDefaultKeys(this.args.value, this.args.defaultKeys));
 
-        // load first languages
-        if (this.languages.length) {
-            this.loadLanguage(this.languages[0]);
+        const [first] = this.languages;
+        if (first) {
+            this.language = first;
         }
     }
 
+    get languages() {
+        return Object.keys(this.rowsByLanguage);
+    }
+
+    /** The rows for the visible language. */
+    get rows() {
+        return this.rowsByLanguage[this.language] ?? [];
+    }
+
+    /**
+     * Fills in any missing default keys. Returns a NEW object — the previous version wrote the
+     * defaults into the caller's own `@value`.
+     */
     @action setDefaultKeys(value, defaultKeys = [], forceKeys = false) {
         if (!defaultKeys) {
             return value ?? {};
         }
 
-        if (isBlank(value) || isArray(value) || typeof value !== 'object') {
-            value = {};
-        }
+        const source = isBlank(value) || isArray(value) || typeof value !== 'object' ? {} : value;
 
         if (forceKeys === true) {
-            for (let i = 0; i < defaultKeys.length; i++) {
-                const defaultKey = defaultKeys[i];
-
-                if (!value[defaultKey]) {
-                    value[defaultKey] = null;
+            const seeded = { ...source };
+            for (const defaultKey of defaultKeys) {
+                if (!seeded[defaultKey]) {
+                    seeded[defaultKey] = null;
                 }
             }
 
-            return value;
+            return seeded;
         }
 
-        for (let lang in value) {
-            for (let i = 0; i < defaultKeys.length; i++) {
-                const defaultKey = defaultKeys[i];
-
-                if (!value[lang][defaultKey]) {
-                    value[lang][defaultKey] = null;
+        const next = {};
+        for (const language of Object.keys(source)) {
+            const pairs = { ...(source[language] ?? {}) };
+            for (const defaultKey of defaultKeys) {
+                if (!pairs[defaultKey]) {
+                    pairs[defaultKey] = null;
                 }
             }
+            next[language] = pairs;
         }
 
-        return value;
+        return next;
     }
 
-    @action updateTranslations(translations) {
-        this.translations = translations;
+    @action setTranslationKey(id, event) {
+        const key = underscore(event.target.value);
 
-        if (typeof this.args.onChange === 'function') {
-            this.args.onChange(translations);
-        }
+        this.#commit(this.#withRows(this.rows.map((row) => (row.id === id ? { ...row, key } : row))));
     }
 
-    @action setTranslationValue(key, event) {
-        const { translations } = this;
-        const { target } = event;
-        const value = target.value?.trim();
+    @action setTranslationValue(id, event) {
+        const value = event.target.value?.trim();
 
-        translations[this.language][key] = value;
-        this.updateTranslations(translations);
-    }
-
-    @action setTranslationKey(key, event) {
-        const { translations } = this;
-        const { target } = event;
-        const newKey = underscore(target.value);
-
-        const currentValue = translations[this.language][key];
-        delete translations[this.language][key];
-
-        translations[this.language][newKey] = currentValue;
-        this.updateTranslations(translations);
+        this.#commit(this.#withRows(this.rows.map((row) => (row.id === id ? { ...row, value } : row))));
     }
 
     @action addTranslation() {
-        const { translations } = this;
-
-        // A count-based index is not a fresh index once anything has been removed — it collides
-        // with a surviving key and silently overwrites it. Take one past the highest in use.
-        const indexes = Object.keys(translations[this.language] ?? {})
-            .map((key) => /^translation_(\d+)$/.exec(key))
+        // One past the highest `translation_N` in use. A count-based index is not a fresh index
+        // once anything has been removed — it collides with a key that is still in play.
+        const indexes = this.rows
+            .map((row) => /^translation_(\d+)$/.exec(row.key ?? ''))
             .filter(Boolean)
             .map((match) => Number(match[1]));
         const next = indexes.length ? Math.max(...indexes) + 1 : 0;
 
-        translations[this.language][`translation_${next}`] = null;
-        this.updateTranslations(translations);
+        this.#commit(this.#withRows([...this.rows, this.#row(`translation_${next}`, null)]));
     }
 
-    @action removeTranslation(key) {
-        const { translations } = this;
-
-        delete translations[this.language][key];
-        this.updateTranslations(translations);
+    @action removeTranslation(id) {
+        this.#commit(this.#withRows(this.rows.filter((row) => row.id !== id)));
     }
 
     @action loadLanguage(language) {
@@ -119,13 +120,56 @@ export default class TranslationsEditorComponent extends Component {
     }
 
     @action addLanguage(iso2) {
-        const { translations } = this;
-        const { defaultKeys } = this.args;
-        const lang = iso2.toLowerCase();
+        const language = iso2.toLowerCase();
+        const seeded = this.setDefaultKeys({}, this.args.defaultKeys, true);
 
-        this.languages = [...this.languages, lang];
-        this.language = lang;
-        translations[lang] = this.setDefaultKeys({}, defaultKeys, true);
-        this.updateTranslations(translations);
+        this.language = language;
+        this.#commit({
+            ...this.rowsByLanguage,
+            [language]: Object.entries(seeded).map(([key, value]) => this.#row(key, value)),
+        });
+    }
+
+    #row(key, value) {
+        ROW_SEQUENCE += 1;
+
+        return { id: `translation-row-${ROW_SEQUENCE}`, key, value };
+    }
+
+    #toRows(translations) {
+        const rowsByLanguage = {};
+
+        for (const [language, pairs] of Object.entries(translations ?? {})) {
+            rowsByLanguage[language] = Object.entries(pairs ?? {}).map(([key, value]) => this.#row(key, value));
+        }
+
+        return rowsByLanguage;
+    }
+
+    /** Back to the `{ language: { key: value } }` shape callers expect. */
+    #toTranslations(rowsByLanguage) {
+        const translations = {};
+
+        for (const [language, rows] of Object.entries(rowsByLanguage)) {
+            translations[language] = {};
+            for (const row of rows) {
+                translations[language][row.key] = row.value;
+            }
+        }
+
+        return translations;
+    }
+
+    #withRows(rows) {
+        return { ...this.rowsByLanguage, [this.language]: rows };
+    }
+
+    /** The single write. Replaces the state, then reports the plain object once. */
+    #commit(rowsByLanguage) {
+        this.rowsByLanguage = rowsByLanguage;
+
+        if (typeof this.args.onChange === 'function') {
+            this.args.onChange(this.#toTranslations(rowsByLanguage));
+        }
     }
 }

--- a/tests/integration/components/tab-navigation-test.js
+++ b/tests/integration/components/tab-navigation-test.js
@@ -167,8 +167,8 @@ module('Integration | Component | tab-navigation', function (hooks) {
 
             await render(TEMPLATE);
 
-            const container = find('.tab-list').parentElement;
             assert.dom('[role="tablist"]').exists('the requested style renders a tablist');
+            assert.dom('.tab-list').exists('alongside the tab list itself');
         });
     });
 

--- a/tests/integration/components/translations-editor-test.js
+++ b/tests/integration/components/translations-editor-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'dummy/tests/helpers';
-import { render, click, triggerEvent, findAll, find } from '@ember/test-helpers';
+import { render, click, fillIn, findAll, find } from '@ember/test-helpers';
 import { selectChoose } from 'ember-power-select/test-support';
 import { hbs } from 'ember-cli-htmlbars';
 
@@ -32,12 +32,11 @@ function removeButtons() {
     return findAll('.text-danger');
 }
 
-// Setting .value directly and firing only `blur` exercises the component's own handler
-// without a re-render landing while the field is still focused, which otherwise reassigns the
-// tracked `translations` object mid-render and raises a backtracking assertion (DEFECTS.md #26).
+// The fields are one-way and commit on `change`, which is what `fillIn` fires. No special
+// handling is needed any more — the editor no longer writes to state the render is consuming
+// (DEFECTS.md #26).
 async function editAndBlur(input, value) {
-    input.value = value;
-    await triggerEvent(input, 'blur');
+    await fillIn(input, value);
 }
 
 function addButton() {
@@ -286,5 +285,78 @@ module('Integration | Component | translations-editor', function (hooks) {
             assert.deepEqual(tabLabels(), [], 'there is nothing to show');
             assert.dom('.translations-editor-input').exists('but the editor still renders');
         });
+    });
+    module('editing without tearing down the row', function () {
+        test('renaming a key keeps the very same input element', async function (assert) {
+            this.set('value', { en: { greeting: 'Hello' } });
+
+            await render(TEMPLATE);
+
+            const before = keyInputs()[0];
+            before.dataset.identity = 'original-node';
+
+            await fillIn(before, 'salutation');
+
+            const after = keyInputs()[0];
+            assert.strictEqual(after.dataset.identity, 'original-node', 'the row survives the rename rather than being rebuilt');
+            assert.strictEqual(after.value, 'salutation', 'and shows the new key');
+            assert.deepEqual(lastChange(), { en: { salutation: 'Hello' } }, 'the value moves with it');
+        });
+
+        test('a key can be renamed twice in a row', async function (assert) {
+            this.set('value', { en: { greeting: 'Hello' } });
+
+            await render(TEMPLATE);
+            await fillIn(keyInputs()[0], 'salutation');
+            await fillIn(keyInputs()[0], 'welcome_message');
+
+            assert.deepEqual(renderedKeys(), ['welcome_message']);
+            assert.deepEqual(lastChange(), { en: { welcome_message: 'Hello' } }, 'the value survives both renames');
+        });
+
+        test('editing a key and then its value reports both', async function (assert) {
+            this.set('value', { en: { greeting: 'Hello' } });
+
+            await render(TEMPLATE);
+            await fillIn(keyInputs()[0], 'salutation');
+            await fillIn(valueInputs()[0], 'Hi there');
+
+            assert.deepEqual(lastChange(), { en: { salutation: 'Hi there' } });
+        });
+
+        test('two rows are edited independently', async function (assert) {
+            this.set('value', { en: { greeting: 'Hello', farewell: 'Bye' } });
+
+            await render(TEMPLATE);
+            await fillIn(valueInputs()[1], 'Goodbye');
+
+            assert.deepEqual(lastChange(), { en: { greeting: 'Hello', farewell: 'Goodbye' } }, 'only the edited row changes');
+            assert.strictEqual(valueInputs()[0].value, 'Hello', 'the other row is untouched');
+        });
+
+        test('a key is underscored as it is committed', async function (assert) {
+            this.set('value', { en: { greeting: 'Hello' } });
+
+            await render(TEMPLATE);
+            await fillIn(keyInputs()[0], 'Welcome Message');
+
+            assert.deepEqual(renderedKeys(), ['welcome_message'], 'the normalised key is shown back to the user');
+            assert.deepEqual(lastChange(), { en: { welcome_message: 'Hello' } });
+        });
+    });
+
+    // The editor used to write the defaults straight into the object it was handed.
+    test('it does not modify the value it was given', async function (assert) {
+        const original = { en: { greeting: 'Hello' } };
+        this.set('value', original);
+        this.set('defaultKeys', ['greeting', 'farewell']);
+
+        await render(TEMPLATE);
+
+        assert.deepEqual(original, { en: { greeting: 'Hello' } }, 'the caller keeps its own object intact');
+
+        await fillIn(valueInputs()[0], 'Hi');
+
+        assert.deepEqual(original, { en: { greeting: 'Hello' } }, 'and edits do not reach back into it either');
     });
 });


### PR DESCRIPTION
**Stacked on #148.** Item 1.5 — the one genuine redesign in the review.

## What was wrong

Two separate faults, which is why the documented one-line fix (two-way → one-way bindings) didn't clear the assertion. I tried that during the coverage work and reverted it; the binding style was the symptom.

**1. Every handler mutated shared state and then reassigned it.**

```js
const { translations } = this;
translations[this.language][key] = value;   // mutate in place
this.updateTranslations(translations);      // reassign the SAME reference
```

`updateTranslations` writes the tracked property that `get loadedTranslations()` is consuming. Fired from a field that still has focus, the write lands while the render is mid-flight — the backtracking-rerender assertion.

**2. `{{#each-in}}` keyed the rows on the translation key itself.**

So typing in a key field changed the iteration identity, and Glimmer destroyed the input and rebuilt it on the next render — while the user was typing in it. Even with the assertion silenced in production, that's dropped keystrokes.

## The redesign

State is now `{ language: [{ id, key, value }] }` rows.

- **A row's identity survives renaming its key**, so the input is reused rather than rebuilt. `{{#each this.rows key="id"}}`.
- **Every edit builds a new structure and assigns it once** — `#commit()` is the single write. Nothing mutates state a render is reading.
- **Fields are one-way, committing on `change`**, so nothing writes back while an edit is in flight.

`setDefaultKeys` also stopped writing defaults into the caller's own `@value` object — it returns a new one. That was a side effect on consumer data; there's now a test for it.

## Public surface unchanged

`@value` in, `@onChange(translations)` out, both in the `{ language: { key: value } }` shape, plus `@defaultKeys`, `@label`, `@labelClass`. All 20 pre-existing tests pass **unmodified** except the shared helper, which no longer needs its workaround:

```js
// before — set .value directly and fire only `blur`, to avoid the assertion
async function editAndBlur(input, value) { input.value = value; await triggerEvent(input, 'blur'); }
// after
async function editAndBlur(input, value) { await fillIn(input, value); }
```

The internal `loadedTranslations` getter is gone. I checked the whole monorepo — it was read only by this component's own template.

## Six new tests

Each covers something the old design could not express:

| test | pins |
|---|---|
| renaming a key keeps the very same input element | the core fix — tagged the DOM node and asserted identity across the rename |
| a key can be renamed twice in a row | the value survives both |
| a key edit followed by a value edit reports both | the sequence that triggered the assertion |
| two rows are edited independently | rows no longer share identity through their keys |
| a key is underscored as it is committed | the normalised value is shown back to the user |
| it does not modify the value it was given | `setDefaultKeys` no longer mutates the caller's object |

## Result

**4946 tests pass, 0 skips.** Lints clean.

| metric | after #148 | after this |
|---|---|---|
| statements | 93.69% | **93.71%** |
| branches | 89.22% | 89.21% |
| functions | 97.18% | 97.18% |
| lines | 94.10% | **94.11%** |

Branches move a hair because the rewrite has slightly different shape; the denominator moved too (6603 → 6611).

## Worth a look

The `change` event rather than `blur`. `change` fires on blur **when the value actually changed**, which is the commit point you want — tabbing through a field without editing no longer fires `onChange`. If you'd rather every blur commit, it's a one-word change in the template.
