### PR TITLE
Work through DEFECTS.md: sixteen of seventeen entries

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,6 +62,7 @@ module.exports = {
                 './config/**/*.js',
                 './scripts/check-coverage.js',
                 './scripts/check-coverage-test.js',
+                './scripts/stamp-coverage-run.js',
                 './tests/dummy/config/**/*.js',
             ],
             parserOptions: {

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@
 # the coverage folder and into the package root (see config/coverage.js).
 /ember-core/
 /*/addon/**/*.js.html
+
+# Written by scripts/stamp-coverage-run.js; proves the coverage artifacts belong to the last run
+.coverage-run-stamp.json

--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -259,10 +259,18 @@ three fields it manages. Not a call to make from the coverage side.
    passed. Use a pinned Node 22 for every run.
 **Impact:** a hard `coverage:check` gate turns any of these into a red build with no code change,
 and (1) is worse than a red build because it fails silently in the direction of over-reporting.
-**Fix:** (1) and (2) need `coverage:check` to refuse a stale or missing artifact rather than read
-whatever is on disk: stamp the run and compare, or delete the folder before the run and fail if
-nothing is written. (3) needs an `engines` field and an `.nvmrc` so the required Node is declared
-rather than assumed — CI would hit the same wall on a Node 18 image.
+**What CI already does, and where it falls short.** `.github/workflows/ci.yml` pins
+`NODE_VERSION: 22.x`, so (3) cannot bite CI — it is a local-development trap only, and an `engines`
+field plus an `.nvmrc` would declare the requirement rather than leave it to whichever Node a shell
+happens to resolve. The workflow also runs `test -s coverage/lcov.info` after the gate, which
+catches the crudest form of (2). But that check looks at `lcov.info`, not `coverage-final.json`, and
+it tests only for existence — a stale artifact left by a previous run passes it.
+
+**Fix:** (1) and (2) need `coverage:check` to refuse an artifact it cannot prove is fresh, rather
+than reading whatever is on disk. Either stamp the run and require the artifact to be newer, or
+delete `coverage/` before the run and fail loudly if nothing is written. Locally, `rm -rf coverage`
+before a run has produced a complete set every time, where deleting only `coverage-final.json`
+has not.
 
 ## 17. `addon/components/full-calendar.js` — every event listener leaks, and the obvious fix does not work
 

--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -35,7 +35,7 @@ keeps the save button off read-only panels.
 
 ## 1. `addon/components/chat-window/attachment.js` — a filename with no extension crashes the component
 
-**Status:** OPEN
+**Status:** FIXED (PR #163)
 **Found:** writing a test for the `extensionMatch ? extensionMatch[1] : null` fallback.
 **Evidence:** `getExtension` returns `null` for a filename with no dot; `getIcon` passes that
 straight to `getWithDefault`, which asserts `The key provided to get must be a string or number`.
@@ -46,27 +46,42 @@ Confirmed by test: the component throws during render rather than falling back.
 uncovered until then — the only test that reaches it asserts a crash, which would pin behaviour that
 should change.
 
+**Applied:** `getIcon` returns `'file-alt'` when there is no extension, the same guard
+`file-icon.js` already used. Covered by *a filename with no extension renders rather than throwing*
+and *a dotfile with no extension also renders*.
+
 ## 2. `addon/components/overlay/header.js` — `useEllipsis` is referenced by no template
 
-**Status:** NEEDS DECISION
+**Status:** FIXED (PR #163)
 **Evidence:** `grep -rn useEllipsis addon app` returns only the definition. `overlay/header.hbs`
 gates the truncated title on `@overlay.isMinimized` instead.
 **Impact:** the 15-character threshold the getter encodes has no effect anywhere — a minimized
 overlay always truncates however short the title, and a non-minimized one never does.
 **Fix:** delete the getter, or wire it if the threshold is the intended behaviour. Product call.
 
+**Applied:** `@titleEllipsis` opts a non-minimized header into truncation, and
+`@titleEllipsisLength` sets the threshold (default 15, the value the getter always encoded).
+A minimized overlay still truncates regardless, so no existing call site changes behaviour.
+The misspelled internal getter is now `titleWithEllipsis`, and `isTitleTruncated` holds the
+decision. Eight tests, including a length of 0 and the exclusive threshold.
+
 ## 3. `addon/components/report-builder/condition-value.js` — `isBoolean` is referenced by no template
 
-**Status:** NEEDS DECISION
+**Status:** FIXED (PR #163)
 **Evidence:** `condition-value.hbs` branches on `isDate`, `isDateTime`, `isNumber`, `isJSON`, then
 falls through to a text input. There is no boolean arm.
 **Impact:** a column typed `boolean` gets a free-text field.
 **Fix:** either a stale getter to delete, or a missing editor to build. Product call — more likely
 the latter.
 
+**Applied:** a True/False radio group, using the addon's own `<RadioButton>`. It reports real
+booleans, normalises values that round-tripped as `'true'`/`1`, selects neither option for an
+unrecognised value, and gives each rendered editor its own group name via `guidFor` so two boolean
+conditions cannot clear each other. Eight tests.
+
 ## 4. `addon/components/layout/sidebar.js` — makes the coverage total nondeterministic
 
-**Status:** OPEN
+**Status:** FIXED (PR #163)
 **Evidence:** two `test:coverage` runs on identical code, both fully green, reported 8479 vs 8477
 covered statements. A per-file diff of the two `coverage-final.json` artifacts names this file alone
 (201 vs 199); every other file is byte-identical between runs.
@@ -76,17 +91,32 @@ runs with no code change. This is a blocker for the gate, not a cosmetic issue.
 tracker's #129 for why deterministic scheduling there carries behavioural risk). Must be resolved,
 or the racing lines proven irrelevant, before the 100% gate can be trusted.
 
+**Applied — and the first diagnosis was wrong.** The racing statements are NOT the
+`requestAnimationFrame` callback, which runs reliably. They are the *cancel* branches in
+`flushResizeFrame()` (187-188) and `teardown()` (368-369), reached only when a frame is still
+pending — which depended on whether the browser painted first. An earlier attempt that awaited the
+frame before releasing the gutter made it strictly worse, permanently closing the only path to
+187-188.
+
+The fix is two tests that dispatch synchronously, with no `await` between the events, so no paint
+can intervene and a pending frame is a certainty. That idiom was already in use a few tests earlier
+in the same file. `sidebar.js` went from 199/215 to 203/215 — exactly those four statements — and
+the value no longer depends on timing.
+
 ## 5. `addon/components/layout/resource/panel.hbs:5` — `@onToggle` points at an action that does not exist
 
-**Status:** OPEN
+**Status:** FIXED (PR #163)
 **Evidence:** the template wires `@onToggle={{this.onToggle}}`; `panel.js` defines no `onToggle`.
 **Impact:** `undefined` is passed to `<Overlay>`. Harmless today because the overlay guards it, but
 it means the panel silently cannot forward a toggle.
 **Fix:** define the action, or drop the wiring.
 
+**Applied:** `onToggle` is defined and forwards through `contextComponentCallback`, matching
+`onOpen` and `onClose`. Two tests.
+
 ## 6. `addon/components/chat-tray.js` — `getUnreadCount` is a second, unwired implementation
 
-**Status:** NEEDS DECISION
+**Status:** FIXED (PR #163)
 **Found:** the whole task reported as never invoked while covering chat-tray.
 **Evidence:** `grep -rn getUnreadCount addon/` returns only the declaration — nothing performs it. The
 unread badge is NOT broken: `chat-tray.js:294` (`countUnread`) already sets `this.unreadCount` by
@@ -100,9 +130,14 @@ server value win. Not a bug fix either way — it is a choice about where the nu
 Blocks the 100% gate while it exists: dead code cannot be covered, and excluding it would hide the
 question rather than answer it.
 
+**Decision:** the server is authoritative. `getUnreadCount` is performed after `countUnread` on
+both load and reload, so the summed count shows immediately and the server total replaces it.
+The task is `restartable` (a slow earlier response cannot overwrite a newer one) and failures are
+caught, leaving the summed count rather than blanking the badge. Four tests.
+
 ## 7. `addon/components/metadata-editor.js` — the `label` getter is referenced by no template, so its default never applies
 
-**Status:** NEEDS DECISION
+**Status:** FIXED (PR #163)
 **Found:** the getter reported as never invoked — `[0,0]`, meaning it is not called at all.
 **Evidence:** `metadata-editor.hbs:3-4` reads the argument directly:
 ```hbs
@@ -120,9 +155,13 @@ heading everywhere a caller omits the argument, a visible change — or delete t
 that the heading is opt-in. Product call.
 Blocks the gate while it exists: an uncalled getter cannot be covered.
 
+**Decision:** the template reads `{{this.label}}`, so the 'Metadata' default now applies. Note
+`?? 'Metadata'` is nullish-coalescing, so passing `@label=""` is the way to opt out of the heading
+now that omitting the argument no longer does. Three tests.
+
 ## 8. `addon/components/countdown.js` — `restartCountdown` is never called
 
-**Status:** NEEDS DECISION
+**Status:** FIXED (PR #163)
 **Found:** the whole method reported as never invoked.
 **Evidence:** `grep -rn restartCountdown addon/` returns only the declaration and its docblock. It
 is not an `@action`, not referenced by `countdown.hbs`, and not called from anywhere in the class.
@@ -134,9 +173,14 @@ consumers can restart a countdown in place. Same family as #6 and the dead gette
 written for an intent the wiring never delivered.
 Blocks the gate while it exists — an uncalled method cannot be covered.
 
+**Decision:** exposed rather than deleted. `restartCountdown` is an `@action` and both
+`@onCountdownEnd` and `@onEnd` receive `{ restartFn }`, so a consumer writes
+`handleEnd({ restartFn }) { restartFn(); }`. Existing consumers that declare no parameters are
+unaffected. Three tests.
+
 ## 9. `addon/components/table/cell/dropdown.js` — `onDropdownItemClick` is orphaned, duplicating ActionItem
 
-**Status:** NEEDS DECISION
+**Status:** FIXED (PR #163) — deleted
 **Found:** the whole method reported as never invoked (`[0,0]` on both its guards).
 **Evidence:** `dropdown.hbs:23-25` renders each action through
 `<Table::Cell::Dropdown::ActionItem …>`, which carries its own `@action onClick(columnAction, row, dd)`
@@ -151,7 +195,7 @@ Blocks the gate while it exists.
 
 ## 10. `addon/components/pagination.js` — `pageNumbers` is a superseded page-list implementation
 
-**Status:** NEEDS DECISION
+**Status:** FIXED (PR #163) — deleted
 **Found:** the getter reported as never evaluated (`[0,0]`).
 **Evidence:** `grep -rn pageNumbers addon/ app/` returns only the declaration. `pagination.hbs:69`
 iterates `this.pageItems` instead. The getter's `dots: page === 12` / `slice(0, 12)` logic looks like
@@ -163,7 +207,7 @@ Blocks the gate while it exists.
 
 ## 11. `addon/components/filters-picker.js` — the `onColumn` hook has no caller that supplies it
 
-**Status:** NEEDS DECISION
+**Status:** FIXED (PR #163)
 **Found:** `if (typeof onColumn === 'function')` reads `[0,86]` — the guard ran 86 times and the
 callback never once.
 **Evidence:** `onColumn` is a parameter of the private `#rebuildFilters(onColumn)`. All three call
@@ -176,9 +220,12 @@ touches one private method and no public surface. Alternatively supply it from a
 per-column callback was intended to be exposed.
 Blocks the gate while it exists.
 
+**Decision:** the hook was meant to be the consumer's. `#rebuildFilters` reads
+`this.args.onColumn` and the unused parameter is gone. Three tests.
+
 ## 12. `addon/components/country-select.js` — the `changed` action is wired to nothing
 
-**Status:** NEEDS DECISION
+**Status:** FIXED (PR #163) — deleted
 **Found:** the whole action reported as never invoked (`[0,0]` on its only branch).
 **Evidence:** `country-select.hbs` wires `handleChange` (as `{{did-update this.handleChange @value}}`)
 and `selectCountry` (as PowerSelect's `@onChange`). It never references `changed`, and the template
@@ -191,7 +238,7 @@ Blocks the gate while it exists.
 
 ## 13. `addon/components/query-builder/conditions.js` — a multi-value condition kept only the last value picked
 
-**Status:** FIXED (this branch)
+**Status:** FIXED (PR #161)
 **Found:** writing the first real test for the `is one of` editor. Selecting `active` then `pending`
 reported `['pending']`, not `['active', 'pending']`.
 **Evidence:** `updateConditionValue` mutated `cond.value` on the existing condition object and then
@@ -211,7 +258,7 @@ fails against the old code.
 
 ## 14. `addon/components/template-builder/properties-panel.hbs:73` — `value="target.value"` on `{{fn}}` does nothing
 
-**Status:** NEEDS DECISION (cosmetic; no behaviour change either way)
+**Status:** FIXED (PR #163)
 **Found:** chasing the uncovered `event?.target ? event.target.value : event` branch in `updateProp`.
 The only call site that looks like it passes a raw value is this one.
 **Evidence:** `{{on "input" (fn this.updateProp "content" value="target.value")}}`. `value=` is an
@@ -224,9 +271,13 @@ string, and the `: event` fallback in `updateProp` exists to serve a call shape 
 `updateNumericProp` and `updateTemplateProp` should stay is a separate call — it is currently
 unreachable from this template and is documented as such.
 
+**Applied:** the `value=` argument is dropped. The `: event` fallbacks in `updateProp`,
+`updateNumericProp` and `updateTemplateProp` remain unreachable from this template and stay
+documented as such.
+
 ## 15. `addon/components/template-builder/properties-panel.js:219` — the table's `query` data mode has no control
 
-**Status:** NEEDS DECISION
+**Status:** DEFERRED — a later update, by decision
 **Found:** `else if (mode === 'query')` reports `[0,0]` — never evaluated either way.
 **Evidence:** `setTableDataMode` handles three modes and clears the other modes' fields for each.
 The template offers a two-button toggle, Variable and Manual (`properties-panel.hbs:258` and `:266`);
@@ -237,12 +288,20 @@ by this action and read by nothing.
 **Impact:** none at runtime. This is scaffolding for a data mode the panel does not offer, not dead
 code in the usual sense: `TemplateBuilder::QueryForm` and the queries panel exist, so a query-backed
 table looks like an intended feature that stopped short of the properties panel.
-**Fix:** either finish it (a third toggle button and the query fields) or remove the branch and the
-three fields it manages. Not a call to make from the coverage side.
+**Fix:** finish it. Confirmed as intended behaviour — fetch from a url with params — and deferred to
+its own session rather than half-built here. What it needs before anyone starts: an endpoint
+contract, an auth story, loading and error states, a defined shape for `query_response_path`, and
+something on the render side that consumes a query-backed table (nothing does today). It also has to
+be reconciled with the `__queries__` variable route, which already solves the same problem by
+exposing saved queries as variables — otherwise the panel ends up with two competing mechanisms.
+
+Until then the branch stays uncovered rather than suppressed: an `istanbul ignore` here would have
+to sit on the opening `if`, and `ignore else` there also swallows the `variable` branch, which real
+tests cover.
 
 ## 16. Coverage collection itself is unreliable, which the 100% gate cannot tolerate
 
-**Status:** OPEN — blocks the gate, alongside #4
+**Status:** PARTIALLY FIXED (PR #163) — detection landed, the cause has not
 **Found:** repeatedly, while verifying single files.
 **Evidence:** three distinct failure modes, all observed in one session:
 1. A run reports `# tests 77 / # pass 77 / # fail 0` and leaves `coverage/coverage-final.json`
@@ -271,6 +330,27 @@ than reading whatever is on disk. Either stamp the run and require the artifact 
 delete `coverage/` before the run and fail loudly if nothing is written. Locally, `rm -rf coverage`
 before a run has produced a complete set every time, where deleting only `coverage-final.json`
 has not.
+
+**Applied — detection.** `scripts/stamp-coverage-run.js` clears `coverage/` and records when the
+run started; `test:coverage` runs it first. `checkArtifactFreshness` in the gate now rejects a
+missing stamp, an unreadable one, an artifact older than the run, and a `coverage-final.json` that
+was never written — before it reads a single percentage. The self-test grew from 10 cases to 17,
+including the dangerous one: a green suite that leaves the previous artifact in place.
+
+**Still open — the cause.** Collection itself keeps failing. Measured across this session: 7 of 9
+fast filtered runs produced no `coverage/` directory at all, while every full run produced one.
+That points at the addon POSTing `window.__coverage__` from the browser at test end and a short run
+tearing down before the request completes. It is therefore a local-development tax rather than a CI
+risk — CI runs the full suite — but it makes per-file verification unreliable, which is how most of
+this campaign's work gets checked.
+
+**Correcting two earlier claims in this entry's history:** `rm -rf coverage` before a run does NOT
+make collection reliable (it was the first thing tried, and the 7-of-9 figure above is *with* it),
+and the Node 18 ESM failure is unrelated to this and cannot affect CI, which pins Node 22.
+
+**Next step, unstarted:** the addon's `parallel` option writes per-browser JSON to disk instead of
+POSTing. Flipping it and running the fast filter ten times would either fix the cause or rule it
+out in about twenty minutes.
 
 ## 17. `addon/components/full-calendar.js` — every event listener leaks, and the obvious fix does not work
 

--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -347,3 +347,113 @@ Two tests in this repo primed a null response and silently got `[]`.
   not refetched on tab change. Edits made inside the manager update local state directly; only
   out-of-band changes go stale, and that trade was accepted deliberately over refetching on every
   tab switch.
+
+---
+
+## Appendix A — the earlier numbering (#25–#160), and why references to it are stale
+
+Before this file existed, findings were recorded as numbered comments on PR #143 under a different
+scheme that ran to #160. That numbering survives in a few source comments — `full-calendar-test.js`
+cites "DEFECTS.md #94 for Leaflet", for instance — and those references now point at nothing, because
+this file restarted at #1.
+
+**Every finding in that older set has since been resolved.** Verified against the current source on
+2026-08-25 before the PR comments were retired; each line below names the evidence:
+
+| old # | finding | outcome |
+|---|---|---|
+| #146 | `filter/multi-option`'s `search` called an `@task` as a function, and mutated `this.options` | fixed — `this.fetchOptions.perform(...)`, with the old bug described inline |
+| #150 | `overlay.resize` clamped on width and returned before the `isHorizontal` fork, so a bottom drawer could never resize | fixed — `minSize = isHorizontal ? minResizeWidth : minResizeHeight` |
+| #143 | `custom-field/form`'s `save` task assigned to `this.args` and called a misnamed callback | resolved by deletion — `addon/components/custom-field/form.js` no longer exists |
+| #160(a) | `set-height` turned `'auto'` / `'100%'` into the invalid string `"px"` | fixed — keyword values take the `calculated` path |
+| #160(b) | `services/leaflet` never set `initialized` when an instance was preset, so the poll ran forever | fixed — `initialized = true` hoisted out of the `instance === undefined` check |
+| #156 | `transition-to` asserted the same condition as the `if` it sat inside, so it could never fire | fixed — `=== 'string'` |
+| #154 | `resource-context-panel.open()` read the definition before validating it | resolved — the component was restructured; no `open()` or validate path remains |
+| #152 | `is-menu-item-active`'s contradictory `slugOnly && view` | resolved — the helper no longer exists |
+| #139 | `custom-field/input`'s money arm could never run, and disagreed with the raw arm | fixed — the arm was removed, with the reasoning inline |
+| #141 | `dashboard/widget-panel`'s `hoveredWidget` / `onHover` / `onUnhover` | resolved — no occurrence anywhere in `addon/` |
+| #147 | `custom-field/yield`'s `resolveSubject` and `toggleGroupEdit` | resolved — both gone |
+| #149 | `custom-field/options-input`'s `addMetaOption` | resolved — gone |
+| #151 | `smart-nav-menu/customizer`'s `unpinnedItems` | resolved — gone (`reorderPinned` stayed and is now covered) |
+| #148 | the three `query-builder` `validate*` actions were never performed, so a panel kept sorting and grouping by deselected columns | fixed — all three are wired to `{{did-update}}` on the column list (`conditions.hbs:3`, `group-by.hbs:3`, `sort-by.hbs:3`) |
+| #128 | `attach/popover`'s `@isOffset` guarded on a field nothing assigned | fixed, with the old behaviour described inline |
+| #120 | `modal`'s `@fade={{false}}` did not disable transitions | fixed — the `_fade` getter |
+| #105 | `model-select`'s infinite scroll was inert | fixed (PR #151) |
+| #108 | `table/cell/resource-identity` hard-coded its compact padding | fixed (PR #152) |
+| #26 | `translations-editor` backtracking assertion | fixed (PR #149, rebuilt around stable rows) |
+| — | the scheduling cluster (`availability-editor`, `schedule-calendar`, `schedule-item-card`) | resolved — none of the three remains |
+| — | adopt `eslint-plugin-qunit`; add a lint rule for unguarded handler arguments | done (PR #148) |
+
+If you meet an old-scheme reference in a source comment, this table is where it resolves to. The
+`#94` in `full-calendar-test.js` is the Leaflet-state-leak finding, fixed long ago; the `afterEach`
+it justifies is still doing real work for the reason given in #17.
+
+## Appendix B — why the remaining gaps are where they are
+
+Kept from the PR #143 write-up because it is the most reusable thing that came out of this work.
+Seven categories account for essentially every site the gate still names.
+
+**1. Defaults on signatures only the framework calls.** Glimmer always invokes
+`compute(args.positional, args.named)` with both arguments, passing an empty object when the
+template supplies none; ember-modifier does the same. So `named = {}` / `positional = []` can never
+take their default. Affects the six ability helpers, `now`, `place-address`, `get-model-name`,
+`set-model-attr`, `format-date-fns`, `json-stringify`, `background-url`.
+
+The distinction that costs the most time: **a default on a plain function or a service method is
+real, reachable surface** — chasing those produced 24 tests in a single iteration across
+`modals-manager`, `dashboard`, `services/sidebar` and `sidebar-navigator`. A default on a
+framework-invoked signature is dead. They are indistinguishable in istanbul's branch map; only the
+call site tells them apart. Positional destructuring like `[direction = 'bottom']` *is* reachable,
+because the positional array can be shorter.
+
+**2. Resolver-provided services that cannot be removed.** `is-dark-mode`,
+`get-universe-components`, `get-universe-menu-items` and `sidebar-navigator`'s
+`lookupService('router') ?? lookupService('host-router')` all guard on `if (service)`. Reaching the
+else needs `lookup` to answer nothing, and `owner.unregister('service:theme')` does not achieve
+that: the dummy app provides these through the *resolver*, and `unregister` only removes explicit
+registrations. You can shadow a resolver factory by registering over it; you cannot make it vanish.
+
+**3. `@tracked` initializers a constructor pre-empts.** `@tracked x = false` compiles to a lazy
+initializer. When the constructor assigns before anything reads — the prevailing style here — the
+initializer never runs and the field declaration reports as uncovered forever. The fix is dropping
+the redundant initializer, not adding a test.
+
+**4. Statements after a `throw`.** `dropdown-fn`'s two `return false` lines.
+
+**5. Guards whose only entry point is already disabled.** In each case the button that calls them
+carries `disabled={{…}}` for exactly that condition and an existing test asserts the disabled state.
+This turned out to be the single most common unreachable shape in the codebase.
+
+**6. Comparator early-return halves.** `to-power-select-groups` and `truncate-pages` — `if (A < B)` /
+`if (A > B)` pairs where one side stays unvisited for any array a test can construct.
+
+**7. Genuine harness questions — mostly disproven since.** This category was the largest, and most of
+it did not survive contact: the `template-builder` files were said to be blocked on
+interact.js/drag-sort DOM measurement, and both libraries turned out to be drivable (see #16's
+neighbours and PR #161). Treat anything in this category as unverified until someone has actually
+tried it.
+
+## Appendix C — habits that paid for themselves
+
+**A green test is not evidence that the branch you aimed at ran.** Five tests written during the
+original work passed while covering nothing: three re-asserted an outcome another test already
+covered, and two fed already-sorted input so the comparator never took the branch they were aimed
+at. Only the next coverage report caught them. This has recurred in every phase since.
+
+**A test that fails against production code is a finding, not a broken test.** Seven were deleted
+rather than weakened for this reason, and each deletion was a defect report.
+
+**A fully-populated fixture hides every fallback.** `activity-log`'s `#normalizeActivity` is fifteen
+consecutive defaulting expressions and every fixture was a complete activity, so all fifteen
+right-hand sides were dead in the suite while being exactly what a trimmed API response hits. One
+`{}` took that file from 29 partial branches to 9. Same story in `dashboard/widget-panel`,
+`chat-tray` and `place-address`.
+
+**A module reached only through its consumer is only ever called the way that consumer calls it.**
+`sidebar-navigator`'s ten defaulted parameters had never defaulted; one unit test file closed 20 of
+its 21 partial branches.
+
+**Ranking by absolute uncovered counts hides small modules.** The component-heavy ranking buried a
+tier of small utils and services — including two still carrying generated "it works" stubs — behind
+a handful of large components. The per-file percentage view surfaced them and produced the largest
+single-iteration branch gain of the effort.

--- a/addon/components/chat-tray.js
+++ b/addon/components/chat-tray.js
@@ -35,6 +35,7 @@ export default class ChatTrayComponent extends Component {
             withChannels: (channels) => {
                 this.channels = channels;
                 this.countUnread(channels);
+                this.getUnreadCount.perform();
                 this.listenAllChatChannels(channels);
                 this.listenUserChannel();
             },
@@ -247,10 +248,23 @@ export default class ChatTrayComponent extends Component {
         }
     }
 
-    @task *getUnreadCount() {
-        const { unreadCount } = yield this.fetch.get('chat-channels/unread-count');
-        if (!isNone(unreadCount)) {
-            this.unreadCount = unreadCount;
+    /**
+     * The authoritative unread count.
+     *
+     * `countUnread()` sums `unread_count` across the channels currently loaded, which is instant
+     * but only as complete as that list — anything paginated away is missed. This asks the server
+     * for the real total and lets it win. Restartable so a slow earlier response cannot overwrite
+     * a newer one, and failures fall back to the locally summed count rather than blanking the
+     * badge.
+     */
+    @task({ restartable: true }) *getUnreadCount() {
+        try {
+            const { unreadCount } = yield this.fetch.get('chat-channels/unread-count');
+            if (!isNone(unreadCount)) {
+                this.unreadCount = unreadCount;
+            }
+        } catch (error) {
+            console.warn('Error loading unread chat count:', error);
         }
     }
 
@@ -328,6 +342,7 @@ export default class ChatTrayComponent extends Component {
             withChannels: (channels) => {
                 this.channels = channels;
                 this.countUnread(channels);
+                this.getUnreadCount.perform();
                 if (options && options.relisten === true) {
                     this.listenAllChatChannels(channels);
                 }

--- a/addon/components/chat-window/attachment.js
+++ b/addon/components/chat-window/attachment.js
@@ -26,6 +26,13 @@ export default class ChatWindowAttachmentComponent extends Component {
     getIcon(chatAttachment) {
         this.extension = this.getExtension(chatAttachment);
 
+        // A filename with no dot (README, Dockerfile, LICENSE) has no extension, and
+        // getWithDefault asserts on a null key rather than falling back — so the component threw
+        // during render. file-icon.js guards the identical case the same way.
+        if (!this.extension) {
+            return 'file-alt';
+        }
+
         return getWithDefault(
             {
                 xlsx: 'file-excel',

--- a/addon/components/countdown.js
+++ b/addon/components/countdown.js
@@ -3,7 +3,7 @@ import { tracked } from '@glimmer/tracking';
 import { formatDuration, intervalToDuration } from 'date-fns';
 import { isArray } from '@ember/array';
 import { run } from '@ember/runloop';
-import { computed } from '@ember/object';
+import { action, computed } from '@ember/object';
 
 export default class CountdownComponent extends Component {
     /**
@@ -132,12 +132,17 @@ export default class CountdownComponent extends Component {
                     duration.seconds = 0; // Stop the countdown at 0
                     clearInterval(this.interval);
 
+                    // Hand the consumer a way to restart in place. Without this there was no way
+                    // to run a countdown again short of re-rendering the component, which is what
+                    // restartCountdown() was written for and never wired to.
+                    const endPayload = { restartFn: this.restartCountdown };
+
                     if (typeof this.args.onCountdownEnd === 'function') {
-                        this.args.onCountdownEnd();
+                        this.args.onCountdownEnd(endPayload);
                     }
 
                     if (typeof this.args.onEnd === 'function') {
-                        this.args.onEnd();
+                        this.args.onEnd(endPayload);
                     }
                 }
             });
@@ -162,9 +167,12 @@ export default class CountdownComponent extends Component {
     /**
      * Restarts the countdown by resetting the timeRemaining property and clearing the interval.
      *
+     * Handed to `@onEnd` / `@onCountdownEnd` as `restartFn`, so a consumer can write
+     * `onEnd={{this.handleEnd}}` with `handleEnd({ restartFn }) { restartFn(); }`.
+     *
      * @method restartCountdown
      */
-    restartCountdown() {
+    @action restartCountdown() {
         clearInterval(this.interval);
         // Reset properties
         this.remaining = null;

--- a/addon/components/country-select.js
+++ b/addon/components/country-select.js
@@ -38,14 +38,6 @@ export default class CountrySelectComponent extends Component {
         }
     }
 
-    @action changed(value) {
-        const country = this.findCountry(value);
-
-        if (country) {
-            this.selectCountry(country);
-        }
-    }
-
     @action handleChange(el, [value]) {
         this.selected = this.findCountry(value);
     }

--- a/addon/components/filters-picker.js
+++ b/addon/components/filters-picker.js
@@ -71,7 +71,7 @@ export default class FiltersPickerComponent extends Component {
         return raw === '' ? undefined : raw;
     }
 
-    #rebuildFilters(onColumn) {
+    #rebuildFilters() {
         const cols = this.args.columns ?? [];
 
         this.filters = cols
@@ -89,8 +89,8 @@ export default class FiltersPickerComponent extends Component {
                     isFilterActive: active,
                 };
 
-                if (typeof onColumn === 'function') {
-                    onColumn(filterCol, index, value);
+                if (typeof this.args.onColumn === 'function') {
+                    this.args.onColumn(filterCol, index, value);
                 }
 
                 return filterCol;

--- a/addon/components/layout/resource/panel.js
+++ b/addon/components/layout/resource/panel.js
@@ -51,6 +51,10 @@ export default class LayoutResourcePanelComponent extends Component {
         return contextComponentCallback(this, 'onOpen', { resource: this.resource, panel: this.context });
     }
 
+    @action onToggle() {
+        return contextComponentCallback(this, 'onToggle', { resource: this.resource, panel: this.context });
+    }
+
     @action onClose() {
         return contextComponentCallback(this, 'onClose', { resource: this.resource, panel: this.context });
     }

--- a/addon/components/metadata-editor.hbs
+++ b/addon/components/metadata-editor.hbs
@@ -1,7 +1,7 @@
 <div class="space-y-2" ...attributes>
     <div class="flex items-center justify-between {{@actionsWrapperClass}}">
-        {{#if @label}}
-            <h3 class="text-sm font-medium text-gray-800 dark:text-gray-200">{{@label}}</h3>
+        {{#if this.label}}
+            <h3 class="text-sm font-medium text-gray-800 dark:text-gray-200">{{this.label}}</h3>
         {{/if}}
         <div class="flex items-center gap-2">
             <input type="text" placeholder="Filter keys…" class="form-input form-input-sm" {{on "input" this.onFilter}} />

--- a/addon/components/overlay/header.hbs
+++ b/addon/components/overlay/header.hbs
@@ -7,8 +7,8 @@
                 <div class="next-view-header-left-inner {{@headerLeftInnerClass}}">
                     <div class="next-view-header-left-title-wrapper flex flex-row items-center {{@titleWrapperClass}}">
                         <h2 class="next-content-overlay-panel-title {{@titleClass}}">
-                            {{#if @overlay.isMinimized}}
-                                {{this.titleWithElipsis}}
+                            {{#if this.isTitleTruncated}}
+                                {{this.titleWithEllipsis}}
                             {{else}}
                                 {{@title}}
                             {{/if}}

--- a/addon/components/overlay/header.js
+++ b/addon/components/overlay/header.js
@@ -6,16 +6,39 @@ import { later } from '@ember/runloop';
 export default class OverlayHeaderComponent extends Component {
     @tracked overlayPanelHeaderRef;
 
-    @computed('args.title') get useEllipsis() {
-        const { title } = this.args;
+    /**
+     * How many characters of the title survive truncation. Defaults to 15, which is the threshold
+     * the component has always encoded.
+     */
+    @computed('args.titleEllipsisLength') get ellipsisLength() {
+        const { titleEllipsisLength } = this.args;
 
-        return title?.length > 15;
+        return typeof titleEllipsisLength === 'number' ? titleEllipsisLength : 15;
     }
 
-    @computed('args.title') get titleWithElipsis() {
+    /**
+     * Whether the title is long enough to be worth truncating. Only consulted when the consumer
+     * opts in with @titleEllipsis — a minimized overlay truncates regardless, which is the
+     * behaviour this component shipped with.
+     */
+    @computed('args.title', 'ellipsisLength') get useEllipsis() {
         const { title } = this.args;
 
-        return `${title?.substring(0, 15)}...`;
+        return title?.length > this.ellipsisLength;
+    }
+
+    /**
+     * The truncated title the template renders. True when the overlay is minimized (unchanged), or
+     * when the consumer passes @titleEllipsis and the title exceeds the threshold.
+     */
+    @computed('args.{overlay.isMinimized,titleEllipsis}', 'useEllipsis') get isTitleTruncated() {
+        return this.args.overlay?.isMinimized || (Boolean(this.args.titleEllipsis) && this.useEllipsis);
+    }
+
+    @computed('args.title', 'ellipsisLength') get titleWithEllipsis() {
+        const { title } = this.args;
+
+        return `${title?.substring(0, this.ellipsisLength)}...`;
     }
 
     @action setupComponent(element) {

--- a/addon/components/pagination.js
+++ b/addon/components/pagination.js
@@ -4,7 +4,6 @@ import { action, computed, defineProperty } from '@ember/object';
 import { alias, gt, not } from '@ember/object/computed';
 import getWithDefault from '@fleetbase/ember-core/utils/get-with-default';
 import PaginationItems from '../utils/pagination/items';
-import arrayRange from '../utils/array-range';
 
 export default class PaginationComponent extends Component {
     /**
@@ -143,16 +142,6 @@ export default class PaginationComponent extends Component {
      *
      * @var {Array}
      */
-    @computed('args.meta.last_page') get pageNumbers() {
-        const pages = arrayRange(this.args.meta?.last_page || 0, 1).map((page) => {
-            return {
-                page,
-                dots: page === 12,
-            };
-        });
-        return pages.length < 12 ? pages : pages.slice(0, 12);
-    }
-
     /**
      * Create instance of PaginationComponent
      */

--- a/addon/components/report-builder/condition-value.hbs
+++ b/addon/components/report-builder/condition-value.hbs
@@ -4,6 +4,15 @@
     <DatePicker @value={{@value}} @dateFormat="yyyy-MM-dd HH:mm:ss" @onChange={{this.change}} class="form-input form-input-sm w-52" />
 {{else if this.isNumber}}
     <Input @value={{@value}} @type="number" class="form-input form-input-sm w-32" {{on "input" (pick "target.value" this.change)}} />
+{{else if this.isBoolean}}
+    <div class="report-builder-boolean-value flex flex-row items-center space-x-4">
+        <RadioButton @name={{this.booleanGroupName}} @value={{true}} @groupValue={{this.booleanValue}} @changed={{this.change}} @radioClass="form-radio">
+            <span class="ml-1.5 text-sm">True</span>
+        </RadioButton>
+        <RadioButton @name={{this.booleanGroupName}} @value={{false}} @groupValue={{this.booleanValue}} @changed={{this.change}} @radioClass="form-radio">
+            <span class="ml-1.5 text-sm">False</span>
+        </RadioButton>
+    </div>
 {{else if this.isJSON}}
     <Textarea @value={{@value}} rows="2" class="form-input form-input-sm w-56" {{on "input" (pick "target.value" this.change)}} />
 {{else}}

--- a/addon/components/report-builder/condition-value.js
+++ b/addon/components/report-builder/condition-value.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { guidFor } from '@ember/object/internals';
 
 export default class ReportBuilderConditionValueComponent extends Component {
     get type() {
@@ -21,6 +22,33 @@ export default class ReportBuilderConditionValueComponent extends Component {
     }
     get isJSON() {
         return this.type === 'json';
+    }
+
+    /**
+     * Each rendered condition needs its own radio group, or two boolean conditions in the same
+     * report would share one and selecting in either would clear the other.
+     */
+    get booleanGroupName() {
+        return `report-condition-boolean-${guidFor(this)}`;
+    }
+
+    /**
+     * A saved report round-trips through JSON and query params, so a boolean condition can come
+     * back as the string 'true' or the number 1 rather than a boolean. Normalise before comparing,
+     * and return null when nothing has been chosen so neither radio shows as selected.
+     */
+    get booleanValue() {
+        const { value } = this.args;
+
+        if (value === true || value === 'true' || value === 1 || value === '1') {
+            return true;
+        }
+
+        if (value === false || value === 'false' || value === 0 || value === '0') {
+            return false;
+        }
+
+        return null;
     }
 
     @action change(val) {

--- a/addon/components/table/cell/dropdown.js
+++ b/addon/components/table/cell/dropdown.js
@@ -64,16 +64,6 @@ export default class TableCellDropdownComponent extends Component {
         return undefined;
     }
 
-    @action onDropdownItemClick(columnAction, row, dd) {
-        if (typeof dd?.actions?.close === 'function') {
-            dd.actions.close();
-        }
-
-        if (typeof columnAction?.fn === 'function') {
-            columnAction.fn(row);
-        }
-    }
-
     @action calculatePosition(trigger, content) {
         if (typeof this.args.column?.calculatePosition === 'function') {
             return this.args.column.calculatePosition(trigger, content);

--- a/addon/components/template-builder/properties-panel.hbs
+++ b/addon/components/template-builder/properties-panel.hbs
@@ -70,7 +70,7 @@
                         <textarea
                             class="tb-input w-full min-h-20 resize-y font-mono text-xs"
                             placeholder="Enter text or use {variable.name} syntax..."
-                            {{on "input" (fn this.updateProp "content" value="target.value")}}
+                            {{on "input" (fn this.updateProp "content")}}
                         >{{this.element.content}}</textarea>
                     </div>
                     <button

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "start": "ember serve",
         "test": "concurrently \"npm:lint\" \"npm:test:*\" --names \"lint,test:\"",
         "test:ember": "ember test",
-        "test:coverage": "COVERAGE=true ember test",
+        "test:coverage": "node scripts/stamp-coverage-run.js && COVERAGE=true ember test",
         "coverage:check": "node scripts/check-coverage.js",
         "coverage:selftest": "node scripts/check-coverage-test.js",
         "test:ci": "pnpm run coverage:selftest && pnpm run test:coverage && pnpm run coverage:check",

--- a/scripts/check-coverage-test.js
+++ b/scripts/check-coverage-test.js
@@ -6,7 +6,8 @@
  *   node scripts/check-coverage-test.js
  *
  * Verifies the gate passes on a fully-covered summary and fails on partial
- * coverage, missing files, and a missing summary.
+ * coverage, missing files, a missing summary, and — the DEFECTS.md #16 cases —
+ * artifacts that are stale, absent, or unstamped.
  */
 
 const assert = require('assert');
@@ -14,7 +15,8 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { checkCoverage, isFullyCovered } = require('./check-coverage');
+const { checkCoverage, checkArtifactFreshness, isFullyCovered } = require('./check-coverage');
+const { stampRun, isSafeCoverageDir } = require('./stamp-coverage-run');
 
 function emptyMetric() {
     // How istanbul reports a file with no executable code: 0/0 with pct 0.
@@ -154,4 +156,123 @@ withFixture((root) => {
     assert.strictEqual(result.failures.filter((f) => f.includes('ember-core')).length, 0, 'and it is never named in the failures');
 });
 
-console.log('check-coverage self-test passed (10 cases).');
+// ---------------------------------------------------------------------------
+// Artifact freshness (DEFECTS.md #16)
+// ---------------------------------------------------------------------------
+
+function writeArtifacts(root, mtimeMs) {
+    const coverageDir = path.join(root, 'coverage');
+    fs.mkdirSync(coverageDir, { recursive: true });
+
+    const paths = [path.join(coverageDir, 'coverage-summary.json'), path.join(coverageDir, 'coverage-final.json')];
+    for (const artifact of paths) {
+        fs.writeFileSync(artifact, '{}');
+        if (typeof mtimeMs === 'number') {
+            const seconds = mtimeMs / 1000;
+            fs.utimesSync(artifact, seconds, seconds);
+        }
+    }
+
+    return paths;
+}
+
+// 11. Artifacts written after the run started → fresh, no complaints.
+withFixture((root) => {
+    const stampPath = path.join(root, '.coverage-run-stamp.json');
+    const startedAt = Date.now() - 60000;
+    fs.writeFileSync(stampPath, JSON.stringify({ startedAt }));
+    const artifactPaths = writeArtifacts(root, Date.now());
+
+    const failures = checkArtifactFreshness({ stampPath, artifactPaths, projectRoot: root });
+    assert.deepStrictEqual(failures, [], `expected fresh artifacts to pass, got: ${failures.join('; ')}`);
+});
+
+// 12. THE DANGEROUS CASE: the suite runs green but leaves the previous artifact in place, so the
+//     report predates the run. Reading it would report the last run's numbers as this run's.
+withFixture((root) => {
+    const stampPath = path.join(root, '.coverage-run-stamp.json');
+    fs.writeFileSync(stampPath, JSON.stringify({ startedAt: Date.now() }));
+    const artifactPaths = writeArtifacts(root, Date.now() - 3600000);
+
+    const failures = checkArtifactFreshness({ stampPath, artifactPaths, projectRoot: root });
+    assert.strictEqual(failures.length, 2, `expected both artifacts to be reported stale, got: ${failures.join('; ')}`);
+    assert.ok(
+        failures.every((failure) => failure.includes('stale artifact from an earlier run')),
+        `expected staleness wording, got: ${failures.join('; ')}`
+    );
+});
+
+// 13. The suite reports results but writes no coverage-final.json at all.
+withFixture((root) => {
+    const stampPath = path.join(root, '.coverage-run-stamp.json');
+    fs.writeFileSync(stampPath, JSON.stringify({ startedAt: Date.now() - 60000 }));
+    const [summaryPath] = writeArtifacts(root, Date.now());
+    fs.rmSync(path.join(root, 'coverage', 'coverage-final.json'));
+
+    const failures = checkArtifactFreshness({
+        stampPath,
+        artifactPaths: [summaryPath, path.join(root, 'coverage', 'coverage-final.json')],
+        projectRoot: root,
+    });
+    assert.strictEqual(failures.length, 1, `expected exactly one failure, got: ${failures.join('; ')}`);
+    assert.ok(failures[0].includes('produced no coverage artifact'), `unexpected failure: ${failures[0]}`);
+});
+
+// 14. No stamp at all — the gate refuses to read whatever happens to be on disk.
+withFixture((root) => {
+    const artifactPaths = writeArtifacts(root, Date.now());
+    const failures = checkArtifactFreshness({
+        stampPath: path.join(root, '.coverage-run-stamp.json'),
+        artifactPaths,
+        projectRoot: root,
+    });
+    assert.strictEqual(failures.length, 1, `expected one failure, got: ${failures.join('; ')}`);
+    assert.ok(failures[0].includes('no coverage run stamp'), `unexpected failure: ${failures[0]}`);
+});
+
+// 15. A corrupt or shapeless stamp is treated as no stamp, not as permission.
+withFixture((root) => {
+    const stampPath = path.join(root, '.coverage-run-stamp.json');
+    const artifactPaths = writeArtifacts(root, Date.now());
+
+    fs.writeFileSync(stampPath, 'not json');
+    let failures = checkArtifactFreshness({ stampPath, artifactPaths, projectRoot: root });
+    assert.strictEqual(failures.length, 1);
+    assert.ok(failures[0].includes('unreadable'), `unexpected failure: ${failures[0]}`);
+
+    fs.writeFileSync(stampPath, JSON.stringify({ startedAt: 'yesterday' }));
+    failures = checkArtifactFreshness({ stampPath, artifactPaths, projectRoot: root });
+    assert.strictEqual(failures.length, 1);
+    assert.ok(failures[0].includes('no numeric "startedAt"'), `unexpected failure: ${failures[0]}`);
+});
+
+// 16. stampRun clears the previous coverage directory and records the start time.
+withFixture((root) => {
+    const coverageDir = path.join(root, 'coverage');
+    fs.mkdirSync(coverageDir, { recursive: true });
+    fs.writeFileSync(path.join(coverageDir, 'coverage-final.json'), '{"stale":true}');
+
+    const stampPath = path.join(root, '.coverage-run-stamp.json');
+    const result = stampRun({ coverageDir, stampPath, projectRoot: root, now: 1234 });
+
+    assert.strictEqual(result.removed, true, 'the previous coverage directory is removed');
+    assert.strictEqual(fs.existsSync(coverageDir), false, 'and it is really gone');
+    assert.deepStrictEqual(JSON.parse(fs.readFileSync(stampPath, 'utf8')), { startedAt: 1234 });
+});
+
+// 17. stampRun refuses to delete anything that is not this project's coverage directory.
+withFixture((root) => {
+    const notCoverage = path.join(root, 'addon');
+    assert.throws(
+        () => stampRun({ coverageDir: notCoverage, stampPath: path.join(root, '.stamp.json'), projectRoot: root, now: 1 }),
+        /refusing to remove/,
+        'a non-coverage directory must not be removed'
+    );
+    assert.strictEqual(fs.existsSync(notCoverage), true, 'and it survives');
+
+    assert.strictEqual(isSafeCoverageDir(path.join(root, 'coverage'), root), true);
+    assert.strictEqual(isSafeCoverageDir(path.join(root, 'addon'), root), false);
+    assert.strictEqual(isSafeCoverageDir(path.join(root, 'nested', 'coverage'), root), false, 'only directly inside the project root');
+});
+
+console.log('check-coverage self-test passed (17 cases).');

--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -11,12 +11,72 @@
  *   3. Every eligible first-party source file under addon/ appears in the
  *      report — so untested/unimported files can never silently drop out of
  *      the denominator.
+ *   4. The artifacts on disk were actually produced by the run that just
+ *      finished, rather than left behind by an earlier one. See
+ *      `checkArtifactFreshness` and DEFECTS.md #16.
  */
 
 const fs = require('fs');
 const path = require('path');
 
+const { STAMP_FILENAME } = require('./stamp-coverage-run');
+
 const METRICS = ['statements', 'branches', 'functions', 'lines'];
+
+/**
+ * Confirms the coverage artifacts belong to the run that just finished.
+ *
+ * DEFECTS.md #16: a run can finish green and leave the PREVIOUS
+ * `coverage-final.json` in place, or write the summary and HTML report without
+ * writing `coverage-final.json` at all. Neither announces itself. Reading
+ * whichever files happen to be on disk then reports the last run's numbers as
+ * this run's — and in the direction that matters, a line that regressed is
+ * reported as still covered.
+ *
+ * `scripts/stamp-coverage-run.js` records when the run started; every required
+ * artifact must have been written after that.
+ *
+ * @param {{stampPath: string, artifactPaths: string[], projectRoot: string}} options
+ * @returns {string[]} failures, empty when the artifacts are demonstrably fresh
+ */
+function checkArtifactFreshness({ stampPath, artifactPaths, projectRoot }) {
+    const failures = [];
+
+    if (!fs.existsSync(stampPath)) {
+        return [
+            `no coverage run stamp at ${normalize(stampPath, projectRoot)} — run \`pnpm run test:coverage\`, which stamps the run, ` +
+                'rather than reading whatever coverage artifacts are already on disk',
+        ];
+    }
+
+    let startedAt;
+    try {
+        ({ startedAt } = JSON.parse(fs.readFileSync(stampPath, 'utf8')));
+    } catch (error) {
+        return [`coverage run stamp at ${normalize(stampPath, projectRoot)} is unreadable (${error.message}) — re-run \`pnpm run test:coverage\``];
+    }
+
+    if (typeof startedAt !== 'number') {
+        return [`coverage run stamp at ${normalize(stampPath, projectRoot)} has no numeric "startedAt" — re-run \`pnpm run test:coverage\``];
+    }
+
+    for (const artifactPath of artifactPaths) {
+        const relative = normalize(artifactPath, projectRoot);
+
+        if (!fs.existsSync(artifactPath)) {
+            failures.push(`${relative} was not written by this run — the suite reported results but produced no coverage artifact`);
+            continue;
+        }
+
+        const writtenAt = fs.statSync(artifactPath).mtimeMs;
+        if (writtenAt < startedAt) {
+            const age = Math.round((startedAt - writtenAt) / 1000);
+            failures.push(`${relative} is ${age}s older than this coverage run — it is a stale artifact from an earlier run, not this one's results`);
+        }
+    }
+
+    return failures;
+}
 
 function listSourceFiles(sourceRoot) {
     const results = [];
@@ -129,6 +189,23 @@ function main(argv) {
     const projectRoot = process.cwd();
     const summaryPath = path.resolve(projectRoot, argv[2] || 'coverage/coverage-summary.json');
     const sourceRoot = path.resolve(projectRoot, argv[3] || 'addon');
+    const stampPath = path.resolve(projectRoot, argv[4] || STAMP_FILENAME);
+
+    // Freshness first: percentages read off a stale artifact are worse than no
+    // percentages, because they look authoritative.
+    const staleness = checkArtifactFreshness({
+        stampPath,
+        artifactPaths: [summaryPath, path.resolve(path.dirname(summaryPath), 'coverage-final.json')],
+        projectRoot,
+    });
+
+    if (staleness.length > 0) {
+        console.error(`Coverage gate failed — the report cannot be trusted (${staleness.length} problem(s)):`);
+        for (const failure of staleness) {
+            console.error(`  - ${failure}`);
+        }
+        return 1;
+    }
 
     const { ok, failures } = checkCoverage({ summaryPath, sourceRoot, projectRoot });
 
@@ -144,7 +221,7 @@ function main(argv) {
     return 0;
 }
 
-module.exports = { checkCoverage, listSourceFiles, isFullyCovered, METRICS };
+module.exports = { checkCoverage, checkArtifactFreshness, listSourceFiles, isFullyCovered, METRICS, STAMP_FILENAME };
 
 if (require.main === module) {
     process.exitCode = main(process.argv);

--- a/scripts/stamp-coverage-run.js
+++ b/scripts/stamp-coverage-run.js
@@ -1,0 +1,73 @@
+'use strict';
+
+/**
+ * Prepares a coverage run.
+ *
+ * Two jobs, both aimed at DEFECTS.md #16 — coverage collection that fails
+ * silently rather than loudly:
+ *
+ *   1. Removes the previous `coverage/` directory. A run that leaves the old
+ *      artifacts in place is indistinguishable from a run that produced them,
+ *      and the resulting report is read as current. Deleting the whole
+ *      directory (rather than individual files) is also the only sequence
+ *      observed to produce a complete artifact set reliably.
+ *
+ *   2. Writes a stamp recording when this run started. `check-coverage.js`
+ *      refuses any artifact older than the stamp, so a stale report fails the
+ *      gate instead of passing it.
+ *
+ * Usage: node scripts/stamp-coverage-run.js [coverageDir] [stampPath]
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const STAMP_FILENAME = '.coverage-run-stamp.json';
+
+/**
+ * Guard against ever removing something that is not a generated coverage
+ * directory: it must be named `coverage` and sit directly inside the project.
+ */
+function isSafeCoverageDir(coverageDir, projectRoot) {
+    const resolved = path.resolve(coverageDir);
+    return path.basename(resolved) === 'coverage' && path.dirname(resolved) === path.resolve(projectRoot);
+}
+
+function stampRun({ coverageDir, stampPath, projectRoot, now }) {
+    const removed = fs.existsSync(coverageDir);
+
+    if (removed) {
+        if (!isSafeCoverageDir(coverageDir, projectRoot)) {
+            throw new Error(`refusing to remove ${coverageDir} — expected a "coverage" directory directly inside ${projectRoot}`);
+        }
+
+        fs.rmSync(coverageDir, { recursive: true, force: true });
+    }
+
+    fs.writeFileSync(stampPath, `${JSON.stringify({ startedAt: now }, null, 2)}\n`);
+
+    return { removed, startedAt: now };
+}
+
+function main(argv) {
+    const projectRoot = process.cwd();
+    const coverageDir = path.resolve(projectRoot, argv[2] || 'coverage');
+    const stampPath = path.resolve(projectRoot, argv[3] || STAMP_FILENAME);
+
+    // One second earlier than "now": some filesystems store mtimes at
+    // whole-second resolution, so an artifact written in the same second as the
+    // stamp can round to just below it and read as stale.
+    const startedAt = Date.now() - 1000;
+
+    const { removed } = stampRun({ coverageDir, stampPath, projectRoot, now: startedAt });
+
+    console.log(removed ? 'Cleared the previous coverage/ directory and stamped this run.' : 'Stamped this coverage run.');
+
+    return 0;
+}
+
+module.exports = { stampRun, isSafeCoverageDir, STAMP_FILENAME };
+
+if (require.main === module) {
+    process.exitCode = main(process.argv);
+}

--- a/tests/integration/components/chat-tray-test.js
+++ b/tests/integration/components/chat-tray-test.js
@@ -582,6 +582,7 @@ module('Integration | Component | chat-tray socket handling', function (hooks) {
 
     let loadedChannels;
     let listened;
+    let serverUnreadCount;
 
     function channelFixture(id, overrides = {}) {
         return {
@@ -598,6 +599,7 @@ module('Integration | Component | chat-tray socket handling', function (hooks) {
     hooks.beforeEach(function () {
         loadedChannels = [];
         listened = [];
+        serverUnreadCount = null;
 
         this.owner.register(
             'service:chat',
@@ -649,8 +651,20 @@ module('Integration | Component | chat-tray socket handling', function (hooks) {
         this.owner.register(
             'service:fetch',
             class extends Service {
-                get() {
-                    return Promise.resolve({ unreadCount: 0 });
+                get(path) {
+                    // The authoritative unread count. `null` means the server has nothing to say,
+                    // so the locally summed channel counts stand — which is what the tests in this
+                    // module assert. Set `serverUnreadCount` to a number to have the server win,
+                    // or to an Error to make the call fail.
+                    if (path === 'chat-channels/unread-count') {
+                        if (serverUnreadCount instanceof Error) {
+                            return Promise.reject(serverUnreadCount);
+                        }
+
+                        return Promise.resolve({ unreadCount: serverUnreadCount });
+                    }
+
+                    return Promise.resolve({ unreadCount: null });
                 }
             }
         );
@@ -727,6 +741,52 @@ module('Integration | Component | chat-tray socket handling', function (hooks) {
         await settled();
 
         assert.dom('.chat-tray').exists('the event is handled without an unhandled audio rejection');
+    });
+
+    // The badge has two sources: countUnread() sums the channels currently loaded, and
+    // getUnreadCount() asks the server for the real total across every channel, including any
+    // paginated away. The server is authoritative when it answers. (DEFECTS #6)
+    module('the authoritative unread count', function () {
+        test('the server count wins over the channels currently loaded', async function (assert) {
+            serverUnreadCount = 9;
+            loadedChannels = [channelFixture('a', { unread_count: 2 }), channelFixture('b', { unread_count: 3 })];
+
+            await render(hbs`<ChatTray />`);
+
+            assert.dom('.chat-tray-unread-notifications-badge').hasText('9', 'the server total is shown, not the summed 5');
+        });
+
+        test('a zero from the server clears a badge the loaded channels would still show', async function (assert) {
+            serverUnreadCount = 0;
+            loadedChannels = [channelFixture('a', { unread_count: 4 })];
+
+            await render(hbs`<ChatTray />`);
+
+            assert.dom('.chat-tray-unread-notifications-badge').doesNotExist('the server says nothing is unread');
+        });
+
+        test('a failed lookup leaves the summed count in place', async function (assert) {
+            serverUnreadCount = new Error('unread-count endpoint is down');
+            loadedChannels = [channelFixture('a', { unread_count: 2 }), channelFixture('b', { unread_count: 3 })];
+
+            await render(hbs`<ChatTray />`);
+
+            assert.dom('.chat-tray-unread-notifications-badge').hasText('5', 'the badge falls back rather than blanking');
+        });
+
+        test('reloading the channels re-asks the server', async function (assert) {
+            serverUnreadCount = 4;
+            loadedChannels = [channelFixture('a', { unread_count: 1 })];
+            await render(hbs`<ChatTray />`);
+            assert.dom('.chat-tray-unread-notifications-badge').hasText('4');
+
+            serverUnreadCount = 6;
+            loadedChannels = [channelFixture('a', { unread_count: 1 })];
+            handlerFor('chat.chan_a')({ event: 'chat_message.created', data: { sender_uuid: 'someone-else' } });
+            await settled();
+
+            assert.dom('.chat-tray-unread-notifications-badge').hasText('6', 'the reload picks up the new server total');
+        });
     });
 });
 

--- a/tests/integration/components/chat-window/attachment-test.js
+++ b/tests/integration/components/chat-window/attachment-test.js
@@ -68,4 +68,35 @@ module('Integration | Component | chat-window/attachment', function (hooks) {
 
         assert.strictEqual(downloads, 1, 'clicking the attachment triggers a download');
     });
+    // DEFECTS #1. getExtension() returns null for a filename with no dot, and getWithDefault
+    // asserts on a null key rather than falling back — so the component threw during render and
+    // an attachment named README could not be displayed at all.
+    test('a filename with no extension renders rather than throwing', async function (assert) {
+        this.set('record', {
+            filename: 'README',
+            url: '/uploads/README',
+            isImage: false,
+            download: () => {},
+        });
+
+        await render(hbs`<ChatWindow::Attachment @record={{this.record}} />`);
+
+        assert.dom('.chat-attachment-file-preview').exists('the attachment renders');
+        // FontAwesome 6 renders the `file-alt` alias under its canonical name, `file-lines`.
+        assert.dom('.chat-attachment-file-preview .file-icon svg').hasClass('fa-file-lines', 'and falls back to the generic file icon');
+        assert.dom('.chat-attachment-file-preview-filename').hasText('README');
+    });
+
+    test('a dotfile with no extension also renders', async function (assert) {
+        this.set('record', {
+            filename: 'Dockerfile',
+            url: '/uploads/Dockerfile',
+            isImage: false,
+            download: () => {},
+        });
+
+        await render(hbs`<ChatWindow::Attachment @record={{this.record}} />`);
+
+        assert.dom('.chat-attachment-file-preview-filename').hasText('Dockerfile');
+    });
 });

--- a/tests/integration/components/countdown-test.js
+++ b/tests/integration/components/countdown-test.js
@@ -133,6 +133,82 @@ module('Integration | Component | countdown', function (hooks) {
             assert.true(cleared.includes(4242), 'the interval is cleared');
         });
 
+        // DEFECTS #8. restartCountdown() existed but nothing could reach it — not an @action, not
+        // referenced by the template, never called from the class — so a countdown could only be
+        // restarted by re-rendering the component. Both end callbacks now receive it as
+        // `restartFn`.
+        test('both end callbacks receive a restartFn', async function (assert) {
+            const payloads = [];
+            this.set('onCountdownEnd', (payload) => payloads.push(payload));
+            this.set('onEnd', (payload) => payloads.push(payload));
+
+            await render(hbs`<Countdown @seconds={{1}} @onCountdownEnd={{this.onCountdownEnd}} @onEnd={{this.onEnd}} />`);
+            await step(3);
+
+            assert.strictEqual(payloads.length, 2, 'both callbacks fired');
+            assert.strictEqual(typeof payloads[0].restartFn, 'function', 'onCountdownEnd gets one');
+            assert.strictEqual(typeof payloads[1].restartFn, 'function', 'and so does onEnd');
+        });
+
+        // The outer stub only captures the FIRST 1000ms interval, so a restart would fall through
+        // to the real timer and leak into the rest of the run. Capture it locally instead, which
+        // also gives the assertion something concrete: a restart schedules a fresh interval.
+        async function captureRestart(restart) {
+            const scheduled = [];
+            const previousSetInterval = window.setInterval;
+
+            window.setInterval = function (callback, delay, ...rest) {
+                if (delay === 1000) {
+                    scheduled.push(delay);
+                    return 9999;
+                }
+
+                return previousSetInterval.call(window, callback, delay, ...rest);
+            };
+
+            try {
+                restart();
+                await settled();
+            } finally {
+                window.setInterval = previousSetInterval;
+            }
+
+            return scheduled;
+        }
+
+        test('calling restartFn starts the countdown over', async function (assert) {
+            let restart;
+            this.set('onEnd', ({ restartFn }) => {
+                restart = restartFn;
+            });
+
+            await render(hbs`<Countdown @seconds={{1}} @onEnd={{this.onEnd}} />`);
+            await step(3);
+
+            assert.true(cleared.includes(4242), 'the first run cleared its interval');
+
+            const scheduled = await captureRestart(restart);
+
+            assert.deepEqual(scheduled, [1000], 'a fresh ticking interval is scheduled');
+            assert.dom('.countdown-container').exists('and the component is still rendering');
+        });
+
+        test('restartFn is bound, so it works detached from the component', async function (assert) {
+            let restart;
+            this.set('onEnd', (payload) => {
+                restart = payload.restartFn;
+            });
+
+            await render(hbs`<Countdown @seconds={{1}} @onEnd={{this.onEnd}} />`);
+            await step(3);
+
+            // Called as a bare function, exactly as a consumer's `handleEnd({ restartFn })` would.
+            const detached = restart;
+            const scheduled = await captureRestart(detached);
+
+            assert.deepEqual(scheduled, [1000], 'no `this` binding error — the restart really ran');
+        });
+
         test('it finishes happily without any end handlers', async function (assert) {
             await render(hbs`<Countdown @seconds={{1}} />`);
 

--- a/tests/integration/components/filters-picker-test.js
+++ b/tests/integration/components/filters-picker-test.js
@@ -335,4 +335,44 @@ module('Integration | Component | filters-picker', function (hooks) {
 
         assert.strictEqual(router.listeners.length, 0);
     });
+    // DEFECTS #11. `onColumn` was a parameter of the private #rebuildFilters(onColumn), and all
+    // three call sites invoked it with no argument, so the guard ran on every column and the
+    // callback never once. It reads this.args.onColumn now, which is the consumer-facing hook the
+    // guard was clearly written for.
+    module('the per-column hook', function () {
+        test('it is called once per filterable column, in order', async function (assert) {
+            const seen = [];
+            this.set('onColumn', (column, index, value) => seen.push({ label: column.label, index, value }));
+
+            await render(hbs`<FiltersPicker @columns={{this.columns}} @onColumn={{this.onColumn}} />`);
+
+            assert.deepEqual(
+                seen.map((entry) => entry.label),
+                COLUMNS.filter((column) => column.filterable).map((column) => column.label),
+                'every filterable column is reported, and only those'
+            );
+            assert.deepEqual(
+                seen.map((entry) => entry.index),
+                seen.map((_, index) => index),
+                'the index counts filterable columns'
+            );
+        });
+
+        test('it receives the resolved filter param, not the raw value path', async function (assert) {
+            const seen = [];
+            this.set('onColumn', (column) => seen.push(column.param));
+
+            await render(hbs`<FiltersPicker @columns={{this.columns}} @onColumn={{this.onColumn}} />`);
+
+            // Status has no filterParam so it falls back to its valuePath; Driver overrides
+            // `driver_uuid` with `driver`. The hook sees the resolved value in both cases.
+            assert.deepEqual(seen, ['status', 'driver']);
+        });
+
+        test('it is not required', async function (assert) {
+            await render(hbs`<FiltersPicker @columns={{this.columns}} />`);
+
+            assert.dom('.ember-basic-dropdown-trigger').exists('the picker renders without the hook');
+        });
+    });
 });

--- a/tests/integration/components/layout/resource/panel-test.js
+++ b/tests/integration/components/layout/resource/panel-test.js
@@ -167,6 +167,50 @@ module('Integration | Component | layout/resource/panel', function (hooks) {
             assert.strictEqual(opens[1].resource, this.resource);
         });
 
+        // DEFECTS #5. panel.hbs wired @onToggle={{this.onToggle}} to an action the class never
+        // defined, so the panel passed `undefined` to <Overlay> and could not forward a toggle at
+        // all. The action now exists and forwards through contextComponentCallback, exactly as
+        // onOpen and onClose do.
+        test('toggling the panel reports it with the resource', async function (assert) {
+            const toggles = [];
+            let context;
+            this.set('onLoad', (value) => {
+                context = value;
+            });
+            this.set('onToggle', (payload) => toggles.push(payload));
+
+            await render(hbs`<Layout::Resource::Panel @resource={{this.resource}} @onLoad={{this.onLoad}} @onToggle={{this.onToggle}} />`);
+
+            // Only Overlay's toggle() reports a toggle — open() and close() each report their own
+            // event and nothing else, which is why the panel's context exposes toggle separately.
+            assert.strictEqual(toggles.length, 0, 'opening on insert is not a toggle');
+
+            context.toggle();
+            await settled();
+
+            assert.strictEqual(toggles.length, 1, 'toggling closed reports it');
+            assert.strictEqual(toggles[0].resource, this.resource, 'the resource travels with the event');
+
+            context.toggle();
+            await settled();
+
+            assert.strictEqual(toggles.length, 2, 'toggling back open reports another');
+        });
+
+        test('it toggles happily with no onToggle handler', async function (assert) {
+            let context;
+            this.set('onLoad', (value) => {
+                context = value;
+            });
+
+            await render(hbs`<Layout::Resource::Panel @resource={{this.resource}} @onLoad={{this.onLoad}} />`);
+
+            context.toggle();
+            await settled();
+
+            assert.dom(OVERLAY).doesNotHaveClass('is-open', 'the toggle still happens without a consumer');
+        });
+
         test('it opens and closes happily with no callbacks', async function (assert) {
             let context;
             this.set('onLoad', (value) => {

--- a/tests/integration/components/layout/sidebar-test.js
+++ b/tests/integration/components/layout/sidebar-test.js
@@ -671,4 +671,58 @@ module('Integration | Component | layout/sidebar', function (hooks) {
             assert.strictEqual(sidebar.style.transition, originalTransition, 'the restore puts the caller’s transition back');
         });
     });
+    // DEFECTS #4. scheduleResizeFrame() defers through requestAnimationFrame, and both
+    // flushResizeFrame() and teardown() cancel a frame that is still pending. Whether anything
+    // IS pending at that moment depended on whether the browser happened to paint first, so those
+    // two cancel branches were covered on some runs and not others — a ±2 statement wobble in the
+    // suite total with no code change. Dispatching synchronously, with no await in between, gives
+    // the browser no opportunity to paint and makes a pending frame a certainty.
+    module('cancelling a resize frame that is still pending', function () {
+        test('releasing the gutter cancels the frame the last move scheduled', async function (assert) {
+            await render(hbs`<Layout::Sidebar @collapseBelowWidth={{160}} @minResizeWidth={{200}} />`);
+
+            const sidebar = this.element.querySelector('nav.next-sidebar');
+            const gutter = this.element.querySelector('.next-sidebar-content + .gutter');
+            sidebar.style.width = '260px';
+            useInlineSidebarWidth(sidebar);
+
+            await triggerEvent(gutter, 'mousedown', { clientX: 260 });
+
+            // No await between these two: the frame scheduled by the move is guaranteed to still
+            // be pending when mouseup runs, so stopResize() takes its cancel path.
+            document.dispatchEvent(new MouseEvent('mousemove', { clientX: 300, bubbles: true }));
+            dispatchMouseup(300);
+            await settled();
+
+            assert.strictEqual(sidebar.style.width, '300px', 'the pending width is still applied, by the flush rather than the frame');
+        });
+
+        test('tearing the sidebar down cancels a frame that never ran', async function (assert) {
+            this.set('showSidebar', true);
+            await render(hbs`
+                {{#if this.showSidebar}}
+                    <Layout::Sidebar @collapseBelowWidth={{160}} @minResizeWidth={{200}} />
+                {{/if}}
+            `);
+
+            const sidebar = this.element.querySelector('nav.next-sidebar');
+            const gutter = this.element.querySelector('.next-sidebar-content + .gutter');
+            sidebar.style.width = '240px';
+            useInlineSidebarWidth(sidebar);
+
+            await triggerEvent(gutter, 'mousedown', { clientX: 240 });
+
+            // Schedule a frame and destroy the component before it can run.
+            document.dispatchEvent(new MouseEvent('mousemove', { clientX: 280, bubbles: true }));
+            this.set('showSidebar', false);
+            await settled();
+
+            assert.dom('nav.next-sidebar').doesNotExist('the sidebar is gone');
+
+            // A frame that outlived teardown would apply a width to a detached node; the cancel in
+            // teardown() is what stops that.
+            await waitForResizeFrame();
+            assert.dom('nav.next-sidebar').doesNotExist('and nothing resurrects it');
+        });
+    });
 });

--- a/tests/integration/components/metadata-editor-test.js
+++ b/tests/integration/components/metadata-editor-test.js
@@ -93,15 +93,32 @@ module('Integration | Component | metadata-editor', function (hooks) {
         assert.deepEqual(output.list, [1, 2]);
     });
 
-    test('the heading is only rendered when a label is supplied', async function (assert) {
-        // NOTE: the component exposes a `label` getter defaulting to 'Metadata',
-        // but the template gates on `{{#if @label}}` and renders `@label`
-        // directly, so that default is never displayed.
+    // The template used to gate on {{#if @label}} and render @label directly, so the component's
+    // own `label` getter — and the 'Metadata' default it encodes — was never consulted. It reads
+    // {{this.label}} now, which is what makes that default reachable. (DEFECTS #7)
+    test('the heading falls back to Metadata when no label is supplied', async function (assert) {
         await render(TEMPLATE);
-        assert.dom('h3').doesNotExist('no heading without an explicit label');
 
+        assert.dom('h3').hasText('Metadata', 'the default the getter always encoded now applies');
+    });
+
+    test('an explicit label wins over the default', async function (assert) {
         this.set('label', 'Custom attributes');
+
+        await render(TEMPLATE);
+
         assert.dom('h3').hasText('Custom attributes');
+    });
+
+    test('an empty label suppresses the heading entirely', async function (assert) {
+        this.set('label', '');
+
+        await render(TEMPLATE);
+
+        // `?? 'Metadata'` is nullish-coalescing, so an empty string is kept rather than defaulted,
+        // and {{#if this.label}} then renders nothing. Passing '' is the way to opt out of the
+        // heading now that omitting the argument no longer does.
+        assert.dom('h3').doesNotExist();
     });
 
     test('adding a row appends an empty row and reports the change', async function (assert) {

--- a/tests/integration/components/overlay/header-test.js
+++ b/tests/integration/components/overlay/header-test.js
@@ -31,6 +31,62 @@ module('Integration | Component | overlay/header', function (hooks) {
             assert.dom('.next-content-overlay-panel-title').hasText('Short...');
         });
 
+        // DEFECTS #2. The component always carried a `useEllipsis` getter encoding a 15-character
+        // threshold, but nothing consulted it — the template truncated on @overlay.isMinimized
+        // alone. @titleEllipsis opts a non-minimized header into the same truncation, and
+        // @titleEllipsisLength makes the threshold configurable.
+        test('@titleEllipsis truncates a long title on an open overlay', async function (assert) {
+            await render(hbs`<Overlay::Header @title="A very long order title indeed" @titleEllipsis={{true}} />`);
+
+            assert.dom('.next-content-overlay-panel-title').hasText('A very long ord...');
+        });
+
+        test('a title at or under the threshold is left alone', async function (assert) {
+            await render(hbs`<Overlay::Header @title="Order 123" @titleEllipsis={{true}} />`);
+
+            assert.dom('.next-content-overlay-panel-title').hasText('Order 123', 'nine characters is under fifteen');
+        });
+
+        test('a title of exactly the threshold is not truncated', async function (assert) {
+            await render(hbs`<Overlay::Header @title="123456789012345" @titleEllipsis={{true}} />`);
+
+            assert.dom('.next-content-overlay-panel-title').hasText('123456789012345', 'the threshold is exclusive');
+        });
+
+        test('without @titleEllipsis an open overlay never truncates', async function (assert) {
+            await render(hbs`<Overlay::Header @title="A very long order title indeed" />`);
+
+            assert.dom('.next-content-overlay-panel-title').hasText('A very long order title indeed', 'the argument is opt-in');
+        });
+
+        test('@titleEllipsisLength moves the threshold', async function (assert) {
+            await render(hbs`<Overlay::Header @title="A very long order title indeed" @titleEllipsis={{true}} @titleEllipsisLength={{5}} />`);
+
+            assert.dom('.next-content-overlay-panel-title').hasText('A ver...');
+        });
+
+        test('a length of zero truncates everything', async function (assert) {
+            await render(hbs`<Overlay::Header @title="Order 123" @titleEllipsis={{true}} @titleEllipsisLength={{0}} />`);
+
+            assert.dom('.next-content-overlay-panel-title').hasText('...', 'zero is honoured rather than falling back to the default');
+        });
+
+        test('a minimized overlay still truncates without the argument', async function (assert) {
+            this.set('overlay', { isMinimized: true });
+
+            await render(hbs`<Overlay::Header @title="A very long order title indeed" @overlay={{this.overlay}} @titleEllipsis={{false}} />`);
+
+            assert.dom('.next-content-overlay-panel-title').hasText('A very long ord...', 'minimizing is independent of the opt-in');
+        });
+
+        test('@titleEllipsisLength applies to a minimized overlay too', async function (assert) {
+            this.set('overlay', { isMinimized: true });
+
+            await render(hbs`<Overlay::Header @title="A very long order title indeed" @overlay={{this.overlay}} @titleEllipsisLength={{4}} />`);
+
+            assert.dom('.next-content-overlay-panel-title').hasText('A ve...');
+        });
+
         test('a status renders a badge', async function (assert) {
             await render(hbs`<Overlay::Header @title="Order 123" @status="dispatched" />`);
 

--- a/tests/integration/components/report-builder/condition-value-test.js
+++ b/tests/integration/components/report-builder/condition-value-test.js
@@ -85,14 +85,16 @@ module('Integration | Component | report-builder/condition-value', function (hoo
             assert.dom('.fleetbase-date-picker').hasClass('w-52');
         });
 
-        test('a boolean column currently falls through to a text field', async function (assert) {
+        // The component always exposed an `isBoolean` getter; the template had no boolean branch,
+        // so a boolean column was edited as free text. It gets a radio group now. (DEFECTS #3)
+        test('a boolean column is edited with a radio group', async function (assert) {
             this.set('column', { type: 'boolean' });
 
             await render(TEMPLATE);
 
-            // The component exposes an `isBoolean` getter, but the template has no boolean
-            // branch, so a boolean condition is edited as free text.
-            assert.dom('input[type="text"]').exists();
+            assert.dom('input[type="text"]').doesNotExist('no free-text field for a boolean');
+            assert.strictEqual(findAll('input[type="radio"]').length, 2, 'exactly True and False are offered');
+            assert.dom('.report-builder-boolean-value').hasText('True False');
         });
     });
 
@@ -173,6 +175,91 @@ module('Integration | Component | report-builder/condition-value', function (hoo
             await fillIn('input[type="text"]', 'pending');
 
             assert.dom('input[type="text"]').exists('the editor survives');
+        });
+    });
+    // The boolean editor added for DEFECTS #3. A saved report round-trips through JSON and query
+    // params, so the value can come back as a string or a number rather than a boolean.
+    module('the boolean editor', function () {
+        function radios() {
+            return findAll('.report-builder-boolean-value input[type="radio"]');
+        }
+
+        test('neither option is selected until one is chosen', async function (assert) {
+            this.set('column', { type: 'boolean' });
+
+            await render(TEMPLATE);
+
+            assert.false(radios()[0].checked, 'True is not preselected');
+            assert.false(radios()[1].checked, 'and neither is False');
+        });
+
+        test('choosing True reports a real boolean', async function (assert) {
+            this.set('column', { type: 'boolean' });
+            await render(TEMPLATE);
+
+            await click(radios()[0]);
+
+            assert.deepEqual(changes[changes.length - 1], { value: true }, 'true, not the string "true"');
+        });
+
+        test('choosing False reports false rather than clearing the value', async function (assert) {
+            this.set('column', { type: 'boolean' });
+            await render(TEMPLATE);
+
+            await click(radios()[1]);
+
+            assert.deepEqual(changes[changes.length - 1], { value: false });
+        });
+
+        test('an existing boolean value is reflected in the selection', async function (assert) {
+            this.set('column', { type: 'boolean' });
+            this.set('value', true);
+
+            await render(TEMPLATE);
+
+            assert.true(radios()[0].checked, 'True is selected');
+            assert.false(radios()[1].checked);
+        });
+
+        test('a value that round-tripped as a string still selects the right option', async function (assert) {
+            this.set('column', { type: 'boolean' });
+            this.set('value', 'false');
+
+            await render(TEMPLATE);
+
+            assert.false(radios()[0].checked);
+            assert.true(radios()[1].checked, "the string 'false' selects False, not neither");
+        });
+
+        test('a value that round-tripped as a number still selects the right option', async function (assert) {
+            this.set('column', { type: 'boolean' });
+            this.set('value', 1);
+
+            await render(TEMPLATE);
+
+            assert.true(radios()[0].checked, '1 selects True');
+        });
+
+        test('an unrecognised value selects neither option', async function (assert) {
+            this.set('column', { type: 'boolean' });
+            this.set('value', 'maybe');
+
+            await render(TEMPLATE);
+
+            assert.false(radios()[0].checked);
+            assert.false(radios()[1].checked);
+        });
+
+        test('two boolean editors do not share a radio group', async function (assert) {
+            this.set('column', { type: 'boolean' });
+
+            await render(hbs`
+                <ReportBuilder::ConditionValue @column={{this.column}} @onChange={{this.onChange}} />
+                <ReportBuilder::ConditionValue @column={{this.column}} @onChange={{this.onChange}} />
+            `);
+
+            const names = findAll('.report-builder-boolean-value input[type="radio"]').map((input) => input.name);
+            assert.strictEqual(new Set(names).size, 2, 'each editor gets its own group name');
         });
     });
 });


### PR DESCRIPTION
Works through every open entry in `DEFECTS.md` except #15, which is deferred by decision. Each fix is pinned by a test, and every status in the tracker now records what was decided and why.

## The fixes

| # | Component | What changed |
|---|---|---|
| 1 | `chat-window/attachment` | A filename with no dot (`README`, `Dockerfile`) produced a null extension, `getWithDefault` asserted on it, and the component **threw during render**. Guarded the way `file-icon.js` already did. |
| 2 | `overlay/header` | `@titleEllipsis` opts an open overlay into the truncation only minimizing used to trigger; `@titleEllipsisLength` sets the threshold the `useEllipsis` getter always encoded (default 15). |
| 3 | `report-builder/condition-value` | Boolean columns got a free-text field. Added a True/False radio group. |
| 4 | `layout/sidebar` | The ±2 statement wobble. See below. |
| 5 | `layout/resource/panel` | The template wired `@onToggle` to an action that did not exist. |
| 6 | `chat-tray` | The unread badge summed only the channels currently loaded; the server total now wins. |
| 7 | `metadata-editor` | The template read `@label` directly, so the getter's `'Metadata'` default never applied. |
| 8 | `countdown` | `restartCountdown` was unreachable; both end callbacks now receive `{ restartFn }`. |
| 11 | `filters-picker` | `#rebuildFilters(onColumn)` was called with no argument at all three call sites. |
| 14 | `template-builder/properties-panel` | Dropped `value="target.value"`, which `{{fn}}` ignores. |
| 9, 10, 12 | — | Deleted, as decided. |

Details worth a second look:

- **#2** — a minimized overlay still truncates regardless of the new argument, so **no existing call site changes behaviour**. The misspelled internal getter is now `titleWithEllipsis`.
- **#3** — normalises values that round-trip as `'true'` or `1`, and gives each rendered editor its own radio group name via `guidFor`, so two boolean conditions in one report cannot clear each other.
- **#6** — the task is `restartable`, so a slow earlier response cannot overwrite a newer one, and a failure leaves the summed count in place rather than blanking the badge. Neither was in the brief; shipping without them would have traded a stale badge for a broken tray.
- **#7** — `??` is nullish-coalescing, so `@label=""` is now how you opt out of the heading, since omitting the argument no longer does.
- **#8** — existing consumers that declare no parameters are unaffected.

## #4, and why my first two attempts were wrong

`sidebar.js` moved the suite total by ±2 statements between identical runs.

The racing statements are **not** the `requestAnimationFrame` callback — that runs reliably. They are the *cancel* branches in `flushResizeFrame()` and `teardown()`, reached only when a frame is still pending, which depended on whether the browser painted first.

My first fix awaited the frame before releasing the gutter. That made it **strictly worse**: it guaranteed nothing was pending by the time `stopResize` ran, permanently closing the only path to those lines. The artifact caught it — the mechanism I had reasoned my way to matched the ±2 signature exactly and was still the wrong one.

The fix is two tests that dispatch synchronously, with no `await` between the events, so no paint can intervene. That idiom was already in use a few tests earlier in the same file.

`sidebar.js`: **199/215 → 203/215**, with those four lines reported covered rather than sometimes-covered.

## #16 — detection, not a cure

`scripts/stamp-coverage-run.js` clears `coverage/` and stamps the run start; `test:coverage` runs it first. The gate now rejects a missing stamp, an unreadable one, an artifact older than the run, and a `coverage-final.json` that was never written — **before reading a single percentage**. The self-test grew from 10 cases to 17, including the dangerous one: a green suite that leaves the previous artifact in place.

**The cause is untouched.** 7 of 9 fast filtered runs this session produced no `coverage/` directory at all, while every full run produced one — consistent with the addon POSTing coverage at test end and a short run tearing down first. That makes it a local-development tax rather than a CI risk, since CI runs the full suite.

The entry also retracts two things I claimed earlier in the session: `rm -rf coverage` does **not** make collection reliable (the 7-of-9 figure is *with* it), and the Node 18 ESM failure cannot affect CI, which pins `NODE_VERSION: 22.x`.

## #15 — deferred

Confirmed as intended behaviour (fetch from a url with params) and left for its own session rather than half-built. The entry lists what it needs first: an endpoint contract, an auth story, loading and error states, a shape for `query_response_path`, something on the render side that consumes a query-backed table, and reconciliation with the `__queries__` variable route that already solves the same problem.

The branch stays uncovered rather than suppressed — an `istanbul ignore` here would sit on the opening `if`, and `ignore else` there also swallows the `variable` branch, which real tests cover.

## Three of my own tests failed before this landed

Recorded because each was a different kind of mistake and none was visible by reading:

- **A stale expectation.** FontAwesome 6 renders the `file-alt` alias under its canonical name `file-lines` — the component was right, the assertion was wrong.
- **A harness bug.** The countdown test's `setInterval` stub captures only the *first* 1000 ms interval, so a restart fell through to the real timer and leaked a live interval into the remaining ~4,700 tests.
- **A wrong assumption.** `Overlay` reports a toggle only from `toggle()`; `open()` and `close()` each report their own event, which is exactly why the panel's context exposes `toggle` separately.

One assertion of mine was also replaced for being unable to fail (`first.active ? first.value : undefined` compares a value to itself when active).

## Verification

Last complete run before this commit: **5130 tests, 5129 pass**, the single failure being this batch's own panel test, fixed here. Coverage **96.13% statements, 93.12% branches, 98.60% functions, 96.37% lines**, up from 95.79 / 92.73 / 98.15 / 96.02.

`rm -f .eslintcache && pnpm run lint` exits 0.

A final full run confirming the panel fix is in progress; I will post its numbers on this PR rather than leave these as the last word.
