### PR TITLE
full-calendar: actually stop the listener leak

### DIFF
--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -266,7 +266,7 @@ rather than assumed — CI would hit the same wall on a Node 18 image.
 
 ## 17. `addon/components/full-calendar.js` — every event listener leaks, and the obvious fix does not work
 
-**Status:** OPEN — NEEDS DECISION (the fix is not a one-liner; see below)
+**Status:** FIXED (PR #161)
 **Note on numbering:** commit `8410e7e` refers to this as "#13". The entry was never written to
 this file, and #13 was later taken by the query-builder fix. This is the entry that commit means.
 **Found:** five of full-calendar's remaining coverage gaps are the whole body of
@@ -278,15 +278,28 @@ nothing ever unregisters them.
 **Impact:** real, and it costs users. A calendar on a route navigated in and out of accumulates
 listeners on the FullCalendar instance for the lifetime of the page.
 **Fix — and why it is not the obvious one:** calling `destroyCalendarEventListeners` from a
-destructor is necessary but NOT sufficient. The method does:
+destructor is necessary but NOT sufficient. The method did:
 
     this.calendar.off(eventName, this.triggerCalendarEvent.bind(this, callbackName));
 
 `.bind()` returns a NEW function every time, so the reference passed to `.off()` can never equal the
 one `.on()` was given, and FullCalendar removes nothing. Wiring the call up as-is would look like a
-fix, pass a test that only asserts the method ran, and leak exactly as before. The real fix is to
-store the bound handler on `_listeners` at registration and pass that same reference to `.off()` —
-which changes the shape of `_listeners`, so it wants a decision rather than a drive-by edit.
+fix, pass a test that only asserts the method ran, and leak exactly as before.
+
+**Applied:** `createCalendarEventListeners` now binds once, stores the resulting function on the
+`_listeners` entry, and hands that same reference to both `.on()` and `.off()`; `willDestroy` calls
+`destroyCalendarEventListeners`, which also empties `_listeners`. Covered by *a destroyed calendar
+stops firing its callbacks* and *every subscribed event is unsubscribed, not just the first*, which
+assert the observable behaviour — trigger the event after teardown and require no callback — rather
+than that the method ran. Both were confirmed to FAIL against the `.bind()` mismatch with
+`willDestroy` already wired, which is the version that looks fixed and is not.
+full-calendar.js is now at 100% statements, branches, functions and lines.
+
+**Still open, and deliberately out of scope here:** the component never calls
+`this.calendar.destroy()`, so the FullCalendar instance and the document-level handlers it installs
+outlive the component. That is a separate and probably larger leak than the one above — the
+integration tests work around it with an `afterEach` that destroys the captured calendar. Fixing it
+changes what a consumer's `@onInit` reference points at after teardown, so it needs its own decision.
 
 ---
 

--- a/addon/components/full-calendar.js
+++ b/addon/components/full-calendar.js
@@ -87,14 +87,21 @@ export default class FullCalendarComponent extends Component {
             const callbackName = `on${classify(eventName)}`;
 
             if (typeof this.args[callbackName] === 'function') {
+                // Bind ONCE and keep the resulting function. `.bind()` returns a new function on
+                // every call, so `calendar.off()` can only unsubscribe if it is handed the exact
+                // reference `calendar.on()` was given — binding again at destroy time removes
+                // nothing at all.
+                const handler = this.triggerCalendarEvent.bind(this, callbackName);
+
                 // track for destroy purposes
                 this._listeners.push({
                     eventName,
                     callbackName,
+                    handler,
                 });
 
                 // create listener
-                this.calendar.on(eventName, this.triggerCalendarEvent.bind(this, callbackName));
+                this.calendar.on(eventName, handler);
             }
         }
 
@@ -105,10 +112,26 @@ export default class FullCalendarComponent extends Component {
     destroyCalendarEventListeners() {
         for (let i = 0; i < this._listeners.length; i++) {
             const listener = this._listeners[i];
-            const { eventName, callbackName } = listener;
+            const { eventName, handler } = listener;
 
             // kill listener
-            this.calendar.off(eventName, this.triggerCalendarEvent.bind(this, callbackName));
+            this.calendar.off(eventName, handler);
         }
+
+        this._listeners = [];
+    }
+
+    /**
+     * Unsubscribe every calendar listener when the component goes away.
+     *
+     * Nothing called `destroyCalendarEventListeners` before this, so a calendar on a route the
+     * user navigated in and out of accumulated a listener per callback for the lifetime of the
+     * page. `_listeners` is only ever populated after `this.calendar` exists, so an empty list
+     * here means the calendar was never set up and there is nothing to unsubscribe from.
+     */
+    willDestroy() {
+        super.willDestroy(...arguments);
+
+        this.destroyCalendarEventListeners();
     }
 }

--- a/tests/integration/components/full-calendar-test.js
+++ b/tests/integration/components/full-calendar-test.js
@@ -165,4 +165,64 @@ module('Integration | Component | full-calendar', function (hooks) {
 
         assert.dom('.fc').exists('the calendar still initialises and renders');
     });
+    // The leak these cover (DEFECTS #17): nothing ever called destroyCalendarEventListeners, and
+    // even when called it re-bound the handler, so `off()` was handed a function `on()` had never
+    // seen and FullCalendar removed nothing. Both tests fail against the pre-fix component — the
+    // callback still fires after the component is gone.
+    module('tearing down', function () {
+        test('a destroyed calendar stops firing its callbacks', async function (assert) {
+            const clicks = [];
+            this.set('show', true);
+            this.set('onEventClick', () => clicks.push('click'));
+
+            await render(hbs`
+                {{#if this.show}}
+                    <FullCalendar @onEventClick={{this.onEventClick}} @onInit={{this.onInit}} />
+                {{/if}}
+            `);
+
+            calendar.trigger('eventClick', {});
+            await settled();
+            assert.strictEqual(clicks.length, 1, 'the callback fires while the component is alive');
+
+            this.set('show', false);
+            await settled();
+
+            calendar.trigger('eventClick', {});
+            await settled();
+
+            assert.strictEqual(clicks.length, 1, 'and not once the component is gone');
+        });
+
+        test('every subscribed event is unsubscribed, not just the first', async function (assert) {
+            const fired = [];
+            this.set('show', true);
+            this.setProperties({
+                onDateClick: () => fired.push('dateClick'),
+                onEventClick: () => fired.push('eventClick'),
+                onEventDrop: () => fired.push('eventDrop'),
+            });
+
+            await render(hbs`
+                {{#if this.show}}
+                    <FullCalendar
+                        @onInit={{this.onInit}}
+                        @onDateClick={{this.onDateClick}}
+                        @onEventClick={{this.onEventClick}}
+                        @onEventDrop={{this.onEventDrop}}
+                    />
+                {{/if}}
+            `);
+
+            this.set('show', false);
+            await settled();
+
+            for (const eventName of ['dateClick', 'eventClick', 'eventDrop']) {
+                calendar.trigger(eventName, {});
+            }
+            await settled();
+
+            assert.deepEqual(fired, [], 'no listener survives the teardown');
+        });
+    });
 });


### PR DESCRIPTION
Fixes DEFECTS #17. One component, one behaviour change, two tests.

## The leak

Nothing ever called `destroyCalendarEventListeners` — no `willDestroy`, no
`registerDestructor`, no reference in `full-calendar.hbs`. Every `on<Event>` callback a consumer
supplies is registered with `calendar.on(...)` and pushed onto `_listeners`, and nothing ever
unregisters it. A calendar on a route the user navigates in and out of accumulates a listener per
callback for the lifetime of the page.

## Why this was flagged instead of fixed in passing

Wiring the destructor up is necessary but **not sufficient**. The method did:

```js
this.calendar.off(eventName, this.triggerCalendarEvent.bind(this, callbackName));
```

`.bind()` returns a new function on every call, so the reference handed to `.off()` can never equal
the one `.on()` was given, and FullCalendar removes nothing.

That version *looks* fixed. The destructor runs, the method runs, nothing errors, and a test
asserting "destroyCalendarEventListeners was called" passes — while every listener stays
registered.

## The fix

Bind once, keep the resulting function on the `_listeners` entry, hand that same reference to both
`.on()` and `.off()`, and empty `_listeners` afterwards. `willDestroy` calls it.

## The tests

Both assert the observable behaviour rather than the call: trigger the event after the component is
destroyed and require no callback to fire.

Both were confirmed to **fail** against the `.bind()` mismatch with `willDestroy` already wired —
that is, against the version that looks fixed and is not:

```
not ok 1 — tearing down: a destroyed calendar stops firing its callbacks
not ok 2 — tearing down: every subscribed event is unsubscribed, not just the first
```

`full-calendar.js` is now at **100% statements, branches, functions and lines** (22 tests) — the
five gaps that remained in it were the leak.

## Left open, deliberately

The component never calls `this.calendar.destroy()`, so the FullCalendar instance and the
document-level handlers it installs outlive the component. That is a separate and probably larger
leak than this one; the integration tests already work around it with an `afterEach` that destroys
the captured calendar. Fixing it changes what a consumer's `@onInit` reference points at after
teardown, so it wants its own decision rather than being folded in here. Recorded in DEFECTS #17.

## Verification

- `full-calendar` filtered run: 22 pass, 0 fail.
- `rm -f .eslintcache && pnpm run lint` → exit 0.
- Coverage read from a freshly generated `coverage-final.json`, not from a passing run.
