### PR TITLE
Stop custom-fields-manager refetching a subject on every tab change

### DIFF
--- a/addon/components/custom-fields-manager.js
+++ b/addon/components/custom-fields-manager.js
@@ -17,6 +17,15 @@ export default class CustomFieldsManagerComponent extends Component {
     @service intl;
     @tracked subjects = [];
 
+    /**
+     * Subjects whose fields have been fetched or restored, by model name.
+     *
+     * Tab changes used to decide this from `subject.groups.length`, which cannot tell "not loaded
+     * yet" apart from "loaded, and this subject genuinely has no field groups" — so a subject with
+     * no groups was refetched every single time its tab was selected.
+     */
+    #loadedSubjects = new Set();
+
     get gridSizeOptions() {
         return [1, 2, 3];
     }
@@ -65,22 +74,34 @@ export default class CustomFieldsManagerComponent extends Component {
         // Skip the first subject as it's loaded in constructor
         const subjectsToRestore = this.subjects.slice(1);
 
+        let company;
+
+        try {
+            company = await this.currentUser.loadCompany();
+        } catch (err) {
+            console.warn('Failed to load the company, so no cached custom fields can be restored:', err);
+            return;
+        }
+
         for (const subject of subjectsToRestore) {
             try {
-                const company = await this.currentUser.loadCompany();
                 const loadOptions = {
                     groupedFor: `${underscore(subject.model)}_custom_field_group`,
                     fieldFor: subject.type,
                 };
 
-                // Check if we have a cached manager for this subject
+                // `forSubject` builds an empty manager on a miss rather than returning nothing, so
+                // whether anything was cached is decided by the groups it carries.
                 const cachedManager = this.customFieldsRegistry.forSubject(company, { loadOptions });
+                // `customFieldGroups`, not `groups`: the raw array holds the categories without
+                // their fields attached, and the load path stores the grouped form.
+                const cachedGroups = cachedManager?.customFieldGroups;
 
-                // Only restore if we have cached groups data
-                if (cachedManager && cachedManager.groups && cachedManager.groups.length > 0) {
+                if (isArray(cachedGroups) && cachedGroups.length > 0) {
                     this.#updateSubject(subject, (s) => {
-                        return { ...s, groups: cachedManager.groups };
+                        return { ...s, groups: cachedGroups };
                     });
+                    this.#loadedSubjects.add(subject.model);
                 }
             } catch (err) {
                 // Silently continue if cache restore fails for a subject
@@ -104,6 +125,7 @@ export default class CustomFieldsManagerComponent extends Component {
             this.#updateSubject(subject, (s) => {
                 return { ...s, groups: customFieldsManager.customFieldGroups };
             });
+            this.#loadedSubjects.add(subject.model);
 
             return customFieldsManager;
         } catch (err) {
@@ -204,10 +226,12 @@ export default class CustomFieldsManagerComponent extends Component {
     }
 
     @action onTabChange(subject) {
-        // Ensure custom fields are loaded when switching tabs
-        if (subject && (!subject.groups || subject.groups.length === 0)) {
-            this.loadCustomFields.perform(subject);
+        // Ensure custom fields are loaded when switching tabs, once per subject.
+        if (!subject || this.#loadedSubjects.has(subject.model)) {
+            return;
         }
+
+        this.loadCustomFields.perform(subject);
     }
 
     #addCustomFieldToGroup(subject, customField, group) {

--- a/tests/integration/components/custom-fields-manager-test.js
+++ b/tests/integration/components/custom-fields-manager-test.js
@@ -52,7 +52,7 @@ module('Integration | Component | custom-fields-manager', function (hooks) {
 
         store = { created: [] };
         modals = { shown: [], confirmed: [] };
-        registry = { edited: [], loads: [] };
+        registry = { edited: [], loads: [], cacheLookups: [] };
         notifications = { serverErrors: [] };
 
         this.owner.unregister('service:store');
@@ -117,8 +117,11 @@ module('Integration | Component | custom-fields-manager', function (hooks) {
                         return Promise.resolve({ customFieldGroups: loadedGroups });
                     },
                 };
-                forSubject() {
-                    return null;
+                // The real service never returns nothing: on a cache miss it builds an empty
+                // manager. Whether anything was cached is decided by the groups it carries.
+                forSubject(company, options) {
+                    registry.cacheLookups.push({ company, options });
+                    return { customFieldGroups: [] };
                 }
             }
         );
@@ -477,7 +480,7 @@ module('Integration | Component | custom-fields-manager', function (hooks) {
 
         test('a cached subject is restored without a second fetch', async function (assert) {
             const asked = cacheReturning(this, {
-                groups: [recordFixture({ id: 'grp_cached', name: 'Cached driver details', customFields: [{ id: 'cf_9', label: 'Licence', type: 'text' }] })],
+                customFieldGroups: [recordFixture({ id: 'grp_cached', name: 'Cached driver details', customFields: [{ id: 'cf_9', label: 'Licence', type: 'text' }] })],
             });
 
             await render(TEMPLATE);
@@ -489,12 +492,24 @@ module('Integration | Component | custom-fields-manager', function (hooks) {
         });
 
         test('a cache entry holding no groups leaves the subject alone', async function (assert) {
-            cacheReturning(this, { groups: [] });
+            cacheReturning(this, { customFieldGroups: [] });
 
             await render(TEMPLATE);
 
             assert.strictEqual(registry.loads.length, 1, 'nothing else is fetched');
             assert.notOk(this.element.textContent.includes('Cached'), 'and nothing is attached');
+        });
+
+        test('a company that will not load stops the restore before any lookup', async function (assert) {
+            // Every lookup needs the company, so failing to load it once is worth reporting once
+            // rather than per subject.
+            this.owner.lookup('service:currentUser').loadCompany = () => Promise.reject(new Error('no company'));
+            const asked = cacheReturning(this, { customFieldGroups: [] });
+
+            await render(TEMPLATE);
+
+            assert.deepEqual(asked, [], 'no subject is asked about');
+            assert.dom(this.element).containsText('Custom Fields Manager', 'and the manager still renders');
         });
 
         test('a cache lookup that throws does not stop the manager rendering', async function (assert) {
@@ -511,7 +526,7 @@ module('Integration | Component | custom-fields-manager', function (hooks) {
 
     test('switching to a tab that is already loaded does not refetch it', async function (assert) {
         this.owner.lookup('service:customFieldsRegistry').forSubject = () => ({
-            groups: [recordFixture({ id: 'grp_cached', name: 'Cached driver details', customFields: [] })],
+            customFieldGroups: [recordFixture({ id: 'grp_cached', name: 'Cached driver details', customFields: [] })],
         });
 
         await render(TEMPLATE);
@@ -521,6 +536,47 @@ module('Integration | Component | custom-fields-manager', function (hooks) {
         await click(driverTab);
 
         assert.strictEqual(registry.loads.length, 1, 'selecting it fetches nothing');
+    });
+
+    // The tab guard used to read `subject.groups.length`, which cannot tell "never fetched" apart
+    // from "fetched, and this subject has no field groups" — so an empty subject was refetched on
+    // every single tab selection.
+    module('a subject with no field groups', function () {
+        function tabFor(label) {
+            return findAll('.ui-tab, [role="tab"]').find((tab) => tab.textContent.trim().includes(label));
+        }
+
+        test('it is fetched once, however often its tab is selected', async function (assert) {
+            loadedGroups = [];
+
+            await render(TEMPLATE);
+            assert.strictEqual(registry.loads.length, 1, 'the first subject is loaded on insert');
+
+            await click(tabFor('driver'));
+            assert.strictEqual(registry.loads.length, 2, 'the second subject is fetched the first time');
+
+            await click(tabFor('order'));
+            await click(tabFor('driver'));
+            await click(tabFor('order'));
+            await click(tabFor('driver'));
+
+            assert.strictEqual(registry.loads.length, 2, 'and never again, despite having no groups to show for it');
+        });
+
+        test('a failed fetch is retried the next time the tab is selected', async function (assert) {
+            await render(TEMPLATE);
+
+            loadShouldFail = true;
+            await click(tabFor('driver'));
+            assert.strictEqual(registry.loads.length, 2, 'the fetch was attempted');
+            assert.strictEqual(notifications.serverErrors.length, 1, 'and reported');
+
+            loadShouldFail = false;
+            await click(tabFor('order'));
+            await click(tabFor('driver'));
+
+            assert.strictEqual(registry.loads.length, 3, 'a subject that failed to load is not treated as loaded');
+        });
     });
 
     test('it renders without a subjects argument at all', async function (assert) {


### PR DESCRIPTION
Decision **4**: "I verified on production that on each tab change it reloads the subject."

> Stacked on #152 (`fix/resource-identity-padding`). Review that one first.

## What you saw, and why

There are **two** causes. One was already fixed earlier in this stack; the other survives that fix, which is why this PR exists.

**Cause 1 — the wiring (already fixed, #97).** `custom-fields-manager.hbs` on `main` reads:

```hbs
<TabNavigation @tabs={{this.tabs}} @onTabChange={{perform this.loadCustomFields}} ...>
```

That performs the fetch task directly on every tab change and never reaches the `onTabChange` action where the already-loaded guard lives. So production refetches unconditionally — exactly what you observed. Fixed earlier in this stack by wiring `@onTabChange={{this.onTabChange}}`.

**Cause 2 — the guard itself (fixed here).** Even with the wiring corrected:

```js
if (subject && (!subject.groups || subject.groups.length === 0)) {
    this.loadCustomFields.perform(subject);
}
```

`groups.length === 0` cannot tell **"not fetched yet"** apart from **"fetched, and this subject genuinely has no field groups"**. Any subject without configured groups is refetched on every single tab selection, forever — the same symptom, just narrowed to empty subjects.

## The fix

Stop inferring, and record what was actually fetched:

```js
/** Subjects whose fields have been fetched or restored, by model name. */
#loadedSubjects = new Set();
```

Added to after a successful load and after a cache restore. A load that **fails** is not recorded, so the next tab selection retries it rather than silently showing an empty tab forever.

## Three things fixed in `restoreFromCache` while I was in there

| | |
|---|---|
| `await loadCompany()` ran **once per subject**, inside the loop | Hoisted. A company that won't load now reports once and stops, instead of failing identically for every subject. |
| It read `cachedManager.groups` | That's the raw category array. The load path stores `customFieldGroups`, the grouped form carrying each group's fields. Both happen to reference the same model instances today — but only because `getGroupedFields()` mutates `customFields` onto them, and only once it has run. Reading the same accessor the load path uses makes a restored tab identical to a fetched one by construction. |
| `if (cachedManager && ...)` | `forSubject` builds an empty manager on a cache miss and **never returns nothing**, so that half could not fail. Dropped. |

I checked the registry itself rather than assuming: the scope keys (`groupedFor::fieldFor`) match between the restore and load paths, and the `WeakMap` is keyed on the same company model, so the cache does resolve. It was not decorative — but a restore would have attached groups without their fields, and then `#loadedSubjects` would mark the tab done. Reading `customFieldGroups` is what makes the restore safe to trust.

## Test-double fidelity

The registry double returned `null` from `forSubject`. **The real service never does that** — it constructs a manager on a miss. It now returns an empty manager, matching the service.

## Tests

Three new:
- an empty subject is fetched once, however often its tab is selected;
- a failed fetch is retried the next time the tab is selected;
- a company that will not load stops the restore before any lookup.

The first two **fail against the previous guard** — verified by reverting `onTabChange` and re-running: 31 pass / 2 fail, both new tests. They pass against this one.

**Full suite 4983 pass / 0 fail / 0 skip.**
