### PR TITLE
fix(tab-navigation): overflow menu for route-backed tabs without ids

### DIFF
--- a/addon/components/tab-navigation.js
+++ b/addon/components/tab-navigation.js
@@ -4,6 +4,16 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { next, scheduleOnce } from '@ember/runloop';
 
+/**
+ * Tabs are keyed by `id`, but route-backed tabs are commonly declared with only a
+ * `route` (and yielded/menu tabs with a `key`). Overflow bookkeeping compares these
+ * identities, so a missing `id` must fall back to the next stable identifier rather
+ * than collapsing every tab onto `undefined`.
+ */
+function tabIdentity(tab) {
+    return tab?.id ?? tab?.route ?? tab?.key ?? null;
+}
+
 export default class TabNavigationComponent extends Component {
     @service universe;
     @tracked _activeTabId = null;
@@ -18,7 +28,7 @@ export default class TabNavigationComponent extends Component {
 
     constructor(owner, args) {
         super(owner, args);
-        this._activeTabId = args.activeTabId || (args.tabs?.[0]?.id ?? null);
+        this._activeTabId = args.activeTabId || tabIdentity(args.tabs?.[0]);
         next(() => {
             if (typeof this.args.contextApi === 'function') {
                 this.args.contextApi(this.context);
@@ -37,7 +47,7 @@ export default class TabNavigationComponent extends Component {
 
     get activeTab() {
         if (!this.args.tabs) return null;
-        return this.args.tabs.find((tab) => tab.id === this._activeTabId) || null;
+        return this.args.tabs.find((tab) => tabIdentity(tab) === this._activeTabId) || null;
     }
 
     get style() {
@@ -53,9 +63,11 @@ export default class TabNavigationComponent extends Component {
         if (!this.args.tabs) return [];
 
         return this.args.tabs.map((tab) => {
+            const id = tabIdentity(tab);
             const enhanced = {
                 ...tab,
-                isActive: tab.id === this._activeTabId,
+                id,
+                isActive: id === this._activeTabId,
                 isDisabled: !!tab.disabled,
                 hasIcon: !!tab.icon,
                 hasBadge: !!(tab.badge && tab.badge > 0),
@@ -141,8 +153,8 @@ export default class TabNavigationComponent extends Component {
     @action argsDidChange() {
         const tabs = this.args.tabs ?? [];
         const hasControlledActiveTab = this.args.activeTabId !== undefined;
-        const currentActiveTabExists = tabs.some((tab) => tab.id === this._activeTabId);
-        const nextActiveTabId = hasControlledActiveTab ? this.args.activeTabId : currentActiveTabExists ? this._activeTabId : (tabs[0]?.id ?? null);
+        const currentActiveTabExists = tabs.some((tab) => tabIdentity(tab) === this._activeTabId);
+        const nextActiveTabId = hasControlledActiveTab ? this.args.activeTabId : currentActiveTabExists ? this._activeTabId : tabIdentity(tabs[0]);
 
         if (nextActiveTabId !== this._activeTabId) {
             this._activeTabId = nextActiveTabId;
@@ -271,7 +283,7 @@ export default class TabNavigationComponent extends Component {
 
     @action handleKeyDown(tab, event) {
         const { key } = event;
-        const currentIndex = this.args.tabs.findIndex((t) => t.id === tab.id);
+        const currentIndex = this.args.tabs.findIndex((t) => tabIdentity(t) === tabIdentity(tab));
 
         let targetIndex = currentIndex;
 
@@ -304,7 +316,7 @@ export default class TabNavigationComponent extends Component {
         const targetTab = this.args.tabs[targetIndex];
         if (targetTab && !targetTab.disabled) {
             // Focus the target tab
-            const targetElement = document.querySelector(`[data-tab-id="${targetTab.id}"]`);
+            const targetElement = document.querySelector(`[data-tab-id="${tabIdentity(targetTab)}"]`);
             if (targetElement) {
                 targetElement.focus();
             }

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -6,4 +6,9 @@ export default class Router extends EmberRouter {
     rootURL = config.rootURL;
 }
 
-Router.map(function () {});
+Router.map(function () {
+    // Route targets for TabNavigation's route-backed tab tests.
+    this.route('positions');
+    this.route('devices');
+    this.route('schedules');
+});

--- a/tests/integration/components/tab-navigation-test.js
+++ b/tests/integration/components/tab-navigation-test.js
@@ -220,6 +220,29 @@ module('Integration | Component | tab-navigation', function (hooks) {
         assert.dom('a[role="menuitem"][data-tab-id="index"]').hasAttribute('href', /view=details/);
     });
 
+    test('route-backed tabs declared without ids still overflow into the More menu', async function (assert) {
+        availableWidth = 142;
+        this.set('tabs', [
+            { route: 'index', label: 'Overview' },
+            { route: 'positions', label: 'Positions' },
+            { route: 'devices', label: 'Devices' },
+            { route: 'schedules', label: 'Schedules' },
+        ]);
+
+        await render(hbs`<TabNavigation @tabs={{this.tabs}} />`);
+
+        assert.dom('[role="tab"][data-tab-id="index"]').exists();
+        assert.dom('[role="tab"][data-tab-id="positions"]').exists();
+        assert.dom('[role="tab"][data-tab-id="devices"]').doesNotExist('tabs past the available width are not rendered inline');
+        assert.dom('[role="tab"][data-tab-id="schedules"]').doesNotExist();
+        assert.dom('[data-tab-navigation-more]').exists();
+
+        await click('[data-tab-navigation-more]');
+
+        assert.dom('a[role="menuitem"][data-tab-id="devices"]').exists();
+        assert.dom('a[role="menuitem"][data-tab-id="schedules"]').exists();
+    });
+
     test('yielded custom tab blocks are not overflow-managed', async function (assert) {
         availableWidth = 40;
 


### PR DESCRIPTION
## Summary

`TabNavigation` moves tabs that do not fit into a "More" dropdown, but the overflow bookkeeping keyed everything on `tab.id`. Route-backed tabs (the common shape in Fleet-Ops detail panels: `{ route, label }`) have no `id`, so:

- `visibleTabIds` and `overflowTabIds` were arrays of `undefined`, which made both the visible filter and the overflow filter match every tab;
- the tab list rendered all tabs inline (clipped by `.tab-items { overflow: hidden }`), so trailing tabs were unreachable and the More menu never appeared.

This change derives a tab's identity from `id`, then `route`, then `key`, and uses it consistently for the active-tab state, overflow calculation and keyboard navigation. Tabs that already pass `id` are unaffected.

## Tests

- Added an integration test covering route-only tabs overflowing into the More menu (the dummy router gains three routes as link targets).
- `eslint` and `prettier` pass on the touched files.
- The browser test suite was **not** run locally for this change (no headless browser session was started on the development machine); CI should run it.
