### PR TITLE
Let the resource-identity cell actually compact

### DIFF
--- a/addon/components/table/cell/resource-identity.hbs
+++ b/addon/components/table/cell/resource-identity.hbs
@@ -3,7 +3,7 @@
         type="button"
         disabled={{and @column.permission (cannot @column.permission)}}
         {{on "click" this.onClick}}
-        class="flex min-w-0 items-start gap-2 text-left py-0.5"
+        class="flex min-w-0 items-start gap-2 text-left {{this.triggerClass}}"
     >
         <div class="relative flex {{this.imageSizeClass}} flex-shrink-0 items-center justify-center">
             <Image

--- a/addon/components/table/cell/resource-identity.js
+++ b/addon/components/table/cell/resource-identity.js
@@ -105,6 +105,19 @@ export default class TableCellResourceIdentityComponent extends Component {
         return this.column.statusBadgeSize ?? 'xxs';
     }
 
+    /**
+     * The trigger's own classes. Vertical padding used to be hard-coded here, so the identity cell
+     * could never be compacted for a dense table however the column was configured.
+     */
+    get triggerClass() {
+        return this.column.triggerClass ?? (this.compact ? 'py-0' : 'py-0.5');
+    }
+
+    /** Shorthand for the dense variant, so a caller need not know the padding class to drop. */
+    get compact() {
+        return this.column.compact ?? false;
+    }
+
     get imageSizeClass() {
         return this.column.imageSizeClass ?? 'h-7 w-7';
     }

--- a/tests/integration/components/table/cell/resource-identity-test.js
+++ b/tests/integration/components/table/cell/resource-identity-test.js
@@ -30,9 +30,7 @@ module('Integration | Component | table/cell/resource-identity', function (hooks
         assert.dom('.table-cell-resource-identity').exists();
         assert.dom('[data-test-resource-identity-image]').hasAttribute('src', 'https://example.com/truck.png');
         assert.dom('button').hasClass('items-start');
-        // DEFECT (see DEFECTS.md #108): the trigger hard-codes `py-0.5` with no argument to switch
-        // it off, so the "compact" identity is never actually compact. Pinned as-is.
-        assert.dom('button').hasClass('py-0.5');
+        assert.dom('button').hasClass('py-0.5', 'the default padding is unchanged');
         assert.dom('[data-test-resource-identity-image]').hasClass('h-7');
         assert.dom('[data-test-resource-identity-image]').hasClass('w-7');
         assert.dom('[data-test-resource-identity-image]').hasClass('border');
@@ -333,6 +331,61 @@ module('Integration | Component | table/cell/resource-identity', function (hooks
 
             const shown = this.element.textContent.match(/ABC-123/g) ?? [];
             assert.strictEqual(shown.length, 1, 'the repeated value is de-duplicated');
+        });
+    });
+    // #108: the trigger's vertical padding used to be a literal in the template, so a dense table
+    // had no way to compact the identity cell however its column was configured.
+    module('the trigger padding', function () {
+        test('it carries the standard padding by default', async function (assert) {
+            this.set('row', { name: 'Truck 104' });
+            this.set('column', { labelPath: 'name' });
+
+            await render(hbs`<Table::Cell::ResourceIdentity @row={{this.row}} @column={{this.column}} />`);
+
+            assert.dom('button').hasClass('py-0.5');
+        });
+
+        test('a compact column drops it', async function (assert) {
+            this.set('row', { name: 'Truck 104' });
+            this.set('column', { labelPath: 'name', compact: true });
+
+            await render(hbs`<Table::Cell::ResourceIdentity @row={{this.row}} @column={{this.column}} />`);
+
+            assert.dom('button').hasClass('py-0', 'the dense variant is actually dense');
+            assert.dom('button').doesNotHaveClass('py-0.5');
+        });
+
+        test('an explicit triggerClass replaces the padding outright', async function (assert) {
+            this.set('row', { name: 'Truck 104' });
+            this.set('column', { labelPath: 'name', triggerClass: 'py-2 font-bold' });
+
+            await render(hbs`<Table::Cell::ResourceIdentity @row={{this.row}} @column={{this.column}} />`);
+
+            assert.dom('button').hasClass('py-2');
+            assert.dom('button').hasClass('font-bold');
+            assert.dom('button').doesNotHaveClass('py-0.5');
+        });
+
+        test('an explicit triggerClass wins over compact', async function (assert) {
+            this.set('row', { name: 'Truck 104' });
+            this.set('column', { labelPath: 'name', compact: true, triggerClass: 'py-3' });
+
+            await render(hbs`<Table::Cell::ResourceIdentity @row={{this.row}} @column={{this.column}} />`);
+
+            assert.dom('button').hasClass('py-3', 'the specific option beats the shorthand');
+            assert.dom('button').doesNotHaveClass('py-0');
+        });
+
+        test('the layout classes survive either way', async function (assert) {
+            this.set('row', { name: 'Truck 104' });
+            this.set('column', { labelPath: 'name', compact: true });
+
+            await render(hbs`<Table::Cell::ResourceIdentity @row={{this.row}} @column={{this.column}} />`);
+
+            assert.dom('button').hasClass('flex');
+            assert.dom('button').hasClass('items-start');
+            assert.dom('button').hasClass('gap-2');
+            assert.dom('button').hasClass('text-left');
         });
     });
 });


### PR DESCRIPTION
Decision **3.2**: "Please fix."

> Stacked on #151 (`fix/model-select-infinity`). Review that one first.

## The problem

`table/cell/resource-identity.hbs` rendered its trigger with a literal:

```hbs
class="flex min-w-0 items-start gap-2 text-left py-0.5"
```

Every other visual aspect of this component is a column option with a default — `wrapperClass`, `imageSizeClass`, `imageRoundedClass`, and the five `statusBadge*` getters. The trigger's vertical padding was the one thing no argument could reach, so the identity cell **could not be compacted for a dense table** however its column was configured. That's DEFECTS #108.

The component's own committed test said as much — it asserted `doesNotHaveClass('py-0.5')`. Template and test disagreed about whether the compact variant carries padding, and that mismatch shipped. The coverage work pinned it to the actual behaviour with a `// DEFECT` comment; this unpins it.

## The fix

The way the rest of the file already works — a getter reading the column with a default:

```js
get triggerClass() {
    return this.column.triggerClass ?? (this.compact ? 'py-0' : 'py-0.5');
}

get compact() {
    return this.column.compact ?? false;
}
```

- `column.compact` is the shorthand, so a caller doesn't need to know which padding class to drop.
- `column.triggerClass` replaces the padding outright and **wins over** the shorthand.
- `triggerClass` is already this addon's name for a trigger's classes (`country-select`, `visible-column-picker`, `dropdown-button`, `content-panel`), so nothing new is invented.

**Default output is unchanged**, so no existing table shifts. `py-0` is generated: Tailwind's content globs include `./addon/**/*.{hbs,js}`, which covers the getter.

## Tests

Five: the default padding, the compact shorthand, an explicit `triggerClass`, the precedence between them, and the layout classes surviving either way.

**Full suite 4980 pass / 0 fail / 0 skip.** The component has zero uncovered statements.

## One thing worth knowing before the coverage gate is tightened

While verifying this I ran `test:coverage` twice on identical code. Both runs were fully green, and the totals differed:

| | run A | run B |
|---|---|---|
| statements | 8479 / 9049 (93.70%) | 8477 / 9049 (93.67%) |
| lines | 8053 / 8558 (94.09%) | 8051 / 8558 (94.07%) |

A per-file diff of the two artifacts names exactly one culprit: `addon/components/layout/sidebar.js`, at 201 covered statements in one run and 199 in the other. Every other file is identical between them.

That's the timing-sensitive component already flagged as #129 — its work is spread across `later`, `next` and resize observation, so whether a statement runs before the test settles is a race. The suite stays green either way, which is why it only shows up in the coverage artifact. Filed as **DEFECTS #164**: a ±0.03% wobble matters once `coverage:check` is set near the current figure, because it can pass and fail on alternating CI runs with no code change. Not fixed here — making that component's scheduling deterministic is exactly the behavioural risk #129 exists to avoid.
