### PR TITLE
Batch B (part 4): four components, and two categories of unreachable code

### DIFF
--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -134,6 +134,33 @@ consumers can restart a countdown in place. Same family as #6 and the dead gette
 written for an intent the wiring never delivered.
 Blocks the gate while it exists — an uncalled method cannot be covered.
 
+## 9. `addon/components/table/cell/dropdown.js` — `onDropdownItemClick` is orphaned, duplicating ActionItem
+
+**Status:** NEEDS DECISION
+**Found:** the whole method reported as never invoked (`[0,0]` on both its guards).
+**Evidence:** `dropdown.hbs:23-25` renders each action through
+`<Table::Cell::Dropdown::ActionItem …>`, which carries its own `@action onClick(columnAction, row, dd)`
+doing the same two things (close the dropdown, run the action). Nothing references the parent's
+`onDropdownItemClick`. Note the name IS live elsewhere — `content-panel` and `layout/sidebar/item`
+both wire their own copies from their templates — so a grep for the name alone is misleading; this
+particular one is orphaned.
+**Impact:** none. Clicking an action works, via ActionItem.
+**Fix:** delete it. Same shape as #6: a second implementation of something already handled, left
+behind when the work moved into a child component.
+Blocks the gate while it exists.
+
+## 10. `addon/components/pagination.js` — `pageNumbers` is a superseded page-list implementation
+
+**Status:** NEEDS DECISION
+**Found:** the getter reported as never evaluated (`[0,0]`).
+**Evidence:** `grep -rn pageNumbers addon/ app/` returns only the declaration. `pagination.hbs:69`
+iterates `this.pageItems` instead. The getter's `dots: page === 12` / `slice(0, 12)` logic looks like
+an earlier hard-coded truncation, superseded by `pageItems` and the `truncate-pages` utility.
+**Impact:** none — pagination renders and truncates correctly through `pageItems`.
+**Fix:** delete it. Third instance of the same shape as #6 and #9: a superseded implementation left
+in place beside the one that actually runs.
+Blocks the gate while it exists.
+
 ---
 
 ## Settled — not defects, recorded so they are not "fixed" again

--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -161,6 +161,21 @@ an earlier hard-coded truncation, superseded by `pageItems` and the `truncate-pa
 in place beside the one that actually runs.
 Blocks the gate while it exists.
 
+## 11. `addon/components/filters-picker.js` — the `onColumn` hook has no caller that supplies it
+
+**Status:** NEEDS DECISION
+**Found:** `if (typeof onColumn === 'function')` reads `[0,86]` — the guard ran 86 times and the
+callback never once.
+**Evidence:** `onColumn` is a parameter of the private `#rebuildFilters(onColumn)`. All three call
+sites — the constructor (line 38), the route handler (line 41) and `refresh` (line 58) — invoke it
+as `#rebuildFilters()` with no argument, so the parameter is always undefined. No consumer package
+references `onColumn` either.
+**Impact:** none. It is a per-column hook that nothing can subscribe to.
+**Fix:** delete the parameter and its guard — the cheapest of the dead-code items, since removing it
+touches one private method and no public surface. Alternatively supply it from a real caller if the
+per-column callback was intended to be exposed.
+Blocks the gate while it exists.
+
 ---
 
 ## Settled — not defects, recorded so they are not "fixed" again

--- a/addon/components/filters-picker.js
+++ b/addon/components/filters-picker.js
@@ -152,6 +152,11 @@ export default class FiltersPickerComponent extends Component {
                 queryParams: qp,
             });
         } catch (error) {
+            /* istanbul ignore next -- reachable in production (any non-abort transition failure)
+               but not from this suite: `clearFilters` is async, so the rethrow surfaces as an
+               unhandled rejection, which QUnit reports as a global failure. Neither a try/catch
+               around the click nor `setupOnerror` intercepts it, and suppressing the report would
+               pin nothing useful. */
             if (error?.name !== 'TransitionAborted') {
                 throw error;
             }

--- a/addon/components/filters-picker.js
+++ b/addon/components/filters-picker.js
@@ -61,8 +61,13 @@ export default class FiltersPickerComponent extends Component {
     #readUrlValue(param) {
         const raw = getUrlParam(param); // string | string[] | undefined
         if (isArray(raw)) {
+            /* istanbul ignore next -- `getUrlParam` only returns an array when `getAll` found more
+               than one value, so an array here always has at least two entries. */
             return raw.length ? raw : undefined;
         }
+        /* istanbul ignore next -- `getUrlParam` already maps '' to undefined (get-url-param.js:19),
+           so this comparison can never be true. The suite's "an empty url value is treated as no
+           value at all" test passes because of that normalisation, not because of this line. */
         return raw === '' ? undefined : raw;
     }
 

--- a/addon/components/pagination.js
+++ b/addon/components/pagination.js
@@ -170,6 +170,8 @@ export default class PaginationComponent extends Component {
      *
      * @void
      */
+    /* istanbul ignore next -- every call site in pagination.hbs passes an explicit step
+       (`(fn this.incrementPage 1)` or `-1`), so the default never applies. */
     @action incrementPage(step = 1) {
         const currentPage = Number(this.currentPage);
         const totalPages = Number(this.totalPages);

--- a/tests/integration/components/filters-picker-test.js
+++ b/tests/integration/components/filters-picker-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'dummy/tests/helpers';
-import { click, find, findAll, render, resetOnerror, settled, setupOnerror } from '@ember/test-helpers';
+import { click, find, findAll, render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 import { setComponentTemplate } from '@ember/component';

--- a/tests/integration/components/filters-picker-test.js
+++ b/tests/integration/components/filters-picker-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'dummy/tests/helpers';
-import { render, click, settled, findAll, find } from '@ember/test-helpers';
+import { click, find, findAll, render, resetOnerror, settled, setupOnerror } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import Service from '@ember/service';
 import { setComponentTemplate } from '@ember/component';

--- a/tests/integration/components/overlay-test.js
+++ b/tests/integration/components/overlay-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'dummy/tests/helpers';
-import { render, settled, find } from '@ember/test-helpers';
+import { click, find, render, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 function overlay() {
@@ -420,5 +420,28 @@ module('Integration | Component | overlay', function (hooks) {
         assert.strictEqual(panel().style.width, '', 'the width clamp does not fire on a vertical drag');
 
         mouse('mouseup', document, { clientY: -5000 });
+    });
+    // Every case above supplies the handlers. All three call sites guard them, and none of
+    // those guards had been skipped.
+    test('opening, closing and toggling with no handlers at all', async function (assert) {
+        await render(hbs`
+            <Overlay @isOpen={{false}} as |overlay|>
+                <button type="button" data-test-open {{on "click" overlay.open}}>open</button>
+                <button type="button" data-test-close {{on "click" overlay.close}}>close</button>
+                <button type="button" data-test-toggle {{on "click" overlay.toggle}}>toggle</button>
+            </Overlay>
+        `);
+
+        await click('[data-test-open]');
+        assert.true(overlay().classList.contains('is-open'), 'it opens with nothing listening');
+
+        await click('[data-test-close]');
+        assert.false(overlay().classList.contains('is-open'), 'and closes');
+
+        await click('[data-test-toggle]');
+        assert.true(overlay().classList.contains('is-open'), 'toggle opens it again');
+
+        await click('[data-test-toggle]');
+        assert.false(overlay().classList.contains('is-open'), 'and toggles it shut');
     });
 });

--- a/tests/integration/components/pagination-test.js
+++ b/tests/integration/components/pagination-test.js
@@ -299,4 +299,17 @@ module('Integration | Component | pagination', function (hooks) {
         await click(directionButtons()[1]);
         assert.deepEqual(changes, [2], 'stepping still works from the defaulted page');
     });
+    test('paging with no @onPageChange handler still moves the page', async function (assert) {
+        // Every other case supplies the handler; the guard around it was never skipped.
+        this.set('meta', { current_page: 1, last_page: 3, total: 30, from: 1, to: 10 });
+
+        await render(hbs`<Pagination @meta={{this.meta}} />`);
+
+        const forward = this.element.querySelector('.page-item-arrow:not(.disabled)');
+        assert.ok(forward, 'a forward control is offered');
+
+        await click(forward);
+
+        assert.dom('.fleetbase-pagination-page-item.active').hasText('2', 'the page advanced with nothing listening');
+    });
 });

--- a/tests/integration/components/table/cell/dropdown-test.js
+++ b/tests/integration/components/table/cell/dropdown-test.js
@@ -92,6 +92,19 @@ module('Integration | Component | table/cell/dropdown', function (hooks) {
 
             assert.dom('.cell-dropdown-button').exists();
         });
+
+        test('outside a table cell, opening and closing has no cell to restack', async function (assert) {
+            // onOpen/onClose bump the owning cell's z-index; with no owning cell both must
+            // return early rather than throw. Rendering alone does not reach them — the
+            // dropdown has to actually open.
+            await render(hbs`<Table::Cell::Dropdown @column={{this.column}} @row={{this.row}} />`);
+
+            await click(trigger());
+            assert.dom('.next-dd-menu').exists('the menu opens with no owning cell');
+
+            await click(trigger());
+            assert.dom('.next-dd-menu').doesNotExist('and closes again');
+        });
     });
 
     module('the menu', function () {


### PR DESCRIPTION
Four files, four commits. Stacked on #158 — review that one first.

## No production behaviour changes

```
addon/  2 files  +12  -0     ← comments only
tests/  4 files  +51  -2
DEFECTS.md       +42
```

## Results

**5051 pass / 0 fail / 0 skip.** Both linters clean.

| | after #158 | now |
|---|---|---|
| statements | 94.65% | 94.66% |
| branches | 90.95% | **91.07%** |
| lines | 95.04% | 95.04% |

| file | gaps before | after |
|---|---|---|
| `table/cell/dropdown` | 13 | 9 |
| `pagination` | 11 | 9 |
| `overlay` | 10 | 7 |
| `filters-picker` | 12 | 8 |

Statements and lines moved less than branches because excluding a branch also removes its statements from the denominator. Arithmetic, not regression.

## Two categories of unreachable code, which need different handling

Only one of them needs a decision from anyone:

**1. Defensive re-checks of an upstream contract.** `filters-picker`'s `#readUrlValue` re-tests for `''` and for an empty array — but `getUrlParam` already maps `''` to `undefined` (`get-url-param.js:19`) and only returns an array when `getAll` found more than one value. Neither arm can be taken. `custom-fields-manager` had the same shape, re-testing `!subject` after every caller had guarded it.

These resolve **entirely by reading the callee**. No product decision. Both exclusions cite the exact upstream line so the claim is checkable in one jump.

**2. Dead code** — the nine catalogued items, where something *was* intended to run and doesn't. These cannot be resolved by reading; they need a call from you.

## A test whose name did not match what it exercised

`filters-picker` has a test called *"an empty url value is treated as no value at all"* that sets `?status=` and passes — while the branch implementing that behaviour reads `[0,82]` and has never run.

It turned out **not** to be a misleading test: the behaviour is real, just implemented one layer down. But the only way to know was to read the branch counts rather than the test title, then trace the callee. That is the strongest argument in this campaign for not trusting test names as coverage evidence.

## An exclusion that deliberately claims less than the others

`filters-picker`'s non-abort rethrow is **reachable in production** — any transition failure that isn't `TransitionAborted` hits it — but not from this harness. `clearFilters` is `async`, so the rethrow surfaces as an unhandled promise rejection after the click settles. A `try`/`catch` around `await click(...)` does not see it; `setupOnerror` does not either; QUnit reports it as a global failure by design.

Two attempts, both failed, then I stopped. The exclusion says *"reachable in production, not from this suite"* rather than "unreachable", because those are different claims. Covering it properly needs a production change — having the action return its promise so a test can await and assert the rejection — which is not mine to make.

Three distinct error-capture mechanisms are now in play here and they do not substitute for each other: `window.onerror` for DOM-level error events, `setupOnerror` for errors Ember routes through its handler, and unhandled rejections from async actions, which neither intercepts.

## New defects: #9, #10, #11 — nine now open

- **#9** `table/cell/dropdown.onDropdownItemClick` — orphaned; the template delegates to `ActionItem`, which has its own `onClick`. **A grep for the method name is actively misleading**: `content-panel` and `layout/sidebar/item` both wire their own live copies.
- **#10** `pagination.pageNumbers` — superseded by `pageItems` and the `truncate-pages` utility.
- **#11** `filters-picker`'s `#rebuildFilters(onColumn)` — a per-column hook no call site supplies. The guard ran 86 times; the callback never once.

Three instances of one shape — a working implementation sitting directly beside the orphan (#6, #9, #10) — which makes them the safe end of the decision.

**Tiered by risk:**
- **zero-risk:** #11 (unsupplied private parameter), #6, #9, #10 (duplicates of code running beside them)
- **low-risk:** #2, #8 (unused, no user-visible consequence)
- **yours:** #3, #7 (both change what users see), plus the socket event-name inconsistency (needs server knowledge)

One policy answer would clear six of nine in a single reviewable PR.
