### PR TITLE
smart-nav-menu: one pinned-list resolver, not two (DEFECTS #18)

### DIFF
--- a/addon/components/layout/header/smart-nav-menu.js
+++ b/addon/components/layout/header/smart-nav-menu.js
@@ -253,6 +253,31 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
      *     the first `maxVisible` items from the universe registry are shown in
      *     the bar by default, and the rest go to overflow.
      */
+    /**
+     * Resolve saved pinned IDs to items, in the user's saved order, dropping any ID that no longer
+     * matches an item — an extension the user pinned and later removed, for instance.
+     *
+     * Both `_distributeFromAllItems` and `_recalculate` need this, and each used to carry its own
+     * copy of the loop. Beyond the ordinary duplication hazard, that gave the stale-ID branch two
+     * homes: one reached deterministically on render and one reached only if a ResizeObserver
+     * happened to fire while a stale ID was present. The second made the suite's branch total vary
+     * between identical runs, which a 100% gate cannot tolerate. See DEFECTS.md #18.
+     *
+     * @param {Array<string>} pinnedIds
+     * @param {Array<object>} allItems
+     * @returns {Array<object>}
+     */
+    _pinnedItems(pinnedIds, allItems) {
+        const pinned = [];
+
+        for (const id of pinnedIds) {
+            const item = allItems.find((i) => i.id === id);
+            if (item) pinned.push(item);
+        }
+
+        return pinned;
+    }
+
     _distributeFromAllItems() {
         const { pinnedIds, allItems, maxVisible } = this;
 
@@ -263,13 +288,8 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
             return;
         }
 
-        // User has an explicit pinned list.
-        // Build the pinned array in the user's saved order (skip stale IDs).
-        const pinned = [];
-        for (const id of pinnedIds) {
-            const item = allItems.find((i) => i.id === id);
-            if (item) pinned.push(item);
-        }
+        // User has an explicit pinned list, in their saved order and without stale IDs.
+        const pinned = this._pinnedItems(pinnedIds, allItems);
 
         // Respect the hard cap (in case maxVisible was reduced after saving).
         const barItems = pinned.slice(0, maxVisible);
@@ -336,12 +356,7 @@ export default class LayoutHeaderSmartNavMenuComponent extends Component {
 
         if (pinnedIds && pinnedIds.length > 0) {
             // Only pinned items can appear in the bar.
-            const pinned = [];
-            for (const id of pinnedIds) {
-                const item = allItems.find((i) => i.id === id);
-                if (item) pinned.push(item);
-            }
-            barCandidates = pinned.slice(0, maxVisible);
+            barCandidates = this._pinnedItems(pinnedIds, allItems).slice(0, maxVisible);
             const barIds = new Set(barCandidates.map((i) => i.id));
             alwaysOverflow = allItems.filter((i) => !barIds.has(i.id));
         } else {


### PR DESCRIPTION
Fixes DEFECTS #18 — the last known blocker to a stable 100% gate.

## The symptom

The suite's branch total varied by ±1 between identical runs. All 5,196 tests passing, identical statement totals, different branch counts. A hard 100% gate flaps on that with no code change, exactly as #4 did.

## Diagnosis — the artifact named it in one step

Rather than reasoning about mechanism, I captured `coverage-final.json` from two runs that disagreed and diffed them per-file, per-branch:

```
addon/components/layout/header/smart-nav-menu.js
  branches 82 vs 83
  branch id 21 path 1 @ line 344: runA=0 runB=1 (if)
```

That is `if (item) pinned.push(item)` — the *"a pinned id matches no item"* path.

## The cause is duplication, not flakiness

The same "resolve pinned IDs in the user's saved order, dropping stale ones" loop existed in **two** methods:

- **`_distributeFromAllItems()`** runs on render, and the existing test *"stale ids in the saved list are skipped"* covers its copy deterministically.
- **`_recalculate()`** carried its own copy, reached only when a `ResizeObserver` fires through `scheduleOnce('afterRender')` — browser layout timing, which no test can force.

So the branch was genuinely exercised, in two places, one of them a coin flip.

## The fix

Extracted `_pinnedItems(pinnedIds, allItems)`; both callers use it. One branch where there were two, covered by the test that already existed.

**This is worth doing on its own merits.** Two copies of stale-ID handling is the shape where someone fixes one and leaves the other quietly wrong. The stable branch count is a consequence of removing the duplication, not the point of it.

## Verification

```
run C: 5196 pass, 0 fail, branches 5908/6332
run D: 5196 pass, 0 fail, branches 5908/6332
C vs D per-file diff: no differences at all
```

Not merely matching totals — the diff compares every file's counts and then every individual branch id, so nothing can cancel out. Lint exits 0.

The branch total drops 6334 → 6332, which is exactly the two paths of the removed duplicate.

## Note on method

#4 — the previous nondeterminism — cost two wrong diagnoses because I reasoned about the mechanism first and was confidently wrong twice, once applying a "fix" that made it strictly worse. #18's entry was written to say: diff two disagreeing artifacts and let them name the file *before* forming a theory. That is what happened here, and it took one step.
