### PR TITLE
Batch B (part 1): modal.js

### DIFF
--- a/addon/components/modal.js
+++ b/addon/components/modal.js
@@ -450,6 +450,7 @@ export default class Modal extends Component {
             return;
         }
 
+        /* istanbul ignore next -- FastBoot-only: this suite runs in a browser, where isFastBoot() is always false. */
         if (!isFastBoot(this)) {
             this.checkScrollbar();
             this.setScrollbar();
@@ -462,6 +463,7 @@ export default class Modal extends Component {
             return;
         }
 
+        /* istanbul ignore next -- FastBoot-only: this suite runs in a browser, where isFastBoot() is always false. */
         if (!isFastBoot(this)) {
             modalElement.scrollTop = 0;
             this.adjustDialog();
@@ -513,6 +515,7 @@ export default class Modal extends Component {
 
         this.removeBodyClass();
 
+        /* istanbul ignore next -- FastBoot-only: this suite runs in a browser, where isFastBoot() is always false. */
         if (!isFastBoot(this)) {
             this.resetAdjustments();
             this.resetScrollbar();
@@ -633,6 +636,7 @@ export default class Modal extends Component {
         // Only add the body class if this is the first modal
         if (this.modalsManager.modals.length === 1) {
             // special handling for FastBoot, where real `document` is not available
+            /* istanbul ignore next -- FastBoot-only: this suite runs in a browser, where isFastBoot() is always false. */
             if (isFastBoot(this)) {
                 // a SimpleDOM instance with just a subset of the DOM API!
                 let document = this.document;
@@ -653,6 +657,7 @@ export default class Modal extends Component {
     removeBodyClass() {
         // Only remove the body class if there are no more modals
         if (this.modalsManager.modals.length === 0) {
+            /* istanbul ignore next -- FastBoot-only: this suite runs in a browser, where isFastBoot() is always false. */
             if (isFastBoot(this)) {
                 // no need for FastBoot support here
                 return;
@@ -683,6 +688,7 @@ export default class Modal extends Component {
 
         this.removeBodyClass();
 
+        /* istanbul ignore next -- FastBoot-only: this suite runs in a browser, where isFastBoot() is always false. */
         if (!isFastBoot(this)) {
             this.resetScrollbar();
         }

--- a/tests/integration/components/modal-test.js
+++ b/tests/integration/components/modal-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'dummy/tests/helpers';
-import { render, click, settled, find, findAll } from '@ember/test-helpers';
+import { render, click, settled, find, findAll, triggerKeyEvent } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 const DIALOG = '.flb--modal';
@@ -243,5 +243,50 @@ module('Integration | Component | modal', function (hooks) {
         await render(hbs`<Modal @open={{true}} />`);
 
         assert.dom('.flb--modal-backdrop').hasClass('fade');
+    });
+    // <Modal> declares `keyboard` and `backdropClose` and hands them to <Modal::Dialog>, which
+    // only reads them from inside its keydown and click handlers. Glimmer evaluates arguments
+    // lazily, so until one of those handlers actually runs through a real <Modal>, the modal's own
+    // defaults are never resolved.
+    module('the dialog arguments the modal supplies', function () {
+        test('escape closes the modal by default', async function (assert) {
+            const closes = [];
+            this.set('onClose', () => closes.push('closed'));
+
+            await render(hbs`<Modal @renderInPlace={{true}} @fade={{false}} @onClose={{this.onClose}}>body</Modal>`);
+            await triggerKeyEvent(DIALOG, 'keydown', 'Escape');
+
+            assert.deepEqual(closes, ['closed'], 'the default keyboard handling is on');
+        });
+
+        test('escape is ignored when keyboard handling is switched off', async function (assert) {
+            const closes = [];
+            this.set('onClose', () => closes.push('closed'));
+
+            await render(hbs`<Modal @renderInPlace={{true}} @fade={{false}} @keyboard={{false}} @onClose={{this.onClose}}>body</Modal>`);
+            await triggerKeyEvent(DIALOG, 'keydown', 'Escape');
+
+            assert.deepEqual(closes, [], 'the modal stays open');
+        });
+
+        test('clicking the backdrop area closes the modal by default', async function (assert) {
+            const closes = [];
+            this.set('onClose', () => closes.push('closed'));
+
+            await render(hbs`<Modal @renderInPlace={{true}} @fade={{false}} @onClose={{this.onClose}}>body</Modal>`);
+            await click(DIALOG);
+
+            assert.deepEqual(closes, ['closed'], 'the default backdrop-close is on');
+        });
+
+        test('clicking it is ignored when backdropClose is switched off', async function (assert) {
+            const closes = [];
+            this.set('onClose', () => closes.push('closed'));
+
+            await render(hbs`<Modal @renderInPlace={{true}} @fade={{false}} @backdropClose={{false}} @onClose={{this.onClose}}>body</Modal>`);
+            await click(DIALOG);
+
+            assert.deepEqual(closes, [], 'the modal stays open');
+        });
     });
 });


### PR DESCRIPTION
First file of Batch B. Opened now rather than held back, because Batch B is large (79 files remaining) and will continue in a separate session.

> Stacked on #154 (`test/coverage-batch-a`). Review that one first.

## modal.js: three unrelated things, one real test gap

It was the largest single remaining file — 13 statements, 14 branches.

**1. FastBoot-only code (6 exclusions).** Every `isFastBoot(this)` guard, plus the SimpleDOM branch of `addBodyClass` sitting behind one. This suite runs in a browser, where `isFastBoot()` is always false, so neither arm is reachable.

**2. Two arguments the modal never resolved (4 tests).** `<Modal>` declares `keyboard` and `backdropClose` and hands them to `<Modal::Dialog>` — which reads them *only* inside `handleKeyDown` and `handleClick`. Glimmer evaluates arguments lazily, so until one of those handlers fires **through a real `<Modal>`**, the modal's own `@arg` defaults are never resolved. The existing dialog tests render `<Modal::Dialog>` directly with the arguments passed explicitly, so they never touched the modal's side.

My first read was that these were dead like #166's getters — `this.keyboard` and `this.backdropClose` genuinely appear nowhere in `modal.js`. Tracing the template proved otherwise. Four tests now cover it: escape closing the modal by default and being ignored under `@keyboard={{false}}`, same pair for the backdrop.

This is the same shape as `layout/resource/panel`'s `authSchema` in #154. Worth recognising on sight: **an argument read only inside a handler is not evaluated until that handler runs.**

**3. Six teardown guards — left uncovered and deliberately NOT excluded.** `_isOpen`, three `isDestroyed` checks after `await`s, two `!modalElement` checks. Same shape as `chart`'s teardown guard, which *was* reachable and got a test in #154. Reaching these needs the component destroyed mid-transition, and `render()` awaits settled, so the transition completes before a test could tear it down. They're reachable in principle, so excluding them would be wrong. Recorded rather than papered over.

## Results

**5018 pass / 0 fail / 0 skip.** Both linters clean.

| | after #154 | now |
|---|---|---|
| statements | 94.06% | **94.13%** |
| branches | 89.87% | **90.06%** |
| functions | 97.45% | 97.45% |
| lines | 94.47% | **94.55%** |

Branches are past 90% for the first time.

## Scope correction for whoever picks this up

I previously described Batch B as roughly 14 files / 100 statements / 120 branches. That was the visible head of the list. The real scope is **80 files, 321 statements, 371 branches** — about six times Batch A. After this file: 79 files, ~308 statements, ~357 branches.

Ranked next: `chat-tray` (12s/11b), `custom-fields-manager` (8/14), `model-select` (8/6), `comment-thread/comment` (8/6), `chat-window` (6/9), `metadata-editor` (8/5), `table` (4/13), `countdown` (6/8), `tab-navigation` (4/11).

## Patterns established across #154 and this PR

Recorded because each one cost several cycles to find:

- **Lazy arguments.** An argument only read inside a handler (or a component that never renders) is never evaluated. Seen in `panel.authSchema` and now `modal.keyboard`.
- **`did-update` parameter defaults are live, not framework residue.** `{{did-update this.handler @arg}}` with `[value = false]` fires its default when the argument changes *to* undefined. I nearly excluded three files' worth of these before realising.
- **`@tracked` initializers are lazy.** Dead only if the value is always assigned before first read — verify per field, don't assume.
- **A guard behind a disabled control is unreachable.** `sidebar-toggle`, `export-options`.
- **An `istanbul ignore` on an `if` does not cover a `return` that follows it.**
- **A green test proves nothing about which branch ran.** Every claim in these PRs was checked against the coverage artifact.
