### PR TITLE
feat(template-builder): finish the table's query data mode

### DIFF
--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -277,8 +277,8 @@ documented as such.
 
 ## 15. `addon/components/template-builder/properties-panel.js:219` — the table's `query` data mode has no control
 
-**Status:** DEFERRED — a later update, by decision
-**Found:** `else if (mode === 'query')` reports `[0,0]` — never evaluated either way.
+**Status:** FIXED (PR #164)
+**Found:** `else if (mode === 'query')` reported `[0,0]` — never evaluated either way.
 **Evidence:** `setTableDataMode` handles three modes and clears the other modes' fields for each.
 The template offers a two-button toggle, Variable and Manual (`properties-panel.hbs:258` and `:266`);
 nothing anywhere calls it with `'query'`. `data_source_mode` appears in exactly three places in the
@@ -288,16 +288,43 @@ by this action and read by nothing.
 **Impact:** none at runtime. This is scaffolding for a data mode the panel does not offer, not dead
 code in the usual sense: `TemplateBuilder::QueryForm` and the queries panel exist, so a query-backed
 table looks like an intended feature that stopped short of the properties panel.
-**Fix:** finish it. Confirmed as intended behaviour — fetch from a url with params — and deferred to
-its own session rather than half-built here. What it needs before anyone starts: an endpoint
-contract, an auth story, loading and error states, a defined shape for `query_response_path`, and
-something on the render side that consumes a query-backed table (nothing does today). It also has to
-be reconciled with the `__queries__` variable route, which already solves the same problem by
-exposing saved queries as variables — otherwise the panel ends up with two competing mechanisms.
+**Fix:** finished, not deleted — the mode was confirmed as intended behaviour, fetch from a url with
+params. The panel now has a three-button toggle and a query-mode form; `element-renderer` labels a
+query- or variable-backed table on the canvas; and the six questions this was blocked on are
+answered below.
 
-Until then the branch stays uncovered rather than suppressed: an `istanbul ignore` here would have
-to sit on the opening `if`, and `ignore else` there also swallows the `variable` branch, which real
-tests cover.
+**Applied — the decisions, so they are not rediscovered:**
+
+- **Reconciliation with `__queries__`, the one that mattered.** They stay two mechanisms with a
+  stated boundary, and Variable mode remains the usual answer. A saved `TemplateQuery` is a
+  structured query over a registered `model_type`, reusable across elements and saved with the
+  template; it is reached through **Variable** mode, under `__queries__`, and that mode's hint now
+  names the namespace so the structured route is the one found first. Query mode is one API path
+  bound to one element, and exists for what the query builder cannot express — aggregates, reports,
+  and extension endpoints with no model behind them. The boundary is written into
+  `properties-panel.js` above the query helpers.
+- **Endpoint contract.** A path relative to the Fleetbase API (`int/v1/orders`); leading slashes are
+  stripped. Absolute and protocol-relative URLs are **rejected**, as typed and again before any
+  request fires: the `fetch` service attaches the session to everything it sends, so a third-party
+  host would be handed those credentials.
+- **Auth.** The injected `fetch` service. Nothing new was introduced.
+- **`query_params` shape.** `[{ key, value }]`, matching the `[]` the clearing arms already seeded.
+  Values may hold `{variable}` tokens, resolved downstream at render.
+- **`query_response_path`.** A dotted path into the response body; blank means the body is itself the
+  array. Every way it can fail to resolve is reported by name — a missing segment, a segment that
+  runs into a primitive, and a path that lands on something other than an array.
+- **Fetching.** The mode stores intent, like variable mode — nothing in this addon resolves a data
+  source at render time. The one exception is the explicit **Test query** button, which fetches once
+  so the endpoint, params and path can be checked before saving. It never writes the fetched rows
+  onto the element; it reports the row count and keys, and offers to turn those keys into columns.
+  Params still holding an unresolved token are left out of that request and named.
+- **Loading and error states.** In-flight reporting on the button, request and response-path failures
+  both surfaced, and results keyed to the element they ran against so selecting another table does
+  not show it the previous one's results.
+
+The `istanbul ignore` problem the deferral noted is gone rather than suppressed: the final arm is now
+a plain `else`, so there is no third condition carrying a permanently-unreachable false path, and the
+`variable` branch real tests cover is untouched.
 
 ## 16. Coverage collection itself is unreliable, which the 100% gate cannot tolerate
 

--- a/addon/components/template-builder/element-renderer.hbs
+++ b/addon/components/template-builder/element-renderer.hbs
@@ -71,6 +71,14 @@
                                     {{/each}}
                                 </tr>
                             {{/each}}
+                            {{#if this.tableSourceCaption}}
+                                <tr>
+                                    <td
+                                        class="tb-table-source-caption border px-2 py-1 text-gray-400 text-center italic truncate"
+                                        colspan={{this.tableColumns.length}}
+                                    >{{this.tableSourceCaption}}</td>
+                                </tr>
+                            {{/if}}
                         {{/if}}
                     </tbody>
                 {{else}}

--- a/addon/components/template-builder/element-renderer.js
+++ b/addon/components/template-builder/element-renderer.js
@@ -334,6 +334,24 @@ export default class TemplateBuilderElementRendererComponent extends Component {
         return this.args.element?.rows ?? [];
     }
 
+    /**
+     * Caption drawn under the placeholder grid of a table that has no rows of its
+     * own. Nothing here resolves a data source — the builder stores intent and
+     * something downstream renders it — so without this a variable- or
+     * query-backed table looks exactly like an empty one on the canvas. Only read
+     * from the table arm of the template, where `isTable` proves the element.
+     */
+    get tableSourceCaption() {
+        const el = this.args.element;
+        if (el.data_source_mode === 'variable') {
+            return el.data_source ? `Rows from ${el.data_source}` : 'Rows from a variable';
+        }
+        if (el.data_source_mode === 'query') {
+            return el.query_endpoint ? `Rows from ${el.query_endpoint}` : 'Rows from a query';
+        }
+        return null;
+    }
+
     get tableBorderStyle() {
         const color = this.args.element?.border_color;
         return color ? `border-color: ${color}` : '';

--- a/addon/components/template-builder/properties-panel.hbs
+++ b/addon/components/template-builder/properties-panel.hbs
@@ -247,7 +247,7 @@
             >
                 <div class="space-y-2">
 
-                    {{! Two-mode toggle: Variable | Manual }}
+                    {{! Three-mode toggle: Variable | Query | Manual }}
                     <div class="flex rounded overflow-hidden border border-gray-200 dark:border-gray-700 text-xs">
                         <button
                             type="button"
@@ -257,6 +257,14 @@
                                     'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'}}"
                             {{on "click" (fn this.setTableDataMode "variable")}}
                         >Variable</button>
+                        <button
+                            type="button"
+                            class="flex-1 py-1 font-medium border-l border-gray-200 dark:border-gray-700 transition-colors
+                                {{if (eq this.tableDataMode 'query')
+                                    'bg-blue-500 text-white'
+                                    'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700'}}"
+                            {{on "click" (fn this.setTableDataMode "query")}}
+                        >Query</button>
                         <button
                             type="button"
                             class="flex-1 py-1 font-medium border-l border-gray-200 dark:border-gray-700 transition-colors
@@ -284,7 +292,119 @@
                                 </button>
                             </div>
                         </TemplateBuilder::PropertiesPanel::Field>
-                        <p class="text-xs text-gray-400 dark:text-gray-500">The variable must resolve to an array of objects. Each object's keys should match the column keys defined above.</p>
+                        <p class="text-xs text-gray-400 dark:text-gray-500">The variable must resolve to an array of objects. Each object's keys should match the column keys defined above. Saved queries appear here under <code>__queries__</code>.</p>
+
+                    {{! ── QUERY MODE ── }}
+                    {{else if this.isTableQueryMode}}
+                        <TemplateBuilder::PropertiesPanel::Field @label="API Endpoint">
+                            <input
+                                type="text"
+                                class="tb-input tb-query-endpoint"
+                                placeholder="int/v1/orders"
+                                value={{this.element.query_endpoint}}
+                                {{on "change" (fn this.updateProp "query_endpoint")}}
+                            />
+                        </TemplateBuilder::PropertiesPanel::Field>
+                        {{#if this.queryEndpointError}}
+                            <p class="tb-query-endpoint-error text-xs text-red-500">{{this.queryEndpointError}}</p>
+                        {{else}}
+                            <p class="text-xs text-gray-400 dark:text-gray-500">A path on the Fleetbase API. Requests carry your session, so full URLs to other hosts are not accepted.</p>
+                        {{/if}}
+
+                        <TemplateBuilder::PropertiesPanel::Field @label="Query Parameters">
+                            <div class="tb-query-params space-y-1">
+                                {{#each this.queryParams as |param index|}}
+                                    <div class="tb-query-param flex items-center space-x-1">
+                                        <input
+                                            type="text"
+                                            class="tb-input tb-query-param-key flex-1"
+                                            placeholder="status"
+                                            value={{param.key}}
+                                            {{on "change" (fn this.updateQueryParam index "key")}}
+                                        />
+                                        <input
+                                            type="text"
+                                            class="tb-input tb-query-param-value flex-1"
+                                            placeholder="{order.status}"
+                                            value={{param.value}}
+                                            {{on "change" (fn this.updateQueryParam index "value")}}
+                                        />
+                                        <button
+                                            type="button"
+                                            class="text-red-400 hover:text-red-600"
+                                            title="Remove parameter"
+                                            {{on "click" (fn this.removeQueryParam index)}}
+                                        >
+                                            <FaIcon @icon="xmark" class="w-3 h-3" />
+                                        </button>
+                                    </div>
+                                {{else}}
+                                    <p class="text-xs text-gray-400 dark:text-gray-500">No parameters.</p>
+                                {{/each}}
+                                <button
+                                    type="button"
+                                    class="w-full flex items-center justify-center space-x-1.5 px-2 py-1.5 rounded border border-dashed border-gray-300 dark:border-gray-600 text-xs text-gray-500 dark:text-gray-400 hover:border-blue-400 hover:text-blue-500 transition-colors"
+                                    {{on "click" this.addQueryParam}}
+                                >
+                                    <FaIcon @icon="plus" class="w-3 h-3" />
+                                    <span>Add parameter</span>
+                                </button>
+                            </div>
+                        </TemplateBuilder::PropertiesPanel::Field>
+                        <p class="text-xs text-gray-400 dark:text-gray-500">Values may hold variable tokens such as <code>{order.uuid}</code>, resolved when the template is rendered.</p>
+
+                        <TemplateBuilder::PropertiesPanel::Field @label="Response Path">
+                            <input
+                                type="text"
+                                class="tb-input tb-query-response-path"
+                                placeholder="data.results"
+                                value={{this.element.query_response_path}}
+                                {{on "change" (fn this.updateProp "query_response_path")}}
+                            />
+                        </TemplateBuilder::PropertiesPanel::Field>
+                        <p class="text-xs text-gray-400 dark:text-gray-500">Dotted path to the array of rows in the response. Leave blank when the response is that array itself.</p>
+
+                        <button
+                            type="button"
+                            class="tb-query-test w-full flex items-center justify-center space-x-1.5 px-2 py-1.5 rounded border border-gray-300 dark:border-gray-600 text-xs text-gray-600 dark:text-gray-400 hover:border-blue-400 hover:text-blue-500 transition-colors disabled:opacity-50"
+                            disabled={{this.isTestingQuery}}
+                            {{on "click" this.testQuery}}
+                        >
+                            {{#if this.isTestingQuery}}
+                                <FaIcon @icon="spinner" @spin={{true}} class="w-3 h-3" />
+                                <span>Testing…</span>
+                            {{else}}
+                                <FaIcon @icon="play" class="w-3 h-3" />
+                                <span>Test query</span>
+                            {{/if}}
+                        </button>
+
+                        {{#if this.queryTestError}}
+                            <p class="tb-query-test-error text-xs text-red-500">{{this.queryTestError}}</p>
+                        {{/if}}
+
+                        {{#if this.queryTestResult}}
+                            <div class="tb-query-test-result rounded border border-gray-200 dark:border-gray-700 p-2 space-y-1">
+                                <p class="text-xs text-gray-600 dark:text-gray-400">
+                                    Returned {{this.queryTestResult.count}}
+                                    {{if (eq this.queryTestResult.count 1) "row" "rows"}}.
+                                </p>
+                                {{#if this.queryTestResult.skippedParams.length}}
+                                    <p class="tb-query-test-skipped text-xs text-amber-500">Sent without unresolved parameters: {{this.queryTestResult.skippedParamsLabel}}.</p>
+                                {{/if}}
+                                {{#if this.queryTestResult.keys.length}}
+                                    <p class="tb-query-test-keys text-xs text-gray-500 dark:text-gray-400 break-all">Keys: {{this.queryTestResult.keysLabel}}</p>
+                                    <button
+                                        type="button"
+                                        class="tb-query-apply-columns w-full flex items-center justify-center space-x-1.5 px-2 py-1 rounded border border-dashed border-gray-300 dark:border-gray-600 text-xs text-gray-500 dark:text-gray-400 hover:border-blue-400 hover:text-blue-500 transition-colors"
+                                        {{on "click" this.applyDiscoveredColumns}}
+                                    >
+                                        <FaIcon @icon="table-columns" class="w-3 h-3" />
+                                        <span>Use these as columns</span>
+                                    </button>
+                                {{/if}}
+                            </div>
+                        {{/if}}
 
                     {{! ── MANUAL MODE ── }}
                     {{else}}

--- a/addon/components/template-builder/properties-panel.js
+++ b/addon/components/template-builder/properties-panel.js
@@ -4,6 +4,107 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 /**
+ * Matches an absolute or protocol-relative URL. A query-mode endpoint has to be
+ * a path relative to the Fleetbase API host: the `fetch` service attaches the
+ * session credentials to every request it makes, so pointing an endpoint at a
+ * third-party host would hand that session to the third party.
+ */
+const ABSOLUTE_URL = /^([a-z][a-z0-9+.-]*:)?\/\//i;
+
+/** A `{token}` left in a query param value, resolved downstream at render time. */
+const UNRESOLVED_TOKEN = /\{[^}]*\}/;
+
+/** How many preview rows are scanned when suggesting column keys. */
+const KEY_DISCOVERY_LIMIT = 20;
+
+/** Strips the leading slashes the `fetch` service does not want. */
+function normalizeEndpoint(raw) {
+    return raw.trim().replace(/^\/+/, '');
+}
+
+/**
+ * Returns a message describing why `raw` is not a usable endpoint, or null.
+ */
+function validateEndpoint(raw) {
+    const value = (raw ?? '').trim();
+    if (!value) {
+        return 'Enter an API endpoint to query.';
+    }
+    if (ABSOLUTE_URL.test(value)) {
+        return 'Enter a path on the Fleetbase API, not a full URL — requests are sent with your session credentials.';
+    }
+    return null;
+}
+
+function describeValue(value) {
+    if (value === null) return 'null';
+    if (value === undefined) return 'nothing';
+    const type = typeof value;
+    // `object` is the only typeof that reaches here needing "an".
+    return `${type === 'object' ? 'an' : 'a'} ${type}`;
+}
+
+/**
+ * Walks the dotted `path` into `body` and returns `{ rows }` when it lands on an
+ * array, or `{ error }` describing exactly where it stopped. An empty path means
+ * the response body is itself the array of rows.
+ */
+function resolveResponsePath(body, path) {
+    const segments = (path ?? '')
+        .trim()
+        .split('.')
+        .map((segment) => segment.trim())
+        .filter(Boolean);
+    const full = segments.join('.');
+    const walked = [];
+    let cursor = body;
+
+    for (const segment of segments) {
+        if (cursor === null || typeof cursor !== 'object') {
+            const at = walked.length ? `"${walked.join('.')}"` : 'the response body';
+            return { error: `Response path "${full}" did not resolve — ${at} is ${describeValue(cursor)}, not an object.` };
+        }
+        if (!(segment in cursor)) {
+            const at = walked.length ? ` under "${walked.join('.')}"` : ' in the response';
+            return { error: `Response path "${full}" did not resolve — there is no "${segment}"${at}.` };
+        }
+        cursor = cursor[segment];
+        walked.push(segment);
+    }
+
+    if (!Array.isArray(cursor)) {
+        const at = full ? `at "${full}"` : 'in the response';
+        return { error: `Expected an array of rows ${at}, got ${describeValue(cursor)}.` };
+    }
+
+    return { rows: cursor };
+}
+
+/**
+ * Collects the union of the keys on the first `KEY_DISCOVERY_LIMIT` rows, in the
+ * order they were first seen, so the panel can offer them as table columns.
+ */
+function discoverKeys(rows) {
+    const keys = [];
+    rows.slice(0, KEY_DISCOVERY_LIMIT).forEach((row) => {
+        if (row === null || typeof row !== 'object' || Array.isArray(row)) return;
+        Object.keys(row).forEach((key) => {
+            if (!keys.includes(key)) keys.push(key);
+        });
+    });
+    return keys;
+}
+
+/** `total_amount` / `totalAmount` -> `Total Amount`, for a suggested column label. */
+function humanizeKey(key) {
+    return String(key)
+        .replace(/[_-]+/g, ' ')
+        .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+        .trim()
+        .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+/**
  * TemplateBuilderPropertiesPanelComponent
  *
  * Right-side panel that shows and edits all properties of the currently
@@ -28,6 +129,18 @@ export default class TemplateBuilderPropertiesPanelComponent extends Component {
 
     /** @type {String|null} Filename of the most recently uploaded image */
     @tracked uploadedImageFilename = null;
+
+    /** @type {Boolean} Whether the query-mode test request is in flight */
+    @tracked isTestingQuery = false;
+
+    /** @type {String|null} Error from the most recent query test */
+    @tracked _queryTestError = null;
+
+    /** @type {Object|null} `{ count, keys, skippedParams }` from the last successful test */
+    @tracked _queryTestResult = null;
+
+    /** @type {String|null} uuid of the element the query test state belongs to */
+    @tracked _queryTestElementUuid = null;
 
     get hasSelection() {
         return !!this.args.selectedElement;
@@ -204,6 +317,7 @@ export default class TemplateBuilderPropertiesPanelComponent extends Component {
     @action
     setTableDataMode(mode) {
         if (!this.args.onUpdateElement || !this.element) return;
+        this._clearQueryTest();
         const changes = { data_source_mode: mode };
         if (mode === 'manual') {
             // Clear variable/query fields when switching to manual
@@ -216,8 +330,11 @@ export default class TemplateBuilderPropertiesPanelComponent extends Component {
             changes.query_endpoint = null;
             changes.query_params = [];
             changes.query_response_path = null;
-        } else if (mode === 'query') {
-            // Clear variable field when switching to query
+        } else {
+            // 'query' — the third and last mode the toggle offers. A plain `else`
+            // rather than `else if (mode === 'query')`: a third condition would
+            // carry a false path nothing can ever reach, which is what left this
+            // branch reporting [0,0] and un-suppressable in the first place.
             changes.data_source = null;
             // Seed empty query_params array if not already present
             if (!this.element.query_params) {
@@ -228,6 +345,158 @@ export default class TemplateBuilderPropertiesPanelComponent extends Component {
     }
 
     // ── Query data source helpers ────────────────────────────────────────────
+    //
+    // Query mode and the `__queries__` variables are deliberately two different
+    // things, and Variable mode is the right answer far more often:
+    //
+    //   Variable mode  — a token resolved from the render context, including the
+    //                    saved TemplateQuery records the queries panel manages.
+    //                    Structured, reusable across elements, and saved with the
+    //                    template. Reach a saved query through this mode.
+    //   Query mode     — one Fleetbase API path, with params, bound to a single
+    //                    element. It exists for the endpoints the saved-query
+    //                    builder cannot express: aggregates, reports, and
+    //                    extension endpoints with no `model_type` behind them.
+    //
+    // Nothing in this addon resolves a data source at render time — the builder
+    // stores intent and the renderer downstream resolves it. `testQuery` is the
+    // one exception, and it is explicitly on demand: it fetches once so the
+    // endpoint, params and response path can be checked before the template is
+    // saved. It never writes the fetched rows onto the element.
+
+    get isTableQueryMode() {
+        return this.tableDataMode === 'query';
+    }
+
+    /** @type {Array<{key: String, value: String}>} Only read while an element is selected. */
+    get queryParams() {
+        return this.element.query_params ?? [];
+    }
+
+    /**
+     * Complaint about the endpoint as typed, or null. An empty endpoint is not
+     * reported here — there is nothing to correct until the user tests it.
+     */
+    get queryEndpointError() {
+        const raw = this.element.query_endpoint;
+        if (!raw || !raw.trim()) {
+            return null;
+        }
+        return validateEndpoint(raw);
+    }
+
+    /**
+     * Test state belongs to the element it was run against — selecting a
+     * different element must not show that element the previous one's results.
+     */
+    get _queryTestMatchesSelection() {
+        return this._queryTestElementUuid === this.element.uuid;
+    }
+
+    get queryTestError() {
+        return this._queryTestMatchesSelection ? this._queryTestError : null;
+    }
+
+    get queryTestResult() {
+        return this._queryTestMatchesSelection ? this._queryTestResult : null;
+    }
+
+    _clearQueryTest() {
+        this._queryTestError = null;
+        this._queryTestResult = null;
+        this._queryTestElementUuid = null;
+    }
+
+    @action
+    addQueryParam() {
+        if (!this.args.onUpdateElement || !this.element) return;
+        const query_params = [...this.queryParams, { key: '', value: '' }];
+        this.args.onUpdateElement(this.element.uuid, { query_params });
+    }
+
+    @action
+    removeQueryParam(index) {
+        if (!this.args.onUpdateElement || !this.element) return;
+        const query_params = this.queryParams.filter((_, i) => i !== index);
+        this.args.onUpdateElement(this.element.uuid, { query_params });
+    }
+
+    @action
+    updateQueryParam(index, field, event) {
+        if (!this.args.onUpdateElement || !this.element) return;
+        const value = event?.target ? event.target.value : event;
+        const query_params = this.queryParams.map((param, i) => (i === index ? { ...param, [field]: value } : param));
+        this.args.onUpdateElement(this.element.uuid, { query_params });
+    }
+
+    /**
+     * Fetches the endpoint once and reports what came back: how many rows the
+     * response path resolved to, which keys those rows carry, and which params
+     * were left out because their value is still an unresolved variable token.
+     */
+    @action
+    async testQuery() {
+        const element = this.element;
+        if (!element) return;
+
+        this._queryTestElementUuid = element.uuid;
+        this._queryTestError = null;
+        this._queryTestResult = null;
+
+        const invalid = validateEndpoint(element.query_endpoint);
+        if (invalid) {
+            this._queryTestError = invalid;
+            return;
+        }
+
+        // A param whose value still holds a `{token}` cannot be sent — the token
+        // is resolved downstream, not here — so it is dropped and named instead.
+        const named = this.queryParams.filter((param) => param.key?.trim());
+        const skippedParams = [];
+        const params = {};
+        named.forEach((param) => {
+            const value = param.value ?? '';
+            if (UNRESOLVED_TOKEN.test(value)) {
+                skippedParams.push(param.key.trim());
+                return;
+            }
+            params[param.key.trim()] = value;
+        });
+
+        this.isTestingQuery = true;
+
+        try {
+            const response = await this.fetch.get(normalizeEndpoint(element.query_endpoint), params);
+            const { rows, error } = resolveResponsePath(response, element.query_response_path);
+            if (error) {
+                this._queryTestError = error;
+            } else {
+                const keys = discoverKeys(rows);
+                this._queryTestResult = {
+                    count: rows.length,
+                    keys,
+                    keysLabel: keys.join(', '),
+                    skippedParams,
+                    skippedParamsLabel: skippedParams.join(', '),
+                };
+            }
+        } catch (err) {
+            this._queryTestError = err?.message ? `The request failed: ${err.message}` : 'The request failed.';
+        } finally {
+            this.isTestingQuery = false;
+        }
+    }
+
+    /**
+     * Replaces the table's columns with one per key the last test discovered.
+     * Undoable — every `onUpdateElement` pushes an undo frame upstream.
+     */
+    @action
+    applyDiscoveredColumns() {
+        if (!this.args.onUpdateElement || !this.element) return;
+        const columns = this.queryTestResult.keys.map((key) => ({ label: humanizeKey(key), key }));
+        this.args.onUpdateElement(this.element.uuid, { columns });
+    }
 
     @action
     addColumn() {

--- a/addon/components/template-builder/properties-panel.js
+++ b/addon/components/template-builder/properties-panel.js
@@ -133,14 +133,19 @@ export default class TemplateBuilderPropertiesPanelComponent extends Component {
     /** @type {Boolean} Whether the query-mode test request is in flight */
     @tracked isTestingQuery = false;
 
-    /** @type {String|null} Error from the most recent query test */
-    @tracked _queryTestError = null;
+    /**
+     * @type {{uuid: String|null, error: String|null, result: Object|null}}
+     * State of the last query test, kept as one object rather than three fields:
+     * a tracked field's initializer only runs on first read, and every path here
+     * writes before reading, so assigning in the constructor is what actually
+     * defines the state. `uuid` is the element the test was run against.
+     */
+    @tracked queryTest;
 
-    /** @type {Object|null} `{ count, keys, skippedParams }` from the last successful test */
-    @tracked _queryTestResult = null;
-
-    /** @type {String|null} uuid of the element the query test state belongs to */
-    @tracked _queryTestElementUuid = null;
+    constructor(owner, args) {
+        super(owner, args);
+        this._clearQueryTest();
+    }
 
     get hasSelection() {
         return !!this.args.selectedElement;
@@ -390,21 +395,19 @@ export default class TemplateBuilderPropertiesPanelComponent extends Component {
      * different element must not show that element the previous one's results.
      */
     get _queryTestMatchesSelection() {
-        return this._queryTestElementUuid === this.element.uuid;
+        return this.queryTest.uuid === this.element.uuid;
     }
 
     get queryTestError() {
-        return this._queryTestMatchesSelection ? this._queryTestError : null;
+        return this._queryTestMatchesSelection ? this.queryTest.error : null;
     }
 
     get queryTestResult() {
-        return this._queryTestMatchesSelection ? this._queryTestResult : null;
+        return this._queryTestMatchesSelection ? this.queryTest.result : null;
     }
 
     _clearQueryTest() {
-        this._queryTestError = null;
-        this._queryTestResult = null;
-        this._queryTestElementUuid = null;
+        this.queryTest = { uuid: null, error: null, result: null };
     }
 
     @action
@@ -424,7 +427,7 @@ export default class TemplateBuilderPropertiesPanelComponent extends Component {
     @action
     updateQueryParam(index, field, event) {
         if (!this.args.onUpdateElement || !this.element) return;
-        const value = event?.target ? event.target.value : event;
+        const value = event.target.value;
         const query_params = this.queryParams.map((param, i) => (i === index ? { ...param, [field]: value } : param));
         this.args.onUpdateElement(this.element.uuid, { query_params });
     }
@@ -436,16 +439,15 @@ export default class TemplateBuilderPropertiesPanelComponent extends Component {
      */
     @action
     async testQuery() {
+        // Reached only from the query-mode form, which the template renders
+        // inside `{{#if this.hasSelection}}`, so an element is always selected.
         const element = this.element;
-        if (!element) return;
-
-        this._queryTestElementUuid = element.uuid;
-        this._queryTestError = null;
-        this._queryTestResult = null;
+        const uuid = element.uuid;
+        this.queryTest = { uuid, error: null, result: null };
 
         const invalid = validateEndpoint(element.query_endpoint);
         if (invalid) {
-            this._queryTestError = invalid;
+            this.queryTest = { uuid, error: invalid, result: null };
             return;
         }
 
@@ -469,19 +471,21 @@ export default class TemplateBuilderPropertiesPanelComponent extends Component {
             const response = await this.fetch.get(normalizeEndpoint(element.query_endpoint), params);
             const { rows, error } = resolveResponsePath(response, element.query_response_path);
             if (error) {
-                this._queryTestError = error;
+                this.queryTest = { uuid, error, result: null };
             } else {
                 const keys = discoverKeys(rows);
-                this._queryTestResult = {
+                const result = {
                     count: rows.length,
                     keys,
                     keysLabel: keys.join(', '),
                     skippedParams,
                     skippedParamsLabel: skippedParams.join(', '),
                 };
+                this.queryTest = { uuid, error: null, result };
             }
         } catch (err) {
-            this._queryTestError = err?.message ? `The request failed: ${err.message}` : 'The request failed.';
+            const message = err?.message ? `The request failed: ${err.message}` : 'The request failed.';
+            this.queryTest = { uuid, error: message, result: null };
         } finally {
             this.isTestingQuery = false;
         }

--- a/tests/integration/components/template-builder/element-renderer-test.js
+++ b/tests/integration/components/template-builder/element-renderer-test.js
@@ -307,6 +307,70 @@ module('Integration | Component | template-builder/element-renderer', function (
             assert.dom('.tb-element').containsText('No columns defined');
         });
 
+        // Nothing here resolves a data source — the builder stores intent and
+        // something downstream renders it — so the caption is what tells a
+        // variable- or query-backed table apart from an empty one.
+        test('a manual table shows no source caption', async function (assert) {
+            this.set('templateElement', element({ type: 'table', columns: [{ label: 'Item' }] }));
+
+            await render(TEMPLATE);
+
+            assert.strictEqual(findAll('tbody tr').length, 3, 'only the placeholder rows');
+            assert.dom('.tb-table-source-caption').doesNotExist();
+        });
+
+        test('a variable-backed table names its variable', async function (assert) {
+            this.set('templateElement', element({ type: 'table', columns: [{ label: 'Item' }], data_source_mode: 'variable', data_source: '{order.items}' }));
+
+            await render(TEMPLATE);
+
+            assert.dom('.tb-table-source-caption').hasText('Rows from {order.items}');
+        });
+
+        test('a variable-backed table with no variable yet still says where its rows come from', async function (assert) {
+            this.set('templateElement', element({ type: 'table', columns: [{ label: 'Item' }], data_source_mode: 'variable' }));
+
+            await render(TEMPLATE);
+
+            assert.dom('.tb-table-source-caption').hasText('Rows from a variable');
+        });
+
+        test('a query-backed table names its endpoint', async function (assert) {
+            this.set('templateElement', element({ type: 'table', columns: [{ label: 'Item' }], data_source_mode: 'query', query_endpoint: 'int/v1/orders' }));
+
+            await render(TEMPLATE);
+
+            assert.dom('.tb-table-source-caption').hasText('Rows from int/v1/orders');
+            assert.dom('.tb-table-source-caption').hasAttribute('colspan', '1');
+        });
+
+        test('a query-backed table with no endpoint yet still says where its rows come from', async function (assert) {
+            this.set('templateElement', element({ type: 'table', columns: [{ label: 'Item' }, { label: 'Qty' }], data_source_mode: 'query' }));
+
+            await render(TEMPLATE);
+
+            assert.dom('.tb-table-source-caption').hasText('Rows from a query');
+            assert.dom('.tb-table-source-caption').hasAttribute('colspan', '2', 'the caption spans every column');
+        });
+
+        test('a query-backed table with rows of its own renders them instead of the caption', async function (assert) {
+            this.set(
+                'templateElement',
+                element({
+                    type: 'table',
+                    columns: [{ label: 'Item', key: 'name' }],
+                    rows: [{ name: 'Widget' }],
+                    data_source_mode: 'query',
+                    query_endpoint: 'int/v1/orders',
+                })
+            );
+
+            await render(TEMPLATE);
+
+            assert.dom('.tb-table-source-caption').doesNotExist();
+            assert.dom('tbody td').hasText('Widget');
+        });
+
         test('header, cell and border styling is applied', async function (assert) {
             this.set(
                 'templateElement',

--- a/tests/integration/components/template-builder/properties-panel-test.js
+++ b/tests/integration/components/template-builder/properties-panel-test.js
@@ -1,8 +1,9 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'dummy/tests/helpers';
-import { render, click, fillIn, findAll, find } from '@ember/test-helpers';
+import { render, click, fillIn, findAll, find, settled } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { selectFiles } from 'ember-file-upload/test-support';
+import Service from '@ember/service';
 
 function element(type, overrides = {}) {
     return { uuid: 'el-1', type, x: 10, y: 20, width: 100, height: 50, ...overrides };
@@ -548,6 +549,613 @@ module('Integration | Component | template-builder/properties-panel', function (
             await click(buttonWithText('Manual'));
 
             assert.dom(this.element).containsText('Define columns first.');
+        });
+    });
+
+    // Query mode fetches an arbitrary Fleetbase API path. It is deliberately a
+    // different mechanism from the saved queries the queries panel manages —
+    // those are reached through Variable mode, under `__queries__`.
+    module('table query mode', function (hooks) {
+        let requests;
+        let respond;
+
+        function queryElement(overrides = {}) {
+            return element('table', {
+                columns: [],
+                rows: [],
+                data_source_mode: 'query',
+                query_endpoint: 'int/v1/orders',
+                ...overrides,
+            });
+        }
+
+        hooks.beforeEach(function () {
+            requests = [];
+            respond = () => [];
+
+            this.owner.unregister('service:fetch');
+            this.owner.register(
+                'service:fetch',
+                class extends Service {
+                    get(path, params, options) {
+                        requests.push({ path, params, options });
+                        return Promise.resolve(respond(path, params));
+                    }
+                }
+            );
+        });
+
+        async function renderQueryMode(context, overrides = {}) {
+            context.set('selectedElement', queryElement(overrides));
+            await render(TEMPLATE);
+            await openSection('Data Source');
+        }
+
+        function testButton() {
+            return find('.tb-query-test');
+        }
+
+        module('the mode toggle', function () {
+            test('the data source toggle offers a query mode', async function (assert) {
+                await renderQueryMode(this);
+
+                assert.ok(buttonWithText('Query'), 'a query mode is offered alongside variable and manual');
+            });
+
+            test('switching to query clears the data variable and seeds the params array', async function (assert) {
+                this.set('selectedElement', element('table', { columns: [], rows: [], data_source_mode: 'variable', data_source: '{order.items}' }));
+                await render(TEMPLATE);
+                await openSection('Data Source');
+                await click(buttonWithText('Query'));
+
+                assert.deepEqual(lastChanges(), {
+                    data_source_mode: 'query',
+                    data_source: null,
+                    query_params: [],
+                });
+            });
+
+            test('switching to query leaves params that are already there alone', async function (assert) {
+                this.set('selectedElement', element('table', { columns: [], rows: [], data_source_mode: 'manual', query_params: [{ key: 'status', value: 'completed' }] }));
+                await render(TEMPLATE);
+                await openSection('Data Source');
+                await click(buttonWithText('Query'));
+
+                assert.deepEqual(lastChanges(), { data_source_mode: 'query', data_source: null }, 'no query_params key, so the existing ones survive');
+            });
+
+            test('query mode is what the panel shows for a query-backed table', async function (assert) {
+                await renderQueryMode(this);
+
+                assert.ok(find('.tb-query-endpoint'), 'the endpoint field is shown');
+                assert.notOk(inputsByPlaceholder('{order.items}').length, 'the variable field is not');
+            });
+        });
+
+        module('the endpoint field', function () {
+            test('an endpoint can be typed', async function (assert) {
+                await renderQueryMode(this, { query_endpoint: '' });
+                await fillIn('.tb-query-endpoint', 'int/v1/reports/revenue');
+
+                assert.deepEqual(lastChanges(), { query_endpoint: 'int/v1/reports/revenue' });
+            });
+
+            test('a relative path is accepted without complaint', async function (assert) {
+                await renderQueryMode(this, { query_endpoint: 'int/v1/orders' });
+
+                assert.notOk(find('.tb-query-endpoint-error'), 'no error is shown');
+                assert.dom(this.element).containsText('A path on the Fleetbase API');
+            });
+
+            test('a full URL is rejected, because the request would carry the session', async function (assert) {
+                await renderQueryMode(this, { query_endpoint: 'https://evil.example.com/orders' });
+
+                assert.dom('.tb-query-endpoint-error').containsText('not a full URL');
+                assert.dom('.tb-query-endpoint-error').containsText('session credentials');
+            });
+
+            test('a protocol-relative URL is rejected too', async function (assert) {
+                await renderQueryMode(this, { query_endpoint: '//evil.example.com/orders' });
+
+                assert.dom('.tb-query-endpoint-error').exists('a leading // is still another host');
+            });
+
+            test('an empty endpoint is not reported as an error until it is tested', async function (assert) {
+                await renderQueryMode(this, { query_endpoint: '   ' });
+
+                assert.notOk(find('.tb-query-endpoint-error'), 'nothing to correct yet');
+            });
+        });
+
+        module('query parameters', function () {
+            test('an element with no params says so', async function (assert) {
+                await renderQueryMode(this);
+
+                assert.dom(this.element).containsText('No parameters.');
+            });
+
+            test('a parameter can be added', async function (assert) {
+                await renderQueryMode(this);
+                await click(buttonWithText('Add parameter'));
+
+                assert.deepEqual(lastChanges(), { query_params: [{ key: '', value: '' }] });
+            });
+
+            test('a parameter is appended to the ones already there', async function (assert) {
+                await renderQueryMode(this, { query_params: [{ key: 'status', value: 'completed' }] });
+                await click(buttonWithText('Add parameter'));
+
+                assert.deepEqual(lastChanges(), {
+                    query_params: [
+                        { key: 'status', value: 'completed' },
+                        { key: '', value: '' },
+                    ],
+                });
+            });
+
+            test('a parameter key can be edited', async function (assert) {
+                await renderQueryMode(this, { query_params: [{ key: 'status', value: 'completed' }] });
+                await fillIn(findAll('.tb-query-param-key')[0], 'state');
+
+                assert.deepEqual(lastChanges(), { query_params: [{ key: 'state', value: 'completed' }] });
+            });
+
+            test('a parameter value can be edited', async function (assert) {
+                await renderQueryMode(this, { query_params: [{ key: 'status', value: 'completed' }] });
+                await fillIn(findAll('.tb-query-param-value')[0], '{order.status}');
+
+                assert.deepEqual(lastChanges(), { query_params: [{ key: 'status', value: '{order.status}' }] });
+            });
+
+            test('editing one parameter leaves the others alone', async function (assert) {
+                await renderQueryMode(this, {
+                    query_params: [
+                        { key: 'status', value: 'completed' },
+                        { key: 'limit', value: '10' },
+                    ],
+                });
+                await fillIn(findAll('.tb-query-param-value')[1], '25');
+
+                assert.deepEqual(lastChanges(), {
+                    query_params: [
+                        { key: 'status', value: 'completed' },
+                        { key: 'limit', value: '25' },
+                    ],
+                });
+            });
+
+            test('a parameter can be removed', async function (assert) {
+                await renderQueryMode(this, {
+                    query_params: [
+                        { key: 'status', value: 'completed' },
+                        { key: 'limit', value: '10' },
+                    ],
+                });
+                await click(buttonsByTitle('Remove parameter')[0]);
+
+                assert.deepEqual(lastChanges(), { query_params: [{ key: 'limit', value: '10' }] });
+            });
+        });
+
+        module('the response path field', function () {
+            test('a response path can be typed', async function (assert) {
+                await renderQueryMode(this);
+                await fillIn('.tb-query-response-path', 'data.results');
+
+                assert.deepEqual(lastChanges(), { query_response_path: 'data.results' });
+            });
+        });
+
+        module('testing the query', function () {
+            test('a successful test reports the row count', async function (assert) {
+                respond = () => [{ id: 1 }, { id: 2 }];
+                await renderQueryMode(this);
+                await click(testButton());
+
+                assert.dom('.tb-query-test-result').containsText('Returned 2 rows.');
+            });
+
+            test('a single row is reported in the singular', async function (assert) {
+                respond = () => [{ id: 1 }];
+                await renderQueryMode(this);
+                await click(testButton());
+
+                assert.dom('.tb-query-test-result').containsText('Returned 1 row.');
+            });
+
+            test('the endpoint is sent to the fetch service with its leading slash stripped', async function (assert) {
+                await renderQueryMode(this, { query_endpoint: '  /int/v1/orders  ' });
+                await click(testButton());
+
+                assert.strictEqual(requests.length, 1, 'exactly one request is made');
+                assert.strictEqual(requests[0].path, 'int/v1/orders');
+            });
+
+            test('named parameters are sent as the query string', async function (assert) {
+                await renderQueryMode(this, {
+                    query_params: [
+                        { key: ' status ', value: 'completed' },
+                        { key: 'limit', value: '10' },
+                    ],
+                });
+                await click(testButton());
+
+                assert.deepEqual(requests[0].params, { status: 'completed', limit: '10' });
+            });
+
+            test('a parameter with no key is not sent', async function (assert) {
+                await renderQueryMode(this, {
+                    query_params: [{ key: '', value: 'blank' }, { value: 'keyless' }, { key: '   ', value: 'whitespace' }, { key: 'limit', value: '10' }],
+                });
+                await click(testButton());
+
+                assert.deepEqual(requests[0].params, { limit: '10' });
+            });
+
+            test('a parameter with no value at all is sent as an empty string', async function (assert) {
+                await renderQueryMode(this, { query_params: [{ key: 'status' }] });
+                await click(testButton());
+
+                assert.deepEqual(requests[0].params, { status: '' });
+            });
+
+            test('a parameter still holding a variable token is left out and named', async function (assert) {
+                await renderQueryMode(this, {
+                    query_params: [
+                        { key: 'order', value: '{order.uuid}' },
+                        { key: 'limit', value: '10' },
+                    ],
+                });
+                await click(testButton());
+
+                assert.deepEqual(requests[0].params, { limit: '10' }, 'the token cannot be resolved here, so it is not sent');
+                assert.dom('.tb-query-test-skipped').containsText('order');
+            });
+
+            test('a test with nothing skipped says nothing about skipping', async function (assert) {
+                await renderQueryMode(this, { query_params: [{ key: 'limit', value: '10' }] });
+                await click(testButton());
+
+                assert.notOk(find('.tb-query-test-skipped'));
+            });
+
+            test('testing an empty endpoint asks for one rather than firing a request', async function (assert) {
+                await renderQueryMode(this, { query_endpoint: '' });
+                await click(testButton());
+
+                assert.dom('.tb-query-test-error').containsText('Enter an API endpoint');
+                assert.strictEqual(requests.length, 0, 'no request is made');
+            });
+
+            test('testing an element that has never had an endpoint asks for one too', async function (assert) {
+                await renderQueryMode(this, { query_endpoint: undefined });
+                await click(testButton());
+
+                assert.dom('.tb-query-test-error').containsText('Enter an API endpoint');
+                assert.strictEqual(requests.length, 0);
+            });
+
+            test('testing a full URL refuses rather than firing a request', async function (assert) {
+                await renderQueryMode(this, { query_endpoint: 'https://evil.example.com/orders' });
+                await click(testButton());
+
+                assert.dom('.tb-query-test-error').containsText('not a full URL');
+                assert.strictEqual(requests.length, 0, 'the session is never sent to another host');
+            });
+
+            test('the button reports that a test is in flight', async function (assert) {
+                let release;
+                respond = () => new Promise((resolve) => (release = resolve));
+
+                await renderQueryMode(this);
+                await click(testButton());
+
+                assert.dom('.tb-query-test').containsText('Testing');
+                assert.dom('.tb-query-test').isDisabled();
+
+                release([{ id: 1 }]);
+                await settled();
+
+                assert.dom('.tb-query-test').containsText('Test query', 'and stops when it lands');
+                assert.dom('.tb-query-test').isNotDisabled();
+            });
+
+            test('a rejected request is reported with its message', async function (assert) {
+                respond = () => Promise.reject(new Error('403 Forbidden'));
+                await renderQueryMode(this);
+                await click(testButton());
+
+                assert.dom('.tb-query-test-error').containsText('The request failed: 403 Forbidden');
+                assert.dom('.tb-query-test').isNotDisabled('the in-flight state is cleared');
+            });
+
+            test('a rejection with no message still reports a failure', async function (assert) {
+                respond = () => Promise.reject(new Error(''));
+                await renderQueryMode(this);
+                await click(testButton());
+
+                assert.dom('.tb-query-test-error').hasText('The request failed.');
+            });
+
+            test('a rejection that is not an error at all still reports a failure', async function (assert) {
+                respond = () => Promise.reject();
+                await renderQueryMode(this);
+                await click(testButton());
+
+                assert.dom('.tb-query-test-error').hasText('The request failed.');
+            });
+
+            test('a later test replaces the earlier error', async function (assert) {
+                respond = () => Promise.reject(new Error('boom'));
+                await renderQueryMode(this);
+                await click(testButton());
+                assert.dom('.tb-query-test-error').exists();
+
+                respond = () => [{ id: 1 }];
+                await click(testButton());
+
+                assert.notOk(find('.tb-query-test-error'), 'the stale error is gone');
+                assert.dom('.tb-query-test-result').containsText('Returned 1 row.');
+            });
+        });
+
+        module('resolving the response path', function () {
+            test('a dotted path is walked into the response', async function (assert) {
+                respond = () => ({ data: { results: [{ id: 1 }, { id: 2 }, { id: 3 }] } });
+                await renderQueryMode(this, { query_response_path: 'data.results' });
+                await click(testButton());
+
+                assert.dom('.tb-query-test-result').containsText('Returned 3 rows.');
+            });
+
+            test('surrounding whitespace in the path is ignored', async function (assert) {
+                respond = () => ({ data: { results: [{ id: 1 }] } });
+                await renderQueryMode(this, { query_response_path: '  data . results  ' });
+                await click(testButton());
+
+                assert.dom('.tb-query-test-result').containsText('Returned 1 row.');
+            });
+
+            test('a missing segment is named', async function (assert) {
+                respond = () => ({ data: {} });
+                await renderQueryMode(this, { query_response_path: 'data.results' });
+                await click(testButton());
+
+                assert.dom('.tb-query-test-error').containsText('no "results" under "data"');
+            });
+
+            test('a missing first segment says it is missing from the response', async function (assert) {
+                respond = () => ({ other: [] });
+                await renderQueryMode(this, { query_response_path: 'data' });
+                await click(testButton());
+
+                assert.dom('.tb-query-test-error').containsText('no "data" in the response');
+            });
+
+            test('a path that runs into a primitive says where it stopped', async function (assert) {
+                respond = () => ({ data: 'nope' });
+                await renderQueryMode(this, { query_response_path: 'data.results' });
+                await click(testButton());
+
+                assert.dom('.tb-query-test-error').containsText('"data" is a string, not an object');
+            });
+
+            test('a path against a null response body says so', async function (assert) {
+                respond = () => null;
+                await renderQueryMode(this, { query_response_path: 'data' });
+                await click(testButton());
+
+                assert.dom('.tb-query-test-error').containsText('the response body is null, not an object');
+            });
+
+            test('a path against an empty response body says so', async function (assert) {
+                respond = () => undefined;
+                await renderQueryMode(this, { query_response_path: 'data' });
+                await click(testButton());
+
+                assert.dom('.tb-query-test-error').containsText('the response body is nothing, not an object');
+            });
+
+            test('a path that lands on something other than an array is named', async function (assert) {
+                respond = () => ({ data: { count: 4 } });
+                await renderQueryMode(this, { query_response_path: 'data' });
+                await click(testButton());
+
+                assert.dom('.tb-query-test-error').containsText('Expected an array of rows at "data", got an object.');
+            });
+
+            test('a response that is not an array, with no path, is named too', async function (assert) {
+                respond = () => ({ count: 4 });
+                await renderQueryMode(this, { query_response_path: '' });
+                await click(testButton());
+
+                assert.dom('.tb-query-test-error').containsText('Expected an array of rows in the response, got an object.');
+            });
+
+            test('an element with no response path at all treats the body as the rows', async function (assert) {
+                respond = () => [{ id: 1 }, { id: 2 }];
+                await renderQueryMode(this);
+                await click(testButton());
+
+                assert.dom('.tb-query-test-result').containsText('Returned 2 rows.');
+            });
+        });
+
+        module('discovered columns', function () {
+            test('the keys of the returned rows are listed', async function (assert) {
+                respond = () => [{ id: 1, name: 'Widget' }];
+                await renderQueryMode(this);
+                await click(testButton());
+
+                assert.dom('.tb-query-test-keys').containsText('id, name');
+            });
+
+            test('keys are the union across rows, in the order first seen', async function (assert) {
+                respond = () => [{ id: 1 }, { id: 2, name: 'Widget' }, { name: 'Gadget', qty: 3 }];
+                await renderQueryMode(this);
+                await click(testButton());
+
+                assert.dom('.tb-query-test-keys').containsText('id, name, qty');
+            });
+
+            test('rows that are not plain objects contribute no keys', async function (assert) {
+                respond = () => ['a string', null, ['nested'], { id: 1 }];
+                await renderQueryMode(this);
+                await click(testButton());
+
+                assert.dom('.tb-query-test-keys').hasText('Keys: id');
+            });
+
+            test('only the first twenty rows are scanned for keys', async function (assert) {
+                const rows = Array.from({ length: 21 }, (_, index) => (index === 20 ? { late: true } : { id: index }));
+                respond = () => rows;
+                await renderQueryMode(this);
+                await click(testButton());
+
+                assert.dom('.tb-query-test-result').containsText('Returned 21 rows.');
+                assert.dom('.tb-query-test-keys').hasText('Keys: id', 'the twenty-first row is past the scan limit');
+            });
+
+            test('rows with no keys at all offer nothing to apply', async function (assert) {
+                respond = () => [{}, {}];
+                await renderQueryMode(this);
+                await click(testButton());
+
+                assert.dom('.tb-query-test-result').containsText('Returned 2 rows.');
+                assert.notOk(find('.tb-query-apply-columns'), 'there is nothing to turn into a column');
+            });
+
+            test('an empty result offers nothing to apply', async function (assert) {
+                respond = () => [];
+                await renderQueryMode(this);
+                await click(testButton());
+
+                assert.dom('.tb-query-test-result').containsText('Returned 0 rows.');
+                assert.notOk(find('.tb-query-apply-columns'));
+            });
+
+            test('the discovered keys can be applied as the table columns', async function (assert) {
+                respond = () => [{ id: 1, total_amount: 20, createdAt: 'today' }];
+                await renderQueryMode(this);
+                await click(testButton());
+                await click('.tb-query-apply-columns');
+
+                assert.deepEqual(lastChanges(), {
+                    columns: [
+                        { label: 'Id', key: 'id' },
+                        { label: 'Total Amount', key: 'total_amount' },
+                        { label: 'Created At', key: 'createdAt' },
+                    ],
+                });
+            });
+
+            test('applying columns replaces the ones already defined', async function (assert) {
+                respond = () => [{ id: 1 }];
+                await renderQueryMode(this, { columns: [{ label: 'Old', key: 'old' }] });
+                await click(testButton());
+                await click('.tb-query-apply-columns');
+
+                assert.deepEqual(lastChanges(), { columns: [{ label: 'Id', key: 'id' }] });
+            });
+        });
+
+        module('test results and the selection', function () {
+            test('switching data mode discards the results', async function (assert) {
+                respond = () => [{ id: 1 }];
+                await renderQueryMode(this);
+                await click(testButton());
+                assert.dom('.tb-query-test-result').exists();
+
+                await click(buttonWithText('Query'));
+
+                assert.notOk(find('.tb-query-test-result'), 'the results belonged to the previous configuration');
+            });
+
+            test("one element's results are not shown against another", async function (assert) {
+                respond = () => [{ id: 1 }];
+                await renderQueryMode(this);
+                await click(testButton());
+                assert.dom('.tb-query-test-result').exists();
+
+                this.set('selectedElement', { ...queryElement(), uuid: 'el-2' });
+                await settled();
+
+                assert.notOk(find('.tb-query-test-result'), 'the second table has not been tested');
+            });
+
+            test("one element's error is not shown against another", async function (assert) {
+                respond = () => Promise.reject(new Error('boom'));
+                await renderQueryMode(this);
+                await click(testButton());
+                assert.dom('.tb-query-test-error').exists();
+
+                this.set('selectedElement', { ...queryElement(), uuid: 'el-2' });
+                await settled();
+
+                assert.notOk(find('.tb-query-test-error'));
+            });
+        });
+
+        module('without an update handler', function () {
+            const UNWIRED = hbs`<TemplateBuilder::PropertiesPanel @selectedElement={{this.selectedElement}} />`;
+
+            async function renderUnwired(context, overrides = {}) {
+                context.set('selectedElement', queryElement(overrides));
+                await render(UNWIRED);
+                await openSection('Data Source');
+            }
+
+            test('switching mode is inert', async function (assert) {
+                await renderUnwired(this);
+                await click(buttonWithText('Manual'));
+
+                assert.deepEqual(updates, []);
+            });
+
+            test('adding a parameter is inert', async function (assert) {
+                await renderUnwired(this);
+                await click(buttonWithText('Add parameter'));
+
+                assert.deepEqual(updates, []);
+            });
+
+            test('editing a parameter is inert', async function (assert) {
+                await renderUnwired(this, { query_params: [{ key: 'status', value: 'completed' }] });
+                await fillIn(findAll('.tb-query-param-key')[0], 'state');
+
+                assert.deepEqual(updates, []);
+            });
+
+            test('removing a parameter is inert', async function (assert) {
+                await renderUnwired(this, { query_params: [{ key: 'status', value: 'completed' }] });
+                await click(buttonsByTitle('Remove parameter')[0]);
+
+                assert.deepEqual(updates, []);
+            });
+
+            test('applying discovered columns is inert', async function (assert) {
+                respond = () => [{ id: 1 }];
+                await renderUnwired(this);
+                await click(testButton());
+
+                assert.dom('.tb-query-test-result').containsText('Returned 1 row.', 'the query can still be tested');
+
+                await click('.tb-query-apply-columns');
+
+                assert.deepEqual(updates, []);
+            });
+
+            test('testing with nothing selected does nothing at all', async function (assert) {
+                this.set('selectedElement', queryElement());
+                await render(UNWIRED);
+                await openSection('Data Source');
+
+                this.set('selectedElement', null);
+                await settled();
+
+                assert.notOk(find('.tb-query-test'), 'there is no panel to test from');
+                assert.strictEqual(requests.length, 0);
+            });
         });
     });
 


### PR DESCRIPTION
Finishes the table's `query` data mode in the template builder's properties panel. The mode has been
half-built for a while: `setTableDataMode` handled `'query'` and the `manual`/`variable` arms cleared
`query_endpoint`, `query_params` and `query_response_path`, but the toggle offered only two buttons,
nothing ever called it with `'query'`, and nothing read those three fields. The branch reported
`[0,0]` in coverage — never evaluated either way.

Deferred out of the coverage sweep (`DEFECTS.md` #15, Appendix D) pending six decisions. Those are
settled here and written into the code so they are not rediscovered.

## The decision that mattered: how this reconciles with `__queries__`

Saved queries already solve "get rows from the server into a table", so a second mechanism needed a
reason to exist. They stay two things with a stated boundary, and **Variable mode remains the usual
answer**:

- **Variable mode** — a token resolved from the render context, including the saved `TemplateQuery`
  records the queries panel manages, which `template-builder.js` exposes under `__queries__`.
  Structured, reusable across elements, saved with the template. A saved query is reached here.
- **Query mode** — one API path with params, bound to one element. It exists for what the saved-query
  builder cannot express: aggregates, reports, and extension endpoints with no `model_type` behind
  them.

That boundary is a comment block above the query helpers in `properties-panel.js`, and the variable
mode hint now points at `__queries__` so the structured route is the one people find first.

## The rest of the contract

- **Endpoint** — a path relative to the Fleetbase API (`int/v1/orders`); leading slashes stripped.
  Absolute and protocol-relative URLs are **rejected**, in the panel as you type and again before any
  request fires. The `fetch` service attaches the session to everything it sends, so allowing
  `https://another-host/…` would hand those credentials over.
- **Auth** — everything goes through the injected `fetch` service. Nothing new introduced.
- **`query_params`** — `[{ key, value }]`, matching the `[]` the clearing arms already seeded. Values
  may hold `{variable}` tokens, resolved downstream at render.
- **`query_response_path`** — a dotted path into the response body; blank means the body is itself the
  array. Every way it can fail is reported by name: a missing segment, a segment that runs into a
  primitive, and a path that lands on something other than an array.
- **Fetching** — query mode stores *intent*, like variable mode; nothing in this addon resolves a data
  source at render time. The one exception is the explicit **Test query** button, which fetches once
  so the endpoint, params and path can be checked before saving. It never writes the fetched rows
  onto the element — it reports the row count and the keys, and offers to turn those keys into
  columns. Params still holding an unresolved token are left out of that request and named.
- **Loading and error states** — the button reports in-flight and disables itself; request failures
  and response-path failures both surface. Results are keyed to the element they ran against, so
  selecting another table does not show it the previous one's results.

## Render side

Nothing consumed a query-backed table before, and a variable-backed one was equally invisible: both
drew the same placeholder dashes as an empty manual table. `element-renderer` now captions a table
that has no rows of its own with where its rows come from — `Rows from int/v1/orders`,
`Rows from {order.items}`. It does not fetch; a builder canvas issuing requests per element while you
drag is not what anyone wants.

## Scope note

The panel is shared, so the third toggle button changes the Data Source section for every consumer.
That is the intended change, not a side effect.

## Tests

~70 new tests. All of them fail against the current code — the mode has no control to drive.

- `properties-panel-test.js` — the toggle and what each mode clears; endpoint validation including
  both URL shapes; the params editor; response-path resolution and each of its failure messages;
  the test request (endpoint normalisation, params sent, keyless and token-holding params dropped);
  in-flight state; rejection handling; key discovery and its 20-row scan bound; applying discovered
  columns; result/selection isolation; and every action inert without an `onUpdateElement` handler.
- `element-renderer-test.js` — the source caption across manual, variable and query modes, with and
  without a configured source, and that a table with real rows renders those instead.

`DEFECTS.md` #15 is updated in place to FIXED with the decisions above, rather than adding a second
entry for a defect the tracker already carries.

## One note on the branch itself

The final arm of `setTableDataMode` is now a plain `else` rather than `else if (mode === 'query')`.
A third condition carries a false path nothing can reach, which is what left this branch reporting
`[0,0]` and un-suppressable in the first place — the deferral note called that out specifically. As a
plain `else` the dead path is gone rather than ignored, and the `variable` arm that real tests cover
is untouched.

Verified on this base: full suite **5196 passing, 0 failing**; `element-renderer.js` at 100%
statements/branches/functions/lines; lint clean across JS, templates and CSS.
