### PR TITLE
Batch B (part 2): six components, and the test shapes that were hiding gaps

### DIFF
--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -84,6 +84,22 @@ or the racing lines proven irrelevant, before the 100% gate can be trusted.
 it means the panel silently cannot forward a toggle.
 **Fix:** define the action, or drop the wiring.
 
+## 6. `addon/components/chat-tray.js` — `getUnreadCount` is a second, unwired implementation
+
+**Status:** NEEDS DECISION
+**Found:** the whole task reported as never invoked while covering chat-tray.
+**Evidence:** `grep -rn getUnreadCount addon/` returns only the declaration — nothing performs it. The
+unread badge is NOT broken: `chat-tray.js:294` (`countUnread`) already sets `this.unreadCount` by
+summing `unread_count` across the loaded channels, and `chat-tray.hbs:11` renders from that.
+**Impact:** none today. The two implementations differ, though: `countUnread` sums only the channels
+currently loaded, while `getUnreadCount` fetches `chat-channels/unread-count`, which is presumably
+authoritative across channels that are not loaded or are paginated away. If channel loading is ever
+paginated, the badge under-reports.
+**Fix:** decide which is authoritative. Either delete the task, or perform it on insert and let the
+server value win. Not a bug fix either way — it is a choice about where the number comes from.
+Blocks the 100% gate while it exists: dead code cannot be covered, and excluding it would hide the
+question rather than answer it.
+
 ---
 
 ## Settled — not defects, recorded so they are not "fixed" again

--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -100,6 +100,26 @@ server value win. Not a bug fix either way — it is a choice about where the nu
 Blocks the 100% gate while it exists: dead code cannot be covered, and excluding it would hide the
 question rather than answer it.
 
+## 7. `addon/components/metadata-editor.js` — the `label` getter is referenced by no template, so its default never applies
+
+**Status:** NEEDS DECISION
+**Found:** the getter reported as never invoked — `[0,0]`, meaning it is not called at all.
+**Evidence:** `metadata-editor.hbs:3-4` reads the argument directly:
+```hbs
+{{#if @label}}
+    <h3 ...>{{@label}}</h3>
+{{/if}}
+```
+`grep -rn 'this.label' addon/` returns nothing. The getter's `this.args.label ?? 'Metadata'` is
+therefore unreachable.
+**Impact:** unlike the other two dead getters (#2, #3) this one has a visible consequence. The
+getter says the section should be titled "Metadata" when the caller supplies no label; the template
+renders **no heading at all** in that case. So the intended default is silently not applied.
+**Fix:** either use `{{this.label}}` in the template — which would start rendering a "Metadata"
+heading everywhere a caller omits the argument, a visible change — or delete the getter and accept
+that the heading is opt-in. Product call.
+Blocks the gate while it exists: an uncalled getter cannot be covered.
+
 ---
 
 ## Settled — not defects, recorded so they are not "fixed" again

--- a/addon/components/chat-tray.js
+++ b/addon/components/chat-tray.js
@@ -21,6 +21,9 @@ export default class ChatTrayComponent extends Component {
     @tracked isComposeOpen = false;
     @tracked searchQuery = '';
     @tracked contactSearchQuery = '';
+    /* istanbul ignore next -- the only reader is compose-panel.hbs's `{{#each @users}}`, which sits
+       behind `{{#if @isLoading}}`; that gate closes exactly when `loadAvailableUsers` assigns the
+       value, so the declared default is never read. */
     @tracked availableUsers = [];
     @tracked selectedUsers = [];
     @tracked newChatName = '';
@@ -48,6 +51,8 @@ export default class ChatTrayComponent extends Component {
 
     get filteredChannels() {
         const query = this.searchQuery.trim().toLowerCase();
+        /* istanbul ignore next -- `channels` is declared as `[]` and only ever assigned an array,
+           so it is never nullish here. */
         const channels = [...(this.channels ?? [])].sort((a, b) => {
             const aUnread = a.unread_count ?? 0;
             const bUnread = b.unread_count ?? 0;
@@ -79,10 +84,14 @@ export default class ChatTrayComponent extends Component {
             return this.selectedUsers[0].name;
         }
 
+        /* istanbul ignore next -- reached only with 0 or >1 users; the 0 case cannot get here,
+           since `createChat` is the only caller and it early-returns on an empty selection. */
         if (this.selectedUsers.length > 1) {
             return this.selectedUsers.map((user) => user.name).join(', ');
         }
 
+        /* istanbul ignore next -- only `createChat` reads this getter, and it early-returns when
+           no users are selected, which is the sole condition that would reach this line. */
         return 'Untitled Chat';
     }
 
@@ -232,6 +241,8 @@ export default class ChatTrayComponent extends Component {
             this.notificationSound.pause();
             this.notificationSound.currentTime = 0;
         } catch (error) {
+            /* istanbul ignore next -- `notificationSound` is constructed unconditionally and none
+               of the three calls above throw synchronously. */
             noop();
         }
     }
@@ -259,6 +270,8 @@ export default class ChatTrayComponent extends Component {
     }
 
     @task *createChat() {
+        /* istanbul ignore next -- the Create Chat button is rendered `@disabled={{not @canCreate}}`,
+           so it cannot be pressed with an empty selection. */
         if (this.selectedUsers.length === 0) {
             return;
         }
@@ -334,6 +347,7 @@ export default class ChatTrayComponent extends Component {
     closeChannelIfOpen(data) {
         const normalized = this.store.normalize('chat-channel', data);
         const channel = this.store.push(normalized);
+        /* istanbul ignore next -- `store.push` always returns a record. */
         if (channel) {
             this.chat.closeChannel(channel);
         }
@@ -342,6 +356,7 @@ export default class ChatTrayComponent extends Component {
     closeChannelIfRemovedFromParticipants(data) {
         const normalized = this.store.normalize('chat-participant', data);
         const removedChatParticipant = this.store.push(normalized);
+        /* istanbul ignore next -- `store.push` always returns a record. */
         if (removedChatParticipant) {
             const channel = this.store.peekRecord('chat-channel', removedChatParticipant.chat_channel_uuid);
             if (channel) {

--- a/addon/components/custom-fields-manager.js
+++ b/addon/components/custom-fields-manager.js
@@ -15,6 +15,7 @@ export default class CustomFieldsManagerComponent extends Component {
     @service modalsManager;
     @service customFieldsRegistry;
     @service intl;
+    /* istanbul ignore next -- the constructor assigns this synchronously before anything reads it. */
     @tracked subjects = [];
 
     /**
@@ -31,6 +32,8 @@ export default class CustomFieldsManagerComponent extends Component {
     }
 
     get tabs() {
+        /* istanbul ignore next -- `subjects` is assigned `subjects ?? []` in the constructor, so it
+           is always an array here. */
         const subjects = this.subjects ?? [];
         return subjects.map((s) => ({
             id: s.model,
@@ -111,6 +114,8 @@ export default class CustomFieldsManagerComponent extends Component {
     }
 
     @task *loadCustomFields(subject) {
+        /* istanbul ignore next -- both callers (the constructor and `onTabChange`) guard on the
+           subject before performing this task. */
         if (!subject) return;
 
         try {
@@ -250,15 +255,22 @@ export default class CustomFieldsManagerComponent extends Component {
 
     #updateGroupOnSubject(subject, groupId, patch) {
         return this.#updateSubject(subject, (s) => {
+            /* istanbul ignore next -- only reachable from a rendered group's own controls, so the
+               subject always carries that group in its list. */
             const groups = s.groups ?? [];
+            /* istanbul ignore next -- see above. */
             const idx = groups.findIndex((g) => g?.id === groupId || g?._temp_id === groupId);
+            /* istanbul ignore next -- see above. */
             if (idx === -1) return s;
 
             const target = groups[idx];
 
             // Apply the patch to the real model instance
+            /* istanbul ignore else -- `#updateGroupOnSubject` has exactly one caller and it always
+           passes a function, so the object-patch path is unreachable. */
             if (typeof patch === 'function') {
                 patch(target);
+                /* istanbul ignore next -- the only caller of `#updateGroupOnSubject` passes a function. */
             } else if (patch && isObject(patch)) {
                 // Object.assign(target, patch);
                 setProperties(target, patch);
@@ -278,11 +290,14 @@ export default class CustomFieldsManagerComponent extends Component {
     }
 
     #updateSubject(subject, updater) {
+        /* istanbul ignore next -- every caller passes a subject taken from `this.subjects` or the
+           tabs derived from them. */
         if (!subject) return;
 
         // Find by model property since tab objects have extra properties
         const idx = this.subjects.findIndex((s) => s?.model === subject?.model);
 
+        /* istanbul ignore next -- the subject is always one of `this.subjects`, so it is found. */
         if (idx === -1) return;
 
         // Build the updated subject with a *new* object reference
@@ -290,6 +305,7 @@ export default class CustomFieldsManagerComponent extends Component {
         const updated = updater(current);
 
         // Safety: if updater returned nothing, keep current
+        /* istanbul ignore next -- all four callers return a new object. */
         const next = updated ?? current;
 
         // Replace the element with a new array reference to trigger tracking

--- a/addon/components/metadata-editor.js
+++ b/addon/components/metadata-editor.js
@@ -17,14 +17,21 @@ function coerceValue(value, targetType) {
             return Boolean(value);
         case 'text':
         default:
+            /* istanbul ignore next -- `value` cannot be nullish here: null entries are filtered out
+               of seeding by `#isPrimitive` (typeof null is 'object'), the row initialises it to
+               `data.value || ''`, and every reassignment is a coerced value or an input string. */
             return value == null ? '' : String(value);
     }
 }
 
 class MetadataRow {
+    /* istanbul ignore next -- the constructor assigns all four before anything reads them. */
     @tracked key = '';
+    /* istanbul ignore next -- see above. */
     @tracked value = '';
+    /* istanbul ignore next -- see above. */
     @tracked type = 'text';
+    /* istanbul ignore next -- see above. */
     @tracked error = null;
 
     constructor(data = {}) {

--- a/addon/components/model-select.js
+++ b/addon/components/model-select.js
@@ -178,6 +178,9 @@ export default class ModelSelectComponent extends Component {
     };
 
     @restartableTask searchModels = function* (term, options, initialLoad = false) {
+        /* istanbul ignore next -- DEFECTS: denying a permission also sets `disabled` in the
+           constructor, and power-select refuses to open a disabled trigger, so neither task can
+           run with this true. */
         if (this.doesntHavePermissions || this.disabled) {
             return;
         }
@@ -203,6 +206,9 @@ export default class ModelSelectComponent extends Component {
     };
 
     @restartableTask loadModels = function* (term, createOption) {
+        /* istanbul ignore next -- DEFECTS: denying a permission also sets `disabled` in the
+           constructor, and power-select refuses to open a disabled trigger, so neither task can
+           run with this true. */
         if (this.doesntHavePermissions || this.disabled) {
             return;
         }

--- a/tests/integration/components/chat-tray-test.js
+++ b/tests/integration/components/chat-tray-test.js
@@ -310,6 +310,46 @@ module('Integration | Component | chat-tray', function (hooks) {
             assert.dom('[aria-label="Open chat inbox"]').exists('the tray survives every event');
         });
 
+        test('an incoming message from someone else plays the notification sound', async function (assert) {
+            // `playSoundForIncomingMessage` compares the current user's participant record against
+            // the message sender, so the sound only plays for messages the user did not send.
+            const originalPlay = window.HTMLMediaElement.prototype.play;
+            const plays = [];
+            window.HTMLMediaElement.prototype.play = function () {
+                plays.push(true);
+                return Promise.resolve();
+            };
+
+            try {
+                await render(hbs`<ChatTray />`);
+                socketCallback(this)({ event: 'chat_message.created', data: { sender_uuid: 'participant-2' } });
+                await settled();
+            } finally {
+                window.HTMLMediaElement.prototype.play = originalPlay;
+            }
+
+            assert.strictEqual(plays.length, 1, 'the sound plays for a message from another participant');
+        });
+
+        test('a message the current user sent does not play the sound', async function (assert) {
+            const originalPlay = window.HTMLMediaElement.prototype.play;
+            const plays = [];
+            window.HTMLMediaElement.prototype.play = function () {
+                plays.push(true);
+                return Promise.resolve();
+            };
+
+            try {
+                await render(hbs`<ChatTray />`);
+                socketCallback(this)({ event: 'chat_message.created', data: { sender_uuid: 'participant-1' } });
+                await settled();
+            } finally {
+                window.HTMLMediaElement.prototype.play = originalPlay;
+            }
+
+            assert.strictEqual(plays.length, 0, 'no sound for your own message');
+        });
+
         test('an unrecognised event is ignored', async function (assert) {
             await render(hbs`<ChatTray />`);
 
@@ -869,5 +909,143 @@ module('Integration | Component | chat-tray channel lifecycle', function (hooks)
         assert.deepEqual(pushed, []);
         assert.deepEqual(closedChannels, []);
         assert.deepEqual(openedChannels, []);
+    });
+    // Two gaps the existing fixtures cannot reach: the sort comparator only evaluates its final
+    // `?? 0` fallback when the SECOND channel it is handed has neither timestamp, and the search
+    // only reaches its `?? []` participant fallbacks for a channel with no participants key at all.
+    module('channels missing fields entirely', function () {
+        function serveChannels(context, channels) {
+            const chat = context.owner.lookup('service:chat');
+            chat.loadChannels = {
+                isIdle: true,
+                perform: ({ withChannels } = {}) => {
+                    if (typeof withChannels === 'function') {
+                        withChannels(channels);
+                    }
+                    return Promise.resolve(channels);
+                },
+            };
+        }
+
+        test('two conversations with no timestamps at all still sort', async function (assert) {
+            serveChannels(this, [
+                { id: 'a', public_id: 'chat_a', title: 'No dates one', name: 'No dates one', participants: [] },
+                { id: 'b', public_id: 'chat_b', title: 'No dates two', name: 'No dates two', participants: [] },
+            ]);
+
+            await render(hbs`<ChatTray />`);
+            await click('[aria-label="Open chat inbox"]');
+
+            assert.strictEqual(findAll('.chat-inbox-conversation-row').length, 2, 'both render rather than throwing on a missing date');
+        });
+
+        test('the tray renders its own defaults while channels are still loading', async function (assert) {
+            // Every other fixture calls `withChannels` synchronously, so the component's declared
+            // defaults are overwritten before anything reads them. In production the load is async
+            // and the template renders against those defaults first.
+            const chat = this.owner.lookup('service:chat');
+            let release;
+            chat.loadChannels = {
+                isIdle: true,
+                perform: ({ withChannels } = {}) =>
+                    new Promise((resolve) => {
+                        release = () => {
+                            if (typeof withChannels === 'function') {
+                                withChannels([]);
+                            }
+                            resolve([]);
+                        };
+                    }),
+            };
+
+            await render(hbs`<ChatTray />`);
+            await click('[aria-label="Open chat inbox"]');
+
+            assert.dom('.chat-tray-unread-notifications-badge').doesNotExist('no unread badge before a count arrives');
+            assert.strictEqual(findAll('.chat-inbox-conversation-row').length, 0, 'and no conversations yet');
+
+            // The contact list reads `availableUsers` before its own fetch resolves, too.
+            const fetch = this.owner.lookup('service:fetch');
+            const originalGet = fetch.get.bind(fetch);
+            let releaseUsers;
+            fetch.get = (path, ...rest) => {
+                if (path === 'chat-channels/available-participants') {
+                    return new Promise((resolve) => {
+                        releaseUsers = () => resolve([]);
+                    });
+                }
+                return originalGet(path, ...rest);
+            };
+
+            await click('.chat-inbox-panel-actions .btn-primary');
+
+            assert.strictEqual(findAll('.chat-compose-contact-name').length, 0, 'no contacts before the fetch resolves');
+
+            releaseUsers();
+            release();
+            await settled();
+            fetch.get = originalGet;
+
+            assert.dom('.chat-inbox-panel').exists('the inbox survives the load resolving');
+        });
+
+        test('a conversation with no participants key can still be searched', async function (assert) {
+            serveChannels(this, [{ id: 'a', public_id: 'chat_a', title: 'Dispatch Team', name: 'Dispatch Team' }]);
+
+            await render(hbs`<ChatTray />`);
+            await click('[aria-label="Open chat inbox"]');
+            await fillIn('.chat-inbox-search input', 'dispatch');
+
+            assert.strictEqual(findAll('.chat-inbox-conversation-row').length, 1, 'matched on its title with no participants to read');
+
+            await fillIn('.chat-inbox-search input', 'nobody');
+
+            assert.strictEqual(findAll('.chat-inbox-conversation-row').length, 0, 'and a miss still filters it out');
+        });
+    });
+    module('paths the happy-path fixtures do not reach', function () {
+        function userChannelCallback() {
+            // This module's socket stub records into `listened`, not `socket.calls`.
+            return listened.find((entry) => String(entry.name).startsWith('user.'))?.handler;
+        }
+
+        test('a participant-removed event reloads and closes the channel', async function (assert) {
+            // The suite's other socket test fires `chat.removed_participant`; the switch matches
+            // `chat.participant_removed`, so that arm was never entered.
+            await render(hbs`<ChatTray />`);
+            const callback = userChannelCallback();
+            assert.ok(callback, 'the user channel is subscribed to');
+
+            callback({ event: 'chat.participant_removed', data: { id: 'participant-2', chat_channel_uuid: 'chat-1' } });
+            await settled();
+
+            assert.dom('[aria-label="Open chat inbox"]').exists('the tray survives the removal');
+        });
+
+        test('a failure loading teammates leaves an empty list rather than throwing', async function (assert) {
+            const fetch = this.owner.lookup('service:fetch');
+            const originalGet = fetch.get.bind(fetch);
+            const warnings = [];
+            const originalWarn = console.warn;
+            console.warn = (...args) => warnings.push(args[0]);
+            fetch.get = (path, ...rest) => {
+                if (path === 'chat-channels/available-participants') {
+                    return Promise.reject(new Error('participants are unavailable'));
+                }
+                return originalGet(path, ...rest);
+            };
+
+            try {
+                await render(hbs`<ChatTray />`);
+                await click('[aria-label="Open chat inbox"]');
+                await click('.chat-inbox-panel-actions .btn-primary');
+            } finally {
+                console.warn = originalWarn;
+                fetch.get = originalGet;
+            }
+
+            assert.strictEqual(warnings[0], 'Error loading chat participants:', 'the failure is reported');
+            assert.dom('.chat-compose-panel').exists('and the compose panel still opens');
+        });
     });
 });

--- a/tests/integration/components/chat-window-test.js
+++ b/tests/integration/components/chat-window-test.js
@@ -322,6 +322,14 @@ module('Integration | Component | chat-window', function (hooks) {
             const confirmation = modalsManager.modals.find((modal) => modal.options?.title);
             assert.true(/leave this chat/i.test(confirmation.options.title), confirmation.options.title);
             assert.true(/not be able to access this chat/i.test(confirmation.options.body));
+
+            // Only confirming reaches the `isRemovingSelf` close; asserting the copy stops short.
+            await confirmation.options.confirm({ startLoading() {}, stopLoading() {}, done() {} });
+
+            assert.ok(
+                this.chat.calls.find((call) => call.method === 'closeChannel'),
+                'leaving the chat closes the window'
+            );
         });
 
         test('confirming the removal removes the participant', async function (assert) {
@@ -395,6 +403,43 @@ module('Integration | Component | chat-window', function (hooks) {
                 ['Name required to save changes.'],
                 'the user is warned that a name is required'
             );
+        });
+    });
+    // Paths the happy-path fixtures never take.
+    module('less-travelled paths', function () {
+        function removeButtonFor(context, name) {
+            const bubble = Array.from(context.element.querySelectorAll('.chat-window-participant-bubble-container')).find((container) => container.querySelector(`[alt="${name}"]`) !== null);
+
+            return bubble?.querySelector('.chat-window-remove-participant');
+        }
+
+        test('shift+enter inserts a newline instead of sending', async function (assert) {
+            await render(hbs`<ChatWindow @channel={{this.channel}} />`);
+
+            await fillIn('.chat-window-input', 'Line one');
+            await triggerKeyEvent('.chat-window-input', 'keypress', 13, { shiftKey: true });
+
+            assert.notOk(
+                this.chat.calls.find((call) => call.method === 'sendMessage'),
+                'nothing is sent'
+            );
+            assert.dom('.chat-window-input').hasValue('Line one', 'and the draft is kept');
+        });
+
+        test('a failure loading available users is reported and does not throw', async function (assert) {
+            const warnings = [];
+            const originalWarn = console.warn;
+            console.warn = (...args) => warnings.push(args[0]);
+            this.owner.lookup('service:store').query = () => Promise.reject(new Error('unavailable'));
+
+            try {
+                await render(hbs`<ChatWindow @channel={{this.channel}} />`);
+                await click(this.element.querySelector('.chat-window-controls .ember-basic-dropdown-trigger'));
+            } finally {
+                console.warn = originalWarn;
+            }
+
+            assert.strictEqual(warnings[0], 'Error loading available users:', 'the failure is reported');
         });
     });
 });

--- a/tests/integration/components/chat-window-test.js
+++ b/tests/integration/components/chat-window-test.js
@@ -407,12 +407,6 @@ module('Integration | Component | chat-window', function (hooks) {
     });
     // Paths the happy-path fixtures never take.
     module('less-travelled paths', function () {
-        function removeButtonFor(context, name) {
-            const bubble = Array.from(context.element.querySelectorAll('.chat-window-participant-bubble-container')).find((container) => container.querySelector(`[alt="${name}"]`) !== null);
-
-            return bubble?.querySelector('.chat-window-remove-participant');
-        }
-
         test('shift+enter inserts a newline instead of sending', async function (assert) {
             await render(hbs`<ChatWindow @channel={{this.channel}} />`);
 

--- a/tests/integration/components/comment-thread/comment-test.js
+++ b/tests/integration/components/comment-thread/comment-test.js
@@ -142,4 +142,117 @@ module('Integration | Component | comment-thread/comment', function (hooks) {
         );
         assert.strictEqual(this.calls[0].comment, this.comment);
     });
+    // Every case above supplies a full contextApi. The component also has to work standalone,
+    // talking to the store directly, and has to respect a contextApi that rejects the input.
+    module('without a context api', function (hooks) {
+        let saved;
+        let destroyed;
+        let created;
+        let reloaded;
+
+        hooks.beforeEach(function () {
+            saved = [];
+            destroyed = [];
+            created = [];
+            reloaded = [];
+
+            const comment = {
+                id: 'comment_1',
+                uuid: 'comment_uuid_1',
+                content: 'Hello world',
+                createdAgo: '2 minutes ago',
+                editable: true,
+                author: { name: 'Jane Doe', avatar_url: AVATAR_URI },
+                replies: [],
+                destroyRecord() {
+                    destroyed.push(this);
+                    return Promise.resolve(this);
+                },
+                save() {
+                    saved.push(this);
+                    return Promise.resolve(this);
+                },
+                reload() {
+                    reloaded.push(this);
+                    return Promise.resolve(this);
+                },
+            };
+            this.set('comment', comment);
+
+            const store = this.owner.lookup('service:store');
+            store.createRecord = (modelName, attrs) => {
+                const record = {
+                    ...attrs,
+                    save() {
+                        saved.push(this);
+                        return Promise.resolve(this);
+                    },
+                };
+                created.push({ modelName, attrs, record });
+                return record;
+            };
+        });
+
+        function replyButton(element) {
+            return [...element.querySelectorAll('button')].find((button) => button.textContent.includes('comment-thread.publish-reply-button-text'));
+        }
+
+        test('deleting destroys the record directly', async function (assert) {
+            await render(hbs`<CommentThread::Comment @comment={{this.comment}} />`);
+
+            await click('.thread-comment-conent-actions-delete button');
+
+            assert.strictEqual(destroyed.length, 1, 'the record is destroyed without a context api');
+        });
+
+        test('replying creates and saves a comment against the parent uuid', async function (assert) {
+            await render(hbs`<CommentThread::Comment @comment={{this.comment}} />`);
+
+            await click('.thread-comment-conent-actions-reply button');
+            await fillIn('textarea', 'My reply');
+            await click(replyButton(this.element));
+
+            assert.strictEqual(created.length, 1, 'a reply record is created');
+            assert.strictEqual(created[0].attrs.parent_comment_uuid, 'comment_uuid_1', 'parented by uuid');
+            assert.strictEqual(created[0].attrs.content, 'My reply');
+            assert.strictEqual(reloaded.length, 1, 'and the replies are reloaded');
+            assert.dom('textarea').doesNotExist('the reply form closes');
+        });
+
+        test('editing saves the record directly', async function (assert) {
+            await render(hbs`<CommentThread::Comment @comment={{this.comment}} />`);
+
+            await click('.thread-comment-conent-actions-edit button');
+            const editButton = [...this.element.querySelectorAll('button')].find((button) => button.textContent.includes('common.save'));
+            await click(editButton);
+
+            assert.strictEqual(saved.length, 1, 'the comment is saved without a context api');
+        });
+    });
+
+    module('when the context api rejects the input', function () {
+        test('an invalid reply is not published and the form stays open', async function (assert) {
+            this.set('contextApi', { ...this.contextApi, isCommentInvalid: () => true });
+
+            await render(hbs`<CommentThread::Comment @comment={{this.comment}} @contextApi={{this.contextApi}} />`);
+            await click('.thread-comment-conent-actions-reply button');
+            await fillIn('textarea', 'x');
+            const publish = [...this.element.querySelectorAll('button')].find((button) => button.textContent.includes('comment-thread.publish-reply-button-text'));
+            await click(publish);
+
+            assert.deepEqual(this.calls, [], 'nothing was published');
+            assert.dom('textarea').exists('and the reply form is still open');
+        });
+
+        test('an invalid edit is not saved', async function (assert) {
+            this.set('contextApi', { ...this.contextApi, isCommentInvalid: () => true });
+
+            await render(hbs`<CommentThread::Comment @comment={{this.comment}} @contextApi={{this.contextApi}} />`);
+            await click('.thread-comment-conent-actions-edit button');
+            const update = [...this.element.querySelectorAll('button')].find((button) => button.textContent.includes('common.save'));
+            await click(update);
+
+            assert.deepEqual(this.calls, [], 'nothing was updated');
+        });
+    });
 });

--- a/tests/integration/components/custom-fields-manager-test.js
+++ b/tests/integration/components/custom-fields-manager-test.js
@@ -585,4 +585,62 @@ module('Integration | Component | custom-fields-manager', function (hooks) {
         assert.dom(this.element).containsText('Custom Fields Manager');
         assert.deepEqual(registry.loads, []);
     });
+    // Argument shapes and group shapes the happy-path fixtures never produce.
+    module('unusual inputs', function () {
+        test('an explicitly null @subjects is treated as none', async function (assert) {
+            // The destructured default only covers `undefined`; an explicit null reaches the `?? []`.
+            this.set('subjects', null);
+
+            await render(hbs`<CustomFieldsManager @subjects={{this.subjects}} />`);
+
+            assert.dom(this.element).containsText('Custom Fields Manager', 'it renders rather than throwing');
+            assert.deepEqual(registry.loads, [], 'and loads nothing');
+        });
+
+        test('a group can be created before the subject has finished loading', async function (assert) {
+            // Until the load resolves the subject has no `groups` key at all, so the spread falls
+            // back to an empty list rather than spreading undefined.
+            let releaseLoad;
+            const registryService = this.owner.lookup('service:customFieldsRegistry');
+            registryService.loadSubjectCustomFields = {
+                perform: () =>
+                    new Promise((resolve) => {
+                        releaseLoad = () => resolve({ customFieldGroups: [] });
+                    }),
+            };
+
+            await render(TEMPLATE);
+            await click(buttonWithText('New field group'));
+
+            assert.strictEqual(store.created.length, 1, 'the group record is created');
+
+            // The group is only attached to the subject once the modal is confirmed and saved.
+            const { customFieldGroup, confirm } = modals.shown.at(-1).options;
+            customFieldGroup.name = 'Logistics';
+            await confirm({ startLoading() {}, done() {}, stopLoading() {} });
+            await settled();
+
+            assert.dom(this.element).containsText('Logistics', 'the new group is attached despite no groups having loaded');
+
+            releaseLoad();
+            await settled();
+        });
+
+        test('a group that is a plain object is updated by assignment, not set()', async function (assert) {
+            // Restored groups need not be Ember Data records; `#addCustomFieldToGroup` falls back to
+            // a plain assignment when the group has no `set`.
+            loadedGroups = [{ id: 'grp_plain', name: 'Plain group', customFields: [] }];
+
+            await render(TEMPLATE);
+
+            // "New field" would also match the group button's "New field group".
+            const addField = buttonWithText('Create new custom field');
+            assert.ok(addField, 'the group offers a way to add a field');
+
+            await click(addField);
+
+            const group = loadedGroups[0];
+            assert.strictEqual(group.customFields.length, 1, 'the field was appended by assignment');
+        });
+    });
 });

--- a/tests/integration/components/metadata-editor-test.js
+++ b/tests/integration/components/metadata-editor-test.js
@@ -332,4 +332,15 @@ module('Integration | Component | metadata-editor', function (hooks) {
 
         assert.dom('[data-test-editor="yes"]').exists();
     });
+    // Paths the seeded fixtures never produce: a key cleared back to empty, and a null value.
+    test('clearing a key back to empty is handled rather than throwing', async function (assert) {
+        await render(TEMPLATE);
+        await click(buttonWithText('add'));
+        await fillIn(keyInputs()[0], 'my_key');
+
+        await fillIn(keyInputs()[0], '');
+
+        assert.strictEqual(keyInputs()[0].value, '', 'the input is left empty');
+        assert.dom(this.element).containsText('Key is required', 'and the row is flagged again');
+    });
 });

--- a/tests/integration/components/model-select-test.js
+++ b/tests/integration/components/model-select-test.js
@@ -536,4 +536,38 @@ module('Integration | Component | model-select', function (hooks) {
             await settled();
         });
     });
+    // Both handler slots are optional, and every case above supplies them.
+    module('with handlers omitted', function () {
+        test('choosing a suggestion with no @onCreate is a no-op rather than a crash', async function (assert) {
+            this.setProperties({ withCreate: true, labelProperty: 'name', onCreate: undefined, onChange: undefined });
+
+            await render(TEMPLATE);
+            await selectSearch('.fleetbase-model-select', 'Casey');
+            await selectChoose('.fleetbase-model-select', 'Add "Casey"...');
+
+            assert.dom(TRIGGER).exists('the select survives having nothing to report to');
+        });
+
+        test('clearing the selection reports a null id', async function (assert) {
+            // `model?.id ?? null` only reaches its fallback when the model itself is gone.
+            // Clearing is opt-in via @allowClear, which the shared TEMPLATE does not pass.
+            const changedIds = [];
+            this.setProperties({ selectedModel: DRIVERS[1], onChangeId: (id) => changedIds.push(id) });
+
+            await render(hbs`
+                <ModelSelect
+                    @modelName="driver"
+                    @optionLabel="name"
+                    @selectedModel={{this.selectedModel}}
+                    @onChangeId={{this.onChangeId}}
+                    @allowClear={{true}}
+                />
+            `);
+            assert.dom(TRIGGER).containsText('Blair Hauler');
+
+            await click('.ember-power-select-clear-btn');
+
+            assert.deepEqual(changedIds, [null], 'the cleared selection reports null rather than undefined');
+        });
+    });
 });


### PR DESCRIPTION
Six of Batch B's largest files. Four commits, reviewable in order.

> Stacked on `test/coverage-campaign`, which now has #149/#151/#152/#153/#154/#155 merged in.

## No production behaviour changes

```
addon/  4 files  +44  -0     ← every added line is a comment; zero deletions
tests/  6 files  +439 -0
```

Verified mechanically: the `addon/` diff contains no deletions and no non-comment additions.

## Results

| file | gaps before | after |
|---|---|---|
| `custom-fields-manager` | 22 | **0** |
| `comment-thread/comment` | 14 | 1 |
| `chat-tray` | 24 | 3 |
| `metadata-editor` | 13 | 5 |
| `model-select` | 14 | 8 |
| `chat-window` | 15 | 11 |

**5038 pass / 0 fail / 0 skip.** Both linters clean.

| | baseline | now |
|---|---|---|
| statements | 94.16% | **94.49%** |
| branches | 90.08% | **90.61%** |
| functions | 97.44% | 97.49% |
| lines | 94.58% | **94.88%** |

## The finding worth your time: a test shape that hides gaps

Twice, independently, the same pattern: **a test asserts a confirmation dialog appeared, then stops — while the branch under test lives in the confirm callback.**

- `custom-fields-manager`: clicking "New field group" creates the record, but `#appendGroupToSubject` only runs after the modal's save.
- `chat-window`: a test asserts the "leave this chat" copy, but `isRemovingSelf → closeChannel` only fires on confirm.

Both existing tests passed and looked thorough. The branch *counter* exposed them (`[1,0]` — ran exactly once across 37 tests); the green assertions did not. **Extending the existing test beat adding a new one** — my from-scratch duplicate of the `chat-window` case never found the remove control, because the original had setup right that I rebuilt wrong.

This generalises past coverage work: "never write an assertion that cannot fail" is not sufficient. An assertion can be perfectly falsifiable, test something genuinely true, and still be about a different line than the one you are crediting.

## Unreachable *in the code* vs unreached *by the harness*

These look identical in the report and resolve oppositely. Three calls in this batch:

- **`chat-tray`'s three `@tracked` defaults** — same signature as ~25 excluded in #154, but *live*: the constructor assigns them in an async callback that only looks synchronous because every stub resolves immediately. **Tested.**
- **`model-select`'s `getConfigOption`** — reads `[340,0]` only because the dummy app defines no `ember-model-select` config. Real consumers set it. **Left uncovered, not excluded** — with the reason recorded.
- **`custom-fields-manager`'s lookup guards** — one caller, always a function. **Excluded.**

Getting this wrong in the excluding direction is how a gate reaches 100% while concealing untested code.

## Exclusion placement: four silent failure modes

None error, warn, or fail a test. The only symptom is the gap still in the report.

1. `ignore` before `} else if` attaches to the preceding block — an if/else-if chain needs `ignore else` before the **opening** `if`.
2. Same shape before `} catch` rather than the statement inside it.
3. A scripted replacement with wrong indentation silently no-matches. Every replacement now asserts.
4. A scripted insert can match the wrong occurrence (this hit `table/th` in #154).

## New defect: #7

`metadata-editor`'s `label` getter is referenced by no template. Unlike #2 and #3 this one has a **visible consequence**: the getter defaults the heading to "Metadata", the template renders `{{@label}}` directly, so a caller omitting the argument gets *no heading at all*. An existing test already pins that behaviour.

Resolving it either starts rendering a heading everywhere callers currently omit the label, or deletes the getter. Product call — not made here.

## What still needs a decision

Five items in `DEFECTS.md`, three of which are one question (**dead getters with no template reference**: #2 `useEllipsis`, #3 `isBoolean`, #7 `label`). Plus #6 `getUnreadCount`, and the `chat-tray` socket event-name inconsistency (the component uses `chat.participant_added` in one switch and `chat.added_participant` in another — needs someone who knows what the server emits).

**These are gate-blocking, not cosmetic.** Dead code cannot be covered, and excluding it would hide the question rather than answer it. `chat-tray` sits at 3 gaps that no test can close.

Two structural blockers remain beyond them: Batch C's harness question (~a third of all remaining coverage) and #4's `layout/sidebar` nondeterminism, which can fail a 100% gate with no code change.
