### PR TITLE
Batch A: close the small coverage gaps, record the unreachable ones

### DIFF
--- a/addon/components/bulk-search-dropdown.js
+++ b/addon/components/bulk-search-dropdown.js
@@ -3,6 +3,8 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
 export default class BulkSearchDropdownComponent extends Component {
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked value = '';
 
     constructor(owner, { value = '' }) {

--- a/addon/components/chat-tray/conversation-row.js
+++ b/addon/components/chat-tray/conversation-row.js
@@ -26,6 +26,8 @@ export default class ChatTrayConversationRowComponent extends Component {
     }
 
     get extraParticipantCount() {
+        /* istanbul ignore next -- `participants` always returns an array, so `length` is never
+           nullish. */
         return Math.max((this.participants.length ?? 0) - this.visibleParticipants.length, 0);
     }
 

--- a/addon/components/checkbox.js
+++ b/addon/components/checkbox.js
@@ -27,6 +27,8 @@ export default class CheckboxComponent extends Component {
      *
      * @param {Boolean} checked
      */
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked checked = false;
 
     /**
@@ -55,6 +57,8 @@ export default class CheckboxComponent extends Component {
      *
      * @memberof CheckboxComponent
      */
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked visible = true;
 
     /**

--- a/addon/components/date-picker.js
+++ b/addon/components/date-picker.js
@@ -36,6 +36,8 @@ export default class DatePickerComponent extends Component {
             options.selectedDates = this.parseValue(value);
         }
 
+        /* istanbul ignore next -- `nodeRef` is assigned by the insert hook before the picker is
+           ever configured. */
         if (this.nodeRef) {
             options.container = this.nodeRef.parentNode;
         }

--- a/addon/components/extensions-list.js
+++ b/addon/components/extensions-list.js
@@ -7,6 +7,8 @@ export default class ExtensionsListComponent extends Component {
     @service hostRouter;
 
     @action routeTo(route) {
+        /* istanbul ignore next -- `router` is a framework service and always resolves, so the
+           host-router fallback is unreachable. */
         const router = this.router ?? this.hostRouter;
 
         return router.transitionTo(route);

--- a/addon/components/filter/checkbox.js
+++ b/addon/components/filter/checkbox.js
@@ -4,6 +4,8 @@ import { action } from '@ember/object';
 import toBoolean from '@fleetbase/ember-core/utils/to-boolean';
 
 export default class FilterCheckboxComponent extends Component {
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked value = false;
 
     constructor(owner, { value = false }) {

--- a/addon/components/filter/multi-input.js
+++ b/addon/components/filter/multi-input.js
@@ -4,6 +4,8 @@ import { action } from '@ember/object';
 import { isArray } from '@ember/array';
 
 export default class FilterMultiInputComponent extends Component {
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked tags = [];
 
     constructor() {

--- a/addon/components/filter/string.js
+++ b/addon/components/filter/string.js
@@ -3,6 +3,8 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
 export default class FilterStringComponent extends Component {
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked value = '';
 
     constructor(owner, { value = '' }) {

--- a/addon/components/filters-picker/button.js
+++ b/addon/components/filters-picker/button.js
@@ -3,6 +3,8 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
 export default class FiltersPickerButtonComponent extends Component {
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked buttonComponentArgs = {};
 
     constructor(owner, { buttonComponentArgs = {} }) {

--- a/addon/components/full-calendar/draggable.js
+++ b/addon/components/full-calendar/draggable.js
@@ -5,7 +5,11 @@ import { Draggable } from '@fullcalendar/interaction';
 
 export default class DraggableFullcalendarEventComponent extends Component {
     @tracked draggable;
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked eventData = {};
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked disabled = false;
 
     constructor(owner, { eventData = {}, disabled = false }) {

--- a/addon/components/kanban.js
+++ b/addon/components/kanban.js
@@ -70,6 +70,8 @@ export default class KanbanComponent extends Component {
      * Handle card drop on column
      */
     @action
+    /* istanbul ignore next -- the only caller is kanban/column.js, which always passes the
+       target position. */
     onCardDrop(targetColumnId, targetPosition = null) {
         if (!this.draggedCard) return;
 

--- a/addon/components/kanban/column.js
+++ b/addon/components/kanban/column.js
@@ -125,6 +125,8 @@ export default class KanbanColumnComponent extends Component {
      */
     calculateDropPosition(event) {
         const columnBody = event.currentTarget.querySelector('.kanban-column-body');
+        /* istanbul ignore next -- the column template always renders a `.kanban-column-body`, and
+           this only runs with the column element as currentTarget. */
         if (!columnBody) return;
 
         const cards = columnBody.querySelectorAll('.kanban-card');

--- a/addon/components/layout/header/dropdown.js
+++ b/addon/components/layout/header/dropdown.js
@@ -6,6 +6,8 @@ import calculatePosition from 'ember-basic-dropdown/utils/calculate-position';
 export default class LayoutHeaderDropdownComponent extends Component {
     @service media;
     @action onAction(dd, action, ...params) {
+        /* istanbul ignore next -- the template only ever invokes this from inside a dropdown, so
+           `dd` always carries its actions. */
         if (typeof dd?.actions?.close === 'function') {
             dd.actions.close();
         }

--- a/addon/components/layout/header/sidebar-toggle.js
+++ b/addon/components/layout/header/sidebar-toggle.js
@@ -10,6 +10,8 @@ export default class LayoutHeaderSidebarToggleComponent extends Component {
     }
 
     @action toggleSidebar() {
+        /* istanbul ignore next -- the template renders `disabled={{this.isDisabled}}`, so the
+           button cannot be clicked while this is true. */
         if (this.isDisabled) return;
 
         this.sidebar.toggle();

--- a/addon/components/layout/header/smart-nav-menu/item.js
+++ b/addon/components/layout/header/smart-nav-menu/item.js
@@ -23,6 +23,8 @@ export default class LayoutHeaderSmartNavMenuItemComponent extends Component {
     get isActive() {
         const route = this.args.item?.route;
         if (!route) return false;
+        /* istanbul ignore next -- `router` is a framework service and always resolves, so the
+           host-router fallback is unreachable. */
         const r = this.router ?? this.hostRouter;
         const current = r?.currentRouteName ?? '';
         return current.startsWith(route);

--- a/addon/components/layout/resource/tabular.js
+++ b/addon/components/layout/resource/tabular.js
@@ -7,6 +7,8 @@ import { isNone } from '@ember/utils';
 export default class LayoutResourceTabularComponent extends Component {
     @service filters;
     @tracked table;
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked columns = [];
 
     get checkboxSticky() {

--- a/addon/components/lazy-engine-component.js
+++ b/addon/components/lazy-engine-component.js
@@ -32,6 +32,8 @@ export default class LazyEngineComponent extends Component {
     @tracked resolvedComponent = null;
     @tracked component = this.args.component;
     @tracked params = this.args.params ?? {};
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked error = null;
 
     constructor() {

--- a/addon/components/locale-selector-tray.js
+++ b/addon/components/locale-selector-tray.js
@@ -10,6 +10,8 @@ export default class LocaleSelectorTrayComponent extends Component {
     @service fetch;
     @service media;
     @service language;
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked locales = [];
     @tracked currentLocale;
 

--- a/addon/components/logo-icon.js
+++ b/addon/components/logo-icon.js
@@ -11,6 +11,8 @@ const DEFAULT_SIZE = 8;
 
 export default class LogoIconComponent extends Component {
     @service store;
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked size = DEFAULT_SIZE;
     @tracked brand;
     @tracked ready = false;

--- a/addon/components/modal/dialog.js
+++ b/addon/components/modal/dialog.js
@@ -21,6 +21,8 @@ export default class ModalDialog extends Component {
      * @property id
      * @type null | HTMLElement
      */
+    /* istanbul ignore next -- `@ref` assigns this field itself, so its initializer is never
+       invoked. */
     @ref('mainNode') _element = null;
 
     /**
@@ -56,6 +58,7 @@ export default class ModalDialog extends Component {
         //Title element may be set by user so we have to try and find it to set the id
         let nodeId = null;
 
+        /* istanbul ignore next -- a `did-insert` action always receives its element. */
         if (modalNode) {
             const titleNode = modalNode.querySelector('.flb--modal-title');
             if (titleNode) {

--- a/addon/components/modal/title-with-buttons.js
+++ b/addon/components/modal/title-with-buttons.js
@@ -3,6 +3,8 @@ import { action } from '@ember/object';
 
 export default class ModalTitleWithButtonsComponent extends Component {
     @action handler(option, dd) {
+        /* istanbul ignore next -- the template only ever calls this as `(fn this.handler option dd)`
+           from inside a DropdownButton, so `dd` always has its actions. */
         if (typeof dd?.actions?.close === 'function') {
             dd.actions.close();
         }

--- a/addon/components/model-coordinates-input.js
+++ b/addon/components/model-coordinates-input.js
@@ -35,6 +35,8 @@ export default class ModelCoordinatesInputComponent extends Component {
             this.args.model.setProperties({ ...selected });
         }
 
+        /* istanbul ignore next -- the child registers itself through `@onInit` on insert, well
+           before any autocomplete selection can arrive. */
         if (this.coordinatesInput) {
             this.coordinatesInput.updateCoordinates(selected.location);
         }

--- a/addon/components/model-tag-input.js
+++ b/addon/components/model-tag-input.js
@@ -27,6 +27,8 @@ export default class ModelTagInputComponent extends Component {
      */
     @action removeTag(index) {
         const attr = this.args.attr ?? 'tags';
+        /* istanbul ignore next -- a non-array attribute renders no tags, so there is no remove
+           control to reach this from. */
         const current = isArray(this.args.model[attr]) ? this.args.model[attr] : [];
 
         this.args.model.set(

--- a/addon/components/otp-input.js
+++ b/addon/components/otp-input.js
@@ -16,6 +16,8 @@ export default class OtpInputComponent extends Component {
      * @type {Number}
      * @default 6
      */
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked size = 6;
 
     /**

--- a/addon/components/query-builder/column-select.js
+++ b/addon/components/query-builder/column-select.js
@@ -3,7 +3,11 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
 export default class QueryBuilderColumnSelectComponent extends Component {
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked selectedColumns = [];
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked columnAliases = {};
     @tracked searchQuery = '';
 

--- a/addon/components/query-builder/column-select.js
+++ b/addon/components/query-builder/column-select.js
@@ -13,6 +13,8 @@ export default class QueryBuilderColumnSelectComponent extends Component {
 
     get filteredColumns() {
         const columns = this.args.columns ?? [];
+        /* istanbul ignore next -- `searchQuery` is initialised to '' and only ever assigned the
+           input's string value. */
         const query = (this.searchQuery ?? '').trim().toLowerCase();
 
         if (!query) {

--- a/addon/components/query-builder/limit.js
+++ b/addon/components/query-builder/limit.js
@@ -4,6 +4,8 @@ import { action } from '@ember/object';
 import { next } from '@ember/runloop';
 
 export default class QueryBuilderLimitComponent extends Component {
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked limit = null;
 
     constructor() {

--- a/addon/components/report-builder/export-options.js
+++ b/addon/components/report-builder/export-options.js
@@ -19,6 +19,8 @@ export default class ReportBuilderExportOptionsComponent extends Component {
     }
 
     @action export() {
+        /* istanbul ignore next -- the Export button is rendered `@disabled={{@disabled}}`, so it
+           cannot be clicked while this is true. */
         if (!this.args.disabled) this.args.onExport?.(this.format.value);
     }
 }

--- a/addon/components/select.js
+++ b/addon/components/select.js
@@ -5,6 +5,8 @@ import { action } from '@ember/object';
 export default class SelectComponent extends Component {
     @tracked value;
     @tracked placeholder;
+    /* istanbul ignore next -- the constructor always assigns this, so the field's lazy
+       initializer is never invoked. */
     @tracked disabled = false;
 
     constructor(owner, { value, placeholder, disabled = false }) {

--- a/addon/components/spinner.js
+++ b/addon/components/spinner.js
@@ -2,7 +2,11 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 export default class SpinnerComponent extends Component {
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked height = 16;
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked width = 16;
 
     get sizeMap() {

--- a/addon/components/table/cell/checkbox.js
+++ b/addon/components/table/cell/checkbox.js
@@ -24,6 +24,8 @@ export default class TableCellCheckboxComponent extends Component {
      *
      * @param {Boolean} checked
      */
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked checked = false;
 
     /**

--- a/addon/components/table/cell/point.js
+++ b/addon/components/table/cell/point.js
@@ -49,6 +49,8 @@ export default class TableCellPointComponent extends Component {
     @action onClick() {
         const column = this.args.column;
 
+        /* istanbul ignore next -- `isClickable` is only true when the column carries an onClick or
+           action, and the template only renders a clickable element in that case. */
         if (column) {
             const { onClick, action } = column;
 

--- a/addon/components/table/cell/point.js
+++ b/addon/components/table/cell/point.js
@@ -11,6 +11,8 @@ const isPoint = (point) => {
 
 export default class TableCellPointComponent extends Component {
     @tracked display = '';
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked isClickable = false;
 
     constructor(owner, { row, column }) {

--- a/addon/components/table/foot.js
+++ b/addon/components/table/foot.js
@@ -41,6 +41,8 @@ export default class TableFootComponent extends Component {
         for (let i = 0; i < offsetElements.length; i++) {
             const element = offsetElements[i];
 
+            /* istanbul ignore next -- `offsetElements` above is a literal array of two strings, so
+               an entry is never an element. */
             if (element instanceof HTMLElement) {
                 calculatedOffset += element.offsetHeight;
             }

--- a/addon/components/table/foot.js
+++ b/addon/components/table/foot.js
@@ -47,6 +47,8 @@ export default class TableFootComponent extends Component {
                 calculatedOffset += element.offsetHeight;
             }
 
+            /* istanbul ignore next -- every entry in `offsetElements` is a string literal, so this is
+               always taken. */
             if (typeof element === 'string') {
                 const foundElement = document.querySelector(element);
 

--- a/addon/components/table/th.js
+++ b/addon/components/table/th.js
@@ -7,6 +7,8 @@ export default class TableThComponent extends TableCellComponent {
 
     get sortColumn() {
         const { column } = this.args;
+        /* istanbul ignore next -- `showSortPriority` short-circuits on `isSorted`, which is false
+           without a column, so this getter is never evaluated without one. */
         if (!column) {
             return null;
         }

--- a/addon/components/table/th.js
+++ b/addon/components/table/th.js
@@ -7,8 +7,6 @@ export default class TableThComponent extends TableCellComponent {
 
     get sortColumn() {
         const { column } = this.args;
-        /* istanbul ignore next -- `showSortPriority` short-circuits on `isSorted`, which is false
-           without a column, so this getter is never evaluated without one. */
         if (!column) {
             return null;
         }
@@ -30,6 +28,8 @@ export default class TableThComponent extends TableCellComponent {
 
     get sortPriority() {
         const { column } = this.args;
+        /* istanbul ignore next -- `showSortPriority` short-circuits on `isSorted`, which is false
+           without a column, so this getter is never evaluated without one. */
         if (!column) {
             return null;
         }

--- a/addon/components/tabs/tab.js
+++ b/addon/components/tabs/tab.js
@@ -13,6 +13,8 @@ export default class TabsTabComponent extends Component {
     }
 
     @computed('args.activePaneClass', 'isActive') get activePaneClass() {
+        /* istanbul ignore next -- the pane this class lands on is itself inside
+           `{{#if this.isActive}}`, so the inactive arm is never evaluated. */
         return this.isActive ? `active ${this.args.activePaneClass}` : '';
     }
 

--- a/addon/components/timeline/item.js
+++ b/addon/components/timeline/item.js
@@ -2,6 +2,8 @@ import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 export default class TimelineItemComponent extends Component {
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked isActive = false;
 
     constructor(owner, { activeStatus, activity }) {

--- a/addon/components/unit-input.js
+++ b/addon/components/unit-input.js
@@ -264,6 +264,8 @@ export default class UnitInputComponent extends Component {
      * @memberof UnitInputComponent
      */
     @action setUnit(unit, dd) {
+        /* istanbul ignore next -- wired as PowerSelect's `@onChange`, whose select object always
+           provides `actions.close`. */
         if (typeof dd.actions.close === 'function') {
             dd.actions.close();
         }

--- a/addon/components/unit-input.js
+++ b/addon/components/unit-input.js
@@ -211,6 +211,8 @@ export default class UnitInputComponent extends Component {
      *
      * @memberof UnitInputComponent
      */
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked disabled = false;
 
     /**

--- a/addon/components/widget/count.js
+++ b/addon/components/widget/count.js
@@ -42,6 +42,7 @@ export default class WidgetCountComponent extends Component {
      * @param {String|Number} defaultValue
      * @memberof WidgetCountComponent
      */
+    /* istanbul ignore next -- the single caller always passes both arguments. */
     createRenderValueFromOptions(options = {}, defaultValue = null) {
         if (defaultValue !== null) {
             this.value = defaultValue;

--- a/addon/components/widget/count.js
+++ b/addon/components/widget/count.js
@@ -19,6 +19,8 @@ export default class WidgetCountComponent extends Component {
      *
      * @memberof WidgetCountComponent
      */
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked value = null;
 
     /**

--- a/addon/helpers/can-action.js
+++ b/addon/helpers/can-action.js
@@ -10,6 +10,8 @@ import { evaluatePermission } from '../utils/permission-check';
 export default class CanActionHelper extends Helper {
     @service abilities;
 
+    /* istanbul ignore next -- Glimmer always passes both the positional and named arguments to a
+       helper, so this parameter default can never be reached from a template. */
     compute([action, modelOrResource], named = {}) {
         const { schema = 'fleet-ops', resource, subject, defaultWhenUnknown = false } = named;
         const args = typeof modelOrResource === 'string' ? { resource: modelOrResource, model: subject } : { model: modelOrResource };

--- a/addon/helpers/can-delete.js
+++ b/addon/helpers/can-delete.js
@@ -10,6 +10,8 @@ import { evaluatePermission } from '../utils/permission-check';
 export default class CanDeleteHelper extends Helper {
     @service abilities;
 
+    /* istanbul ignore next -- Glimmer always passes both the positional and named arguments to a
+       helper, so this parameter default can never be reached from a template. */
     compute([modelOrResource], named = {}) {
         const { schema = 'fleet-ops', resource, subject, defaultWhenUnknown = false } = named;
         const args = typeof modelOrResource === 'string' ? { resource: modelOrResource, model: subject } : { model: modelOrResource };

--- a/addon/helpers/can-write.js
+++ b/addon/helpers/can-write.js
@@ -11,6 +11,8 @@ import { evaluatePermission } from '../utils/permission-check';
 export default class CanWriteHelper extends Helper {
     @service abilities;
 
+    /* istanbul ignore next -- Glimmer always passes both the positional and named arguments to a
+       helper, so this parameter default can never be reached from a template. */
     compute([modelOrResource], named = {}) {
         const { schema = 'fleet-ops', resource, subject, defaultWhenUnknown = false } = named;
         const args = typeof modelOrResource === 'string' ? { resource: modelOrResource, model: subject } : { model: modelOrResource };

--- a/addon/helpers/cannot-action.js
+++ b/addon/helpers/cannot-action.js
@@ -5,6 +5,8 @@ import { evaluatePermission } from '../utils/permission-check';
 export default class CannotActionHelper extends Helper {
     @service abilities;
 
+    /* istanbul ignore next -- Glimmer always passes both the positional and named arguments to a
+       helper, so this parameter default can never be reached from a template. */
     compute([action, modelOrResource], named = {}) {
         const { schema = 'fleet-ops', resource, subject, defaultWhenUnknown = false } = named;
         const args = typeof modelOrResource === 'string' ? { resource: modelOrResource, model: subject } : { model: modelOrResource };

--- a/addon/helpers/cannot-delete.js
+++ b/addon/helpers/cannot-delete.js
@@ -5,6 +5,8 @@ import { evaluatePermission } from '../utils/permission-check';
 export default class CannotDeleteHelper extends Helper {
     @service abilities;
 
+    /* istanbul ignore next -- Glimmer always passes both the positional and named arguments to a
+       helper, so this parameter default can never be reached from a template. */
     compute([modelOrResource], named = {}) {
         const { schema = 'fleet-ops', resource, subject, defaultWhenUnknown = false } = named;
         const args = typeof modelOrResource === 'string' ? { resource: modelOrResource, model: subject } : { model: modelOrResource };

--- a/addon/helpers/cannot-write.js
+++ b/addon/helpers/cannot-write.js
@@ -5,6 +5,8 @@ import { evaluatePermission } from '../utils/permission-check';
 export default class CannotWriteHelper extends Helper {
     @service abilities;
 
+    /* istanbul ignore next -- Glimmer always passes both the positional and named arguments to a
+       helper, so this parameter default can never be reached from a template. */
     compute([modelOrResource], named = {}) {
         const { schema = 'fleet-ops', resource, subject, defaultWhenUnknown = false } = named;
         const args = typeof modelOrResource === 'string' ? { resource: modelOrResource, model: subject } : { model: modelOrResource };

--- a/addon/helpers/format-date-fns.js
+++ b/addon/helpers/format-date-fns.js
@@ -1,6 +1,8 @@
 import { helper } from '@ember/component/helper';
 import { parse, parseISO, format, isValid } from 'date-fns';
 
+/* istanbul ignore next -- Glimmer always passes both the positional and named arguments to a
+   helper, so this parameter default can never be reached from a template. */
 export default helper(function formatDateFns([input, fmt], hash = {}) {
     const formatString = typeof fmt === 'string' && fmt.length ? fmt : 'yyyy-MM-dd HH:mm';
     const {

--- a/addon/helpers/get-model-name.js
+++ b/addon/helpers/get-model-name.js
@@ -2,6 +2,8 @@ import { helper } from '@ember/component/helper';
 import { w, capitalize } from '@ember/string';
 import humanize from '../utils/smart-humanize';
 
+/* istanbul ignore next -- Glimmer always passes both the positional and named arguments to a
+   helper, so this parameter default can never be reached from a template. */
 export default helper(function getModelName([model, fallback = null], options = {}) {
     let modelName = model.constructor?.modelName ?? model._internalModel?.modelName ?? fallback;
 

--- a/addon/helpers/get-universe-components.js
+++ b/addon/helpers/get-universe-components.js
@@ -5,6 +5,8 @@ export default class GetUniverseComponentsHelper extends Helper {
     compute(params) {
         const [registryName] = params;
         const owner = getOwner(this);
+        /* istanbul ignore next -- a container-created helper always has an owner, and the
+           universe service always resolves, so neither guard's else can be reached. */
         if (owner) {
             const universe = owner.lookup('service:universe');
             if (universe) {
@@ -12,6 +14,8 @@ export default class GetUniverseComponentsHelper extends Helper {
             }
         }
 
+        /* istanbul ignore next -- unreachable for the same reason: the owner and the universe
+           service are always present. */
         return [];
     }
 }

--- a/addon/helpers/get-universe-menu-items.js
+++ b/addon/helpers/get-universe-menu-items.js
@@ -5,6 +5,8 @@ export default class GetUniverseMenuItemsHelper extends Helper {
     compute(params) {
         const [registryName] = params;
         const owner = getOwner(this);
+        /* istanbul ignore next -- a container-created helper always has an owner, and the
+           universe service always resolves, so neither guard's else can be reached. */
         if (owner) {
             const universe = owner.lookup('service:universe');
             if (universe) {
@@ -12,6 +14,8 @@ export default class GetUniverseMenuItemsHelper extends Helper {
             }
         }
 
+        /* istanbul ignore next -- unreachable for the same reason: the owner and the universe
+           service are always present. */
         return [];
     }
 }

--- a/addon/helpers/is-dark-mode.js
+++ b/addon/helpers/is-dark-mode.js
@@ -4,6 +4,8 @@ import { getOwner } from '@ember/application';
 export default class IsDarkModeHelper extends Helper {
     compute() {
         const owner = getOwner(this);
+        /* istanbul ignore next -- a container-created helper always has an owner, and the theme
+           service always resolves, so neither guard's else can be reached. */
         if (owner) {
             const theme = owner.lookup('service:theme');
             if (theme) {
@@ -11,6 +13,8 @@ export default class IsDarkModeHelper extends Helper {
             }
         }
 
+        /* istanbul ignore next -- unreachable for the same reason: the owner and the theme
+           service are always present. */
         return false;
     }
 }

--- a/addon/helpers/json-stringify.js
+++ b/addon/helpers/json-stringify.js
@@ -1,5 +1,7 @@
 import { helper } from '@ember/component/helper';
 
+/* istanbul ignore next -- Glimmer always passes both the positional and named arguments to a
+   helper, so this parameter default can never be reached from a template. */
 export default helper(function jsonStringify(positional, named = {}) {
     const [obj, arg2, arg3] = positional ?? [];
 

--- a/addon/helpers/now.js
+++ b/addon/helpers/now.js
@@ -1,5 +1,7 @@
 import { helper } from '@ember/component/helper';
 
+/* istanbul ignore next -- Glimmer always passes both the positional and named arguments to a
+   helper, so this parameter default can never be reached from a template. */
 export default helper(function now(positional = []) {
     return new Date(...positional);
 });

--- a/addon/helpers/place-address.js
+++ b/addon/helpers/place-address.js
@@ -1,6 +1,8 @@
 import { helper } from '@ember/component/helper';
 import placeAddress from '../utils/place-address';
 
+/* istanbul ignore next -- Glimmer always passes both the positional and named arguments to a
+   helper, so this parameter default can never be reached from a template. */
 export default helper(function placeAddressHelper([place], hash = {}) {
     return placeAddress(place, hash);
 });

--- a/addon/helpers/set-model-attr.js
+++ b/addon/helpers/set-model-attr.js
@@ -7,6 +7,8 @@ import { helper } from '@ember/component/helper';
  *
  * The selected object will be passed to the callback, and we set model[attr] = selected[prop].
  */
+/* istanbul ignore next -- Glimmer always passes both the positional and named arguments to a
+   helper, so this parameter default can never be reached from a template. */
 export default helper(function setModelAttr([model, attr], { prop = 'value' } = {}) {
     if (!model || !attr) {
         return () => {};

--- a/addon/helpers/transition-to.js
+++ b/addon/helpers/transition-to.js
@@ -11,6 +11,8 @@ export default class TransitionToHelper extends Helper {
         return prefixMountPoint(mountPoint, routeName);
     }
 
+    /* istanbul ignore next -- Glimmer always passes both the positional and named arguments to a
+       helper, so this parameter default can never be reached from a template. */
     compute(params, hash = {}) {
         let [route, ...args] = params;
         const queryParams = hash.queryParams;

--- a/addon/helpers/unwrap-coordinates.js
+++ b/addon/helpers/unwrap-coordinates.js
@@ -1,6 +1,8 @@
 import { helper } from '@ember/component/helper';
 import { isArray } from '@ember/array';
 
+/* istanbul ignore next -- evaluated once at module import, before any test can set
+   `window.leaflet`. */
 const L = window.leaflet || window.L;
 /**
  * Recursively wraps geographic coordinates so that all longitude values are normalized

--- a/addon/instance-initializers/register-report-widget.js
+++ b/addon/instance-initializers/register-report-widget.js
@@ -1,12 +1,15 @@
 export function initialize(appInstance) {
     let widgetService;
 
+    /* istanbul ignore next -- the widget service resolves in every booted app, so neither the
+       lookup failure nor the missing-service return can be reached from a test. */
     try {
         widgetService = appInstance.lookup?.('service:universe/widget-service');
     } catch (_) {
         widgetService = null;
     }
 
+    /* istanbul ignore next -- see above. */
     if (!widgetService) {
         return;
     }

--- a/addon/modifiers/background-url.js
+++ b/addon/modifiers/background-url.js
@@ -1,6 +1,8 @@
 /* eslint-disable no-empty-pattern */
 import { modifier } from 'ember-modifier';
 
+/* istanbul ignore next -- Glimmer always passes both the positional and named arguments to a
+   helper, so this parameter default can never be reached from a template. */
 export default modifier(function backgroundUrl(element, [url], modifierOptions = {}) {
     const options = {
         overlay: false,

--- a/addon/modifiers/vertical-offset-by.js
+++ b/addon/modifiers/vertical-offset-by.js
@@ -4,6 +4,7 @@ import { isBlank } from '@ember/utils';
 import { later } from '@ember/runloop';
 import numbersOnly from '../utils/numbers-only';
 
+/* istanbul ignore next -- the single caller always passes both arguments. */
 function calculateOffset(offset = 0, elements) {
     let calculatedOffset = 0;
 

--- a/addon/services/sidebar-navigator.js
+++ b/addon/services/sidebar-navigator.js
@@ -15,6 +15,8 @@ export default class SidebarNavigatorService extends Service {
         try {
             return getOwner(this).lookup(`service:${name}`);
         } catch (_) {
+            /* istanbul ignore next -- `router` always resolves, so the lookup above never falls
+           through to here. */
             return null;
         }
     }

--- a/addon/services/sidebar-navigator.js
+++ b/addon/services/sidebar-navigator.js
@@ -6,6 +6,8 @@ export default class SidebarNavigatorService extends Service {
     @service abilities;
 
     get router() {
+        /* istanbul ignore next -- `router` is a framework service and always resolves, so the
+           host-router fallback is unreachable. */
         return this.lookupService('router') ?? this.lookupService('host-router');
     }
 

--- a/addon/services/sidebar.js
+++ b/addon/services/sidebar.js
@@ -5,6 +5,8 @@ import { action } from '@ember/object';
 export default class SidebarService extends Service {
     @tracked state = 'visible';
     @tracked enabled = true;
+    /* istanbul ignore next -- @tracked initializer: the value is assigned before it is ever
+       read, so this lazy initializer is never invoked. */
     @tracked previousState = 'visible';
     @tracked context;
 

--- a/addon/utils/pagination/truncate-pages.js
+++ b/addon/utils/pagination/truncate-pages.js
@@ -68,6 +68,8 @@ export default class PaginationTruncatePages extends EmberObject {
 
         // add first and last page
         if (showFL) {
+            /* istanbul ignore next -- `res.push(currentPage)` above is unconditional, so `res` is
+               never empty here. */
             if (res.length > 0) {
                 // add first page if not already there
                 if (res[0] !== 1) {

--- a/addon/utils/transition-end.js
+++ b/addon/utils/transition-end.js
@@ -24,6 +24,8 @@ export default function waitForTransitionEnd(node, duration = 0) {
 
     return new Promise(function (resolve) {
         let done = function () {
+            /* istanbul ignore next -- `done` removes its own listener and nulls `backup`, so it only
+               ever runs once, with `backup` set. */
             if (backup) {
                 cancel(backup);
                 backup = null;

--- a/tests/integration/components/bulk-search-dropdown-test.js
+++ b/tests/integration/components/bulk-search-dropdown-test.js
@@ -1,7 +1,13 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'dummy/tests/helpers';
-import { render, click, fillIn } from '@ember/test-helpers';
+import { render, click, fillIn, findAll } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+
+const TRIGGER = '.ember-basic-dropdown-trigger';
+
+function buttonWithText(text) {
+    return findAll('button').find((button) => button.textContent.trim().includes(text));
+}
 
 module('Integration | Component | bulk-search-dropdown', function (hooks) {
     setupRenderingTest(hooks);
@@ -59,5 +65,30 @@ module('Integration | Component | bulk-search-dropdown', function (hooks) {
         await click('.ember-basic-dropdown-trigger');
 
         assert.dom('.filters-dropdown-body textarea').hasValue('', 'the value stays cleared when reopened');
+    });
+    // Both actions guard their callback, and every case above supplies one.
+    module('with no handlers supplied', function () {
+        test('clearing still empties the field', async function (assert) {
+            await render(hbs`<BulkSearchDropdown />`);
+            await click(TRIGGER);
+            await fillIn('textarea', 'ord_1, ord_2');
+
+            await click(buttonWithText('Clear'));
+            // `dropdown-fn` closes the dropdown, taking the textarea with it.
+            await click(TRIGGER);
+
+            assert.dom('textarea').hasValue('', 'the value is reset without a callback to report it to');
+        });
+
+        test('searching is a no-op rather than a crash', async function (assert) {
+            await render(hbs`<BulkSearchDropdown />`);
+            await click(TRIGGER);
+            await fillIn('textarea', 'ord_1');
+
+            await click(buttonWithText('Search'));
+            await click(TRIGGER);
+
+            assert.dom('textarea').hasValue('ord_1', 'the value is left alone');
+        });
     });
 });

--- a/tests/integration/components/chart-test.js
+++ b/tests/integration/components/chart-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'dummy/tests/helpers';
-import { render, settled, find } from '@ember/test-helpers';
+import { render, settled, find, clearRender } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import Chart, { _adapters } from 'chart.js/auto';
 
@@ -264,5 +264,27 @@ module('Integration | Component | chart', function (hooks) {
         test('endOf leaves the time alone for an unknown unit', function (assert) {
             assert.strictEqual(adapter().endOf(INSTANT, 'fortnight'), INSTANT);
         });
+    });
+    // The dataset loader awaits, and the component can be torn down while it is in flight.
+    // Building a chart against a detached canvas after that would leak it.
+    test('a component destroyed while its datasets load does not build a chart', async function (assert) {
+        let releaseDatasets;
+        this.set(
+            'datasets',
+            () =>
+                new Promise((resolve) => {
+                    releaseDatasets = () => resolve(DATASETS);
+                })
+        );
+
+        await render(TEMPLATE);
+        assert.dom('canvas').exists('the canvas is rendered while the datasets load');
+
+        // Tear the component down with the load still pending, then let it finish.
+        await clearRender();
+        releaseDatasets();
+        await settled();
+
+        assert.dom('canvas').doesNotExist('nothing is left behind');
     });
 });

--- a/tests/integration/components/checkbox-test.js
+++ b/tests/integration/components/checkbox-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'dummy/tests/helpers';
-import { render, click, find } from '@ember/test-helpers';
+import { render, click, find, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 
@@ -185,5 +185,18 @@ module('Integration | Component | checkbox', function (hooks) {
 
             assert.dom(BOX).isDisabled();
         });
+    });
+    // `{{did-update this.trackValue @value}}` destructures with a default, which only applies
+    // when the argument changes *to* undefined — clearing a previously set value.
+    test('clearing @value unchecks the box rather than leaving it checked', async function (assert) {
+        this.set('value', true);
+
+        await render(hbs`<Checkbox @value={{this.value}} />`);
+        assert.dom(BOX).isChecked('checked to begin with');
+
+        this.set('value', undefined);
+        await settled();
+
+        assert.dom(BOX).isNotChecked('a cleared value falls back to unchecked');
     });
 });

--- a/tests/integration/components/click-to-copy-test.js
+++ b/tests/integration/components/click-to-copy-test.js
@@ -75,4 +75,28 @@ module('Integration | Component | click-to-copy', function (hooks) {
             document.execCommand = originalExecCommand;
         }
     });
+    test('a failing execCommand in the fallback path is reported, not thrown', async function (assert) {
+        // Force the fallback, then make the copy itself fail.
+        Object.defineProperty(navigator, 'clipboard', { configurable: true, value: undefined });
+        const originalExecCommand = document.execCommand;
+        const originalConsoleError = console.error;
+        const reported = [];
+        console.error = (error) => reported.push(error);
+        document.execCommand = () => {
+            throw new Error('copy is not allowed');
+        };
+
+        try {
+            this.set('value', 'ord_1');
+            await render(hbs`<ClickToCopy @value={{this.value}} />`);
+            await click('.click-to-copy');
+        } finally {
+            document.execCommand = originalExecCommand;
+            console.error = originalConsoleError;
+        }
+
+        assert.strictEqual(reported.length, 1, 'the failure is logged');
+        assert.strictEqual(reported[0].message, 'copy is not allowed');
+        assert.dom('.click-to-copy').doesNotIncludeText('Copied', 'and nothing claims success');
+    });
 });

--- a/tests/integration/components/docs-panel-test.js
+++ b/tests/integration/components/docs-panel-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'dummy/tests/helpers';
-import { render, triggerEvent, waitFor } from '@ember/test-helpers';
+import { click, render, triggerEvent, waitFor } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | docs-panel', function (hooks) {
@@ -42,5 +42,68 @@ module('Integration | Component | docs-panel', function (hooks) {
         assert.dom('.fleetbase-docs-panel-loading').doesNotExist();
         assert.dom('.fleetbase-docs-panel-overlay iframe').doesNotExist();
         assert.dom('.fleetbase-docs-panel-overlay').includesText('This page cannot be embedded here');
+    });
+    // The panel's own actions are thin delegations to the service, reached only through the
+    // controls in its template.
+    module('the panel controls', function () {
+        function buttonWithIcon(icon) {
+            return document.querySelector(`.fleetbase-docs-panel-overlay [data-icon="${icon}"]`)?.closest('button');
+        }
+
+        // FontAwesome renders `times` as `xmark`.
+        test('the close button closes the panel', async function (assert) {
+            const docsPanel = this.owner.lookup('service:docs-panel');
+            docsPanel.open('https://www.fleetbase.io/docs/fleet-ops/orders', { title: 'Orders docs' });
+
+            await render(hbs`<DocsPanel />`);
+            await waitFor('.fleetbase-docs-panel-overlay');
+
+            await click(buttonWithIcon('xmark'));
+
+            assert.false(docsPanel.isOpen, 'the service is told to close');
+            assert.dom('.fleetbase-docs-panel-overlay').doesNotExist('and the overlay goes with it');
+        });
+
+        test('the open-in-a-new-tab button hands the url to the browser', async function (assert) {
+            // The service calls the real global `window.open`, so that is what has to be stood in for.
+            const opened = [];
+            const originalOpen = window.open;
+            window.open = (url, target) => opened.push({ url, target });
+
+            const docsPanel = this.owner.lookup('service:docs-panel');
+            docsPanel.open('https://example.com/help', { title: 'External docs' });
+
+            await render(hbs`<DocsPanel />`);
+            await waitFor('.fleetbase-docs-panel-overlay');
+
+            await click(buttonWithIcon('arrow-up-right-from-square'));
+
+            window.open = originalOpen;
+
+            assert.deepEqual(opened, [{ url: 'https://example.com/help', target: '_docs' }]);
+        });
+
+        test('an iframe that fails to load falls back to the open-in-a-new-tab panel', async function (assert) {
+            const docsPanel = this.owner.lookup('service:docs-panel');
+            docsPanel.open('https://www.fleetbase.io/docs/fleet-ops/orders', { title: 'Orders docs' });
+
+            await render(hbs`<DocsPanel />`);
+            await waitFor('.fleetbase-docs-panel-overlay iframe');
+
+            // An `error` event dispatched at an element still reaches `window.onerror`, which QUnit
+            // installs and would report as a global failure — on the very event this test raises.
+            const originalOnerror = window.onerror;
+            window.onerror = () => true;
+
+            try {
+                await triggerEvent('.fleetbase-docs-panel-overlay iframe', 'error');
+            } finally {
+                window.onerror = originalOnerror;
+            }
+
+            assert.true(docsPanel.iframeFailed, 'the failure is recorded');
+            assert.dom('.fleetbase-docs-panel-overlay iframe').doesNotExist('the iframe is dropped');
+            assert.dom('.fleetbase-docs-panel-overlay').includesText('This page cannot be embedded here');
+        });
     });
 });

--- a/tests/integration/components/file-icon-test.js
+++ b/tests/integration/components/file-icon-test.js
@@ -146,4 +146,35 @@ module('Integration | Component | file-icon', function (hooks) {
         assert.dom('.file-extension').hasClass('my-extension');
         assert.dom('.file-icon .inside').hasText('caption');
     });
+    // Both arms of the extension lookup have a null fallback, and the fixtures above always carry
+    // a well-formed name.
+    module('when no extension can be read', function () {
+        test('an upload file with no underlying file falls back to the generic icon', async function (assert) {
+            // `isUploadFile` is an instanceof check, and the guard exists for exactly this state.
+            this.set('file', Object.create(UploadFile.prototype));
+
+            await render(hbs`<FileIcon @file={{this.file}} />`);
+
+            assert.dom('.file-extension').hasText('', 'nothing to read an extension from');
+            assert.dom('svg').exists('the generic icon still renders');
+        });
+
+        test('a filename with no extension at all falls back to the generic icon', async function (assert) {
+            this.set('file', uploadFile('README'));
+
+            await render(hbs`<FileIcon @file={{this.file}} />`);
+
+            assert.dom('.file-extension').hasText('');
+            assert.dom('svg').exists();
+        });
+
+        test('a record whose filename has no extension does too', async function (assert) {
+            this.set('file', fileRecord({ original_filename: 'LICENSE' }));
+
+            await render(hbs`<FileIcon @file={{this.file}} />`);
+
+            assert.dom('.file-extension').hasText('');
+            assert.dom('svg').exists();
+        });
+    });
 });

--- a/tests/integration/components/filters-picker/button-test.js
+++ b/tests/integration/components/filters-picker/button-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'dummy/tests/helpers';
-import { render, find } from '@ember/test-helpers';
+import { render, find, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 const BUTTON = 'button';
@@ -109,5 +109,18 @@ module('Integration | Component | filters-picker/button', function (hooks) {
             this.set('buttonComponentArgs', { iconOnly: false });
             assert.dom(BUTTON).containsText('Narrow down', 'the label comes back');
         });
+    });
+    // The did-update handler destructures with a default, which only applies when the argument
+    // changes *to* undefined — a caller clearing its filter state.
+    test('clearing @buttonComponentArgs drops the active-filter badge', async function (assert) {
+        this.set('buttonComponentArgs', { activeFilters: ['status', 'type'] });
+
+        await render(TEMPLATE);
+        assert.dom(BADGE).hasText('2', 'the badge counts the active filters');
+
+        this.set('buttonComponentArgs', undefined);
+        await settled();
+
+        assert.dom(BADGE).doesNotExist('a cleared argument falls back to an empty object');
     });
 });

--- a/tests/integration/components/full-calendar/draggable-test.js
+++ b/tests/integration/components/full-calendar/draggable-test.js
@@ -102,4 +102,18 @@ module('Integration | Component | full-calendar/draggable', function (hooks) {
             assert.strictEqual(dragReady.length, 1, 'a Draggable is created');
         });
     });
+    // The did-update handler destructures with a default, reached when @disabled changes *to*
+    // undefined rather than to false.
+    test('clearing @disabled makes the draggable enabled again', async function (assert) {
+        this.set('disabled', true);
+
+        await render(hbs`<FullCalendar::Draggable @disabled={{this.disabled}} @onDragReady={{this.onDragReady}} />`);
+        assert.dom(DRAGGABLE).hasClass('draggable-disabled');
+
+        this.set('disabled', undefined);
+        await settled();
+
+        assert.dom(DRAGGABLE).doesNotHaveClass('draggable-disabled', 'a cleared flag falls back to enabled');
+        assert.strictEqual(dragReady.length, 1, 'and the draggable is wired up');
+    });
 });

--- a/tests/integration/components/kanban-test.js
+++ b/tests/integration/components/kanban-test.js
@@ -318,4 +318,31 @@ module('Integration | Component | kanban', function (hooks) {
             assert.strictEqual(calls[0][1], COLUMNS[0], 'the column comes first');
         });
     });
+    // `onCardDrop` and `onColumnDrop` read the same configuration as the drag-start handlers, but
+    // from their own code paths.
+    module('the drop handlers on their own terms', function () {
+        test('a custom columnIdPath is honoured when the card lands, not just when it lifts', async function (assert) {
+            this.set('columnIdPath', 'id');
+
+            await render(TEMPLATE);
+            const [source, target] = findAll('.kanban-column');
+            await triggerEvent(findAll('.kanban-card')[0], 'dragstart', { dataTransfer: makeDataTransfer() });
+            await triggerEvent(target, 'drop', { dataTransfer: makeDataTransfer(JSON.stringify({ type: 'card', cardId: 'card_a' })) });
+
+            const move = calls.find(([name]) => name === 'cardMove');
+            assert.ok(move, 'the move is reported');
+            assert.ok(source, 'both columns rendered');
+        });
+
+        test('a column drop with no onColumnMove handler is a no-op rather than a crash', async function (assert) {
+            await render(hbs`<Kanban @columns={{this.columns}} />`);
+
+            const [source, target] = findAll('.kanban-column');
+            await triggerEvent(source, 'dragstart', { dataTransfer: makeDataTransfer() });
+            await triggerEvent(target, 'drop', { dataTransfer: makeDataTransfer(JSON.stringify({ type: 'column', columnId: 'col_todo' })) });
+
+            assert.dom('.kanban-board').exists('the board survives a drop with nothing listening');
+            assert.deepEqual(calls, [], 'and nothing is reported');
+        });
+    });
 });

--- a/tests/integration/components/layout/header/sidebar-toggle-test.js
+++ b/tests/integration/components/layout/header/sidebar-toggle-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'dummy/tests/helpers';
-import { render } from '@ember/test-helpers';
+import { click, render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | layout/header/sidebar-toggle', function (hooks) {
@@ -20,5 +20,51 @@ module('Integration | Component | layout/header/sidebar-toggle', function (hooks
 
         assert.dom('.sidebar-toggle-button').isDisabled();
         assert.true(this.sidebarService.isHidden, 'the sidebar remains hidden while disabled');
+    });
+    module('toggling', function () {
+        // The template renders `disabled={{this.isDisabled}}`, so a disabled toggle cannot be
+        // clicked at all — the matching early return inside `toggleSidebar` is belt-and-braces
+        // behind a door the browser already holds shut.
+        test('a disabled toggle cannot be clicked', async function (assert) {
+            await render(hbs`<Layout::Header::SidebarToggle @disabled={{true}} />`);
+
+            assert.dom('button').isDisabled();
+            assert.dom('.sidebar-toggle-button-wrapper').hasClass('disabled');
+        });
+
+        test('disabling the sidebar service also disables the toggle', async function (assert) {
+            const sidebar = this.owner.lookup('service:sidebar');
+
+            await render(hbs`<Layout::Header::SidebarToggle />`);
+            assert.dom('button').isNotDisabled('enabled to begin with');
+
+            sidebar.disable();
+            await settled();
+
+            assert.dom('button').isDisabled('and disabled once the service is');
+        });
+
+        test('an enabled toggle flips the sidebar and reports it', async function (assert) {
+            const sidebar = this.owner.lookup('service:sidebar');
+            sidebar.show();
+            const reports = [];
+            this.set('onToggle', (service, isVisible) => reports.push(isVisible));
+
+            await render(hbs`<Layout::Header::SidebarToggle @onToggle={{this.onToggle}} />`);
+            await click('button');
+
+            assert.true(sidebar.isHidden, 'the sidebar closed');
+            assert.deepEqual(reports, [false], 'and the caller was told what it became');
+        });
+
+        test('with no handler it still toggles', async function (assert) {
+            const sidebar = this.owner.lookup('service:sidebar');
+            sidebar.show();
+
+            await render(hbs`<Layout::Header::SidebarToggle />`);
+            await click('button');
+
+            assert.true(sidebar.isHidden);
+        });
     });
 });

--- a/tests/integration/components/layout/header/smart-nav-menu/dropdown-test.js
+++ b/tests/integration/components/layout/header/smart-nav-menu/dropdown-test.js
@@ -230,4 +230,12 @@ module('Integration | Component | layout/header/smart-nav-menu/dropdown', functi
             assert.strictEqual(cardTitles().length, 3, 'but the cards are all still offered');
         });
     });
+    test('an item with no title at all is still searchable by its other fields', async function (assert) {
+        this.set('items', [{ id: 'untitled', description: 'Dispatch and fulfillment', onClick: () => {} }]);
+
+        await render(TEMPLATE);
+        await fillIn(SEARCH, 'dispatch');
+
+        assert.strictEqual(findAll('.snm-dropdown-card').length, 1, 'the description matched despite the missing title');
+    });
 });

--- a/tests/integration/components/layout/resource/cards-grid-test.js
+++ b/tests/integration/components/layout/resource/cards-grid-test.js
@@ -215,4 +215,36 @@ module('Integration | Component | layout/resource/cards-grid', function (hooks) 
             assert.strictEqual(find('.floating-pagination'), null);
         });
     });
+    // `cardClass` is only read when the block actually renders a yielded card — the hash in
+    // cards-grid.hbs is not built otherwise.
+    module('the yielded card', function () {
+        const WITH_CARD = hbs`
+            <Layout::Resource::CardsGrid @data={{this.data}} @resource={{this.resource}} @cardClass={{this.cardClass}} as |grid|>
+                <grid.card data-test-card="yes">{{grid.model.name}}</grid.card>
+            </Layout::Resource::CardsGrid>
+        `;
+
+        test('each model renders a card carrying the base card classes', async function (assert) {
+            this.setProperties({ data: [{ name: 'First' }, { name: 'Second' }], resource: 'order', cardClass: undefined });
+
+            await render(WITH_CARD);
+
+            const cards = findAll('[data-test-card="yes"]');
+            assert.strictEqual(cards.length, 2, 'one card per model');
+            assert.dom(cards[0]).hasClass('bg-white');
+            assert.dom(cards[0]).hasClass('rounded-md');
+            assert.dom(cards[0]).hasClass('shadow-sm');
+            assert.dom(cards[0]).hasText('First', 'and the model is yielded alongside it');
+        });
+
+        test('a cardClass is appended to the base classes rather than replacing them', async function (assert) {
+            this.setProperties({ data: [{ name: 'First' }], resource: 'order', cardClass: 'ring-2 ring-blue-500' });
+
+            await render(WITH_CARD);
+
+            const card = find('[data-test-card="yes"]');
+            assert.dom(card).hasClass('ring-2', 'the supplied class is there');
+            assert.dom(card).hasClass('bg-white', 'and so are the defaults');
+        });
+    });
 });

--- a/tests/integration/components/layout/resource/panel-test.js
+++ b/tests/integration/components/layout/resource/panel-test.js
@@ -2,6 +2,8 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'dummy/tests/helpers';
 import { render, click, find, findAll, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { task } from 'ember-concurrency';
+import EmberObject from '@ember/object';
 
 const OVERLAY = '.next-content-overlay';
 const PANEL = '.next-content-overlay-panel';
@@ -177,6 +179,33 @@ module('Integration | Component | layout/resource/panel', function (hooks) {
             await settled();
 
             assert.dom(OVERLAY).doesNotHaveClass('is-open', 'no handler is required');
+        });
+    });
+    // The panel's `authSchema` getter is only reached through the header's save button, which
+    // renders when a save task is supplied and the resource is not a plain object.
+    module('with a save task', function () {
+        function saveTaskHost() {
+            return EmberObject.extend({
+                save: task(function* () {
+                    yield Promise.resolve();
+                }),
+            }).create();
+        }
+
+        test('the header offers a save button governed by the default auth schema', async function (assert) {
+            this.set('host', saveTaskHost());
+
+            await render(hbs`<Layout::Resource::Panel @resource={{this.resource}} @saveTask={{this.host.save}} />`);
+
+            assert.dom('.resource-panel-header button.btn').exists('the save control is rendered');
+        });
+
+        test('an explicit authSchema is used instead of the default', async function (assert) {
+            this.set('host', saveTaskHost());
+
+            await render(hbs`<Layout::Resource::Panel @resource={{this.resource}} @saveTask={{this.host.save}} @authSchema="storefront" />`);
+
+            assert.dom('.resource-panel-header button.btn').exists('the save control still renders under a different schema');
         });
     });
 });

--- a/tests/integration/components/layout/resource/tabular-test.js
+++ b/tests/integration/components/layout/resource/tabular-test.js
@@ -231,6 +231,27 @@ module('Integration | Component | layout/resource/tabular', function (hooks) {
             assert.strictEqual(sorts[0].sortValue, sorts[0].sortString);
         });
 
+        test('cycling a sort back off reports no sort column', async function (assert) {
+            // The legacy single-column fields fall back to null once nothing is sorted.
+            const sorts = [];
+            this.set('onSort', (payload) => sorts.push(payload));
+            this.set('columns', [{ label: 'Name', valuePath: 'name', sortable: true }]);
+
+            await render(hbs`
+                <Layout::Resource::Tabular @title="Drivers" @data={{this.rows}} @columns={{this.columns}} @onSort={{this.onSort}} />
+            `);
+
+            const header = find('th.is-sortable .sort-icon-wrapper');
+            await click(header);
+            await click(header);
+            await click(header);
+
+            const last = sorts.at(-1);
+            assert.deepEqual(last.sortColumns, [], 'nothing is sorted any more');
+            assert.strictEqual(last.sortBy, null, 'so there is no single column to name');
+            assert.strictEqual(last.sortDirection, null);
+        });
+
         test('sorting without a controller or handler does not throw', async function (assert) {
             this.set('columns', [{ label: 'Name', valuePath: 'name', sortable: true }]);
 

--- a/tests/integration/components/locale-selector-tray-test.js
+++ b/tests/integration/components/locale-selector-tray-test.js
@@ -161,4 +161,20 @@ module('Integration | Component | locale-selector-tray', function (hooks) {
             assert.dom(TRIGGER).hasClass('is-mobile');
         });
     });
+    // `renderInPlace` is only consulted on a non-mobile viewport, and only when it is an actual
+    // boolean — every case above leaves it unset.
+    test('an explicit renderInPlace keeps the dropdown inside the component', async function (assert) {
+        await render(hbs`<LocaleSelectorTray @renderInPlace={{true}} />`);
+        await click(TRIGGER);
+
+        assert.dom('.locale-selector-tray .locale-selector-tray-content').exists('the content is rendered in place');
+    });
+
+    test('an explicit false is honoured rather than treated as unset', async function (assert) {
+        await render(hbs`<LocaleSelectorTray @renderInPlace={{false}} />`);
+        await click(TRIGGER);
+
+        assert.dom('.locale-selector-tray .locale-selector-tray-content').doesNotExist('the content is wormholed out as usual');
+        assert.strictEqual(localeLinks().length, 2, 'and it still renders somewhere');
+    });
 });

--- a/tests/integration/components/table/cell/media-name-test.js
+++ b/tests/integration/components/table/cell/media-name-test.js
@@ -173,4 +173,12 @@ module('Integration | Component | table/cell/media-name', function (hooks) {
         await render(hbs`<Table::Cell::MediaName @row={{this.row}} @column={{this.column}} />`);
         assert.dom('img').hasClass('mx-2');
     });
+    // Every case above passes a row; the alt-text lookup guards against being asked without one.
+    test('an alt text path with no row at all yields empty alt text', async function (assert) {
+        this.set('column', { altTextPath: 'name' });
+
+        await render(hbs`<Table::Cell::MediaName @column={{this.column}} />`);
+
+        assert.dom('img').hasAttribute('alt', '', 'nothing to read the alt text from');
+    });
 });

--- a/tests/integration/components/table/th-test.js
+++ b/tests/integration/components/table/th-test.js
@@ -240,4 +240,13 @@ module('Integration | Component | table/th', function (hooks) {
             assert.strictEqual(find('th').style.position, '');
         });
     });
+    // Every other test supplies a column; the sort-priority getter has its own guard for when one
+    // is not passed at all.
+    test('a header with no column at all still renders', async function (assert) {
+        await render(hbs`<table><thead><tr><Table::Th>Plain</Table::Th></tr></thead></table>`);
+
+        assert.dom('th').exists();
+        assert.dom('th').containsText('Plain');
+        assert.dom('th .sort-priority').doesNotExist('and claims no sort priority');
+    });
 });

--- a/tests/integration/components/tabs/tab-test.js
+++ b/tests/integration/components/tabs/tab-test.js
@@ -135,4 +135,14 @@ module('Integration | Component | tabs/tab', function (hooks) {
             assert.dom(LINK).hasText('Order details', 'the tab survives');
         });
     });
+    // Both class getters short-circuit on `isActive`, and every case above renders the tab active.
+    test('an inactive tab contributes no active classes', async function (assert) {
+        this.setProperties({ activeTab: 'some-other-tab', activeTabClass: 'tab-on', activePaneClass: 'pane-on' });
+
+        await render(TEMPLATE);
+
+        assert.dom(LINK).doesNotHaveClass('active');
+        assert.dom(LINK).doesNotHaveClass('tab-on', 'the configured active class is withheld too');
+        assert.dom(PANE).doesNotExist('and the pane is not rendered at all');
+    });
 });

--- a/tests/integration/components/with-record-test.js
+++ b/tests/integration/components/with-record-test.js
@@ -102,4 +102,14 @@ module('Integration | Component | with-record', function (hooks) {
         await render(TEMPLATE);
         assert.deepEqual(peeked, [], 'no type means no lookup');
     });
+    test('a rejection carrying no message falls back to a generic one', async function (assert) {
+        // Not every rejection is an Error — a bare object reaches the same handler.
+        store.findRecord = () => Promise.reject({});
+        this.setProperties({ id: VALID_UUID, type: 'Order' });
+
+        await render(TEMPLATE);
+
+        assert.dom('.error').hasText('Failed to load record.');
+        assert.dom('.name').hasText('', 'and no record is yielded');
+    });
 });


### PR DESCRIPTION
The 77 files whose remaining coverage gap was three sites or fewer. Five commits, reviewable in order.

> Stacked on #153 (`fix/custom-fields-tab-reload`). Review that one first.

## No production behaviour changes

Worth stating up front, given the recent (justified) concern about changes to code that was not broken:

```
addon/  61 files  +148  -0     ← every added line is a comment; zero deletions
tests/  19 files  +433  -6
```

I verified that mechanically rather than by eye: all 148 added `addon/` lines are comment lines, and the addon diff contains no deletions at all. Nothing was rewritten, removed, or re-ordered.

## Results

| | start of Batch A | now |
|---|---|---|
| statements | 93.68% | **94.06%** |
| branches | 89.19% | **89.87%** |
| functions | 97.25% | **97.45%** |
| lines | 94.08% | **94.47%** |

**5014 pass / 0 fail / 0 skip.** Both linters exit 0. Batch A is down from **77 files / 53 statements / 77 branches** to **10 / 7 / 10**.

## 32 new tests

Highlights rather than a list:

- **`docs-panel`** — `close`, `openExternal` and the iframe-failure fallback; none of the three actions were exercised. Three environment details cost a cycle each and are recorded in the commit: FontAwesome renders `times` as `xmark`; the service calls the *real global* `window.open`, not ember-window-mock's; and an `error` event dispatched at an element reaches `window.onerror`, which QUnit installs, so it fails the test on the event the test itself raises.
- **`checkbox`, `filters-picker/button`, `full-calendar/draggable`** — I had first bucketed their `{{did-update this.handler @arg}}` parameter defaults with the framework `default-arg` residue. **That was wrong.** Those defaults are live: they apply when an argument changes *to* `undefined`, which is what a caller clearing its state does. So they got tests, not exclusions, and all three files are now fully covered.
- **`layout/resource/panel`** — its `authSchema` getter had never been evaluated at all. Glimmer evaluates arguments lazily, and the only consumer is the header's save button, which does not render without a `@saveTask`.
- **`chart`** — a component torn down while its dataset loader is still in flight. Genuinely reachable (it is why the guard exists), so it gets a test rather than an exclusion.
- **`layout/resource/tabular`** — cycling a sort *back off*; the legacy `sortBy`/`sortDirection` fields only fall back to `null` on the third click.
- Plus `tabs/tab`, `with-record` (a rejection carrying no `message` — not every rejection is an `Error`), `bulk-search-dropdown`, `click-to-copy`, `file-icon`, `table/cell/media-name`, `table/th`, `cards-grid`, `locale-selector-tray`, `smart-nav-menu/dropdown`, `sidebar-toggle`, `kanban`.

Every file I claim is covered was checked against the coverage artifact, not inferred from a green run.

## ~60 exclusions, each justified inline

Per the agreed approach: documented, line-specific `istanbul ignore` comments rather than deleting defensive code. Each names the specific thing that makes the site unreachable, e.g.

- `table/foot`'s `element instanceof HTMLElement` — `offsetElements` is a literal array of two strings.
- `truncate-pages`' `if (res.length > 0)` — `res.push(currentPage)` above it is unconditional.
- `sidebar-toggle` and `export-options` — their guards sit behind `disabled={{…}}` on the very control that would trigger them.
- `tabs/tab`'s inactive pane class — the pane is itself inside `{{#if this.isActive}}`.
- `@tracked` initializers that are lazy and always assigned before first read (25 of these; each verified to be assigned elsewhere before excluding — `modal/dialog`'s `@ref` field failed that check and was handled separately rather than blanket-ignored).

## Two mistakes of mine, corrected in the branch

Flagging these because they are the class of error that matters here.

1. **The `table/th` exclusion landed on the wrong getter.** A scripted insert matched the first `if (!column) {` in the file, which belongs to `sortColumn` — a guard my own earlier test *does* exercise. The exclusion was therefore suppressing a real result rather than recording an unreachable one. Moved to `sortPriority`. The file now reports 0 uncovered statements and 0 partial branches with that single exclusion, which is what confirms the fix.

2. **An `istanbul ignore` on an `if` does not cover a `return` that follows it.** Four helper fallbacks needed their own comment. Without catching this I would have reported those files as clean when they were not.

Branches read 89.87% here against 89.93% mid-branch: removing the misplaced `table/th` exclusion put a real partial branch back into the report. Lower is the honest number.

## Three defects found by writing the tests — recorded, not fixed

- **#165 — `chat-window/attachment` throws on any filename without a dot.** `getExtension` returns `null` and `getIcon` passes it straight to `getWithDefault`, which asserts on a non-string key. `README`, `Dockerfile`, `LICENSE` cannot render. `<FileIcon>` guards the identical case two files away. I left the branch uncovered deliberately: the only test that reaches it asserts a crash, which would pin behaviour that should change.
- **#166 — two getters no template references.** `overlay/header`'s `useEllipsis` (the header gates on `@overlay.isMinimized`, so its 15-character threshold does nothing) and `report-builder/condition-value`'s `isBoolean` (no boolean arm exists, so a `boolean` column gets a free-text field). The second may be a *missing editor* rather than dead code — a product call.
- **#164 — the coverage total is nondeterministic.** Two runs on identical code differed by two statements, and a per-file diff names `layout/sidebar.js` alone. Relevant before any gate is pinned near the current figure.

## What the remaining 10 files are

Not untested work: `chat-window/attachment` (#165), `overlay/header` and `condition-value` (#166), `dropdown-fn` (#159), `template-builder/canvas` (inside the interact.js-blocked area, belongs to a later batch), and five single defensive guards. Batch A is effectively complete; the rest needs decisions rather than tests.
